### PR TITLE
Fix regex for <ref> tag when it's not self-closing

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -215,7 +215,7 @@ comment = re.compile(r'<!--.*?-->', re.DOTALL)
 # Match ignored tags
 ignored_tag_patterns = []
 def ignoreTag(tag):
-    left = re.compile(r'<%s\b[^>/]*>' % tag, re.IGNORECASE) # both <ref> and <reference>
+    left = re.compile(r'<%s\b.*?>' % tag, re.IGNORECASE) # both <ref> and <reference>
     right = re.compile(r'</\s*%s>' % tag, re.IGNORECASE)
     ignored_tag_patterns.append((left, right))
 


### PR DESCRIPTION
In some articles <ref> tag appears like this (article about Afganistan):

    <ref name="Ahmed Rashid/The Telegraph">{{cite

Previous regex breaks when it sees the forward slash ("Rashid/The"). New regex stops at the earliest occurrence of the closing bracket, no need to pre-filter characters.