### PR TITLE
multiline tag match fix

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -215,7 +215,7 @@ comment = re.compile(r'<!--.*?-->', re.DOTALL)
 # Match ignored tags
 ignored_tag_patterns = []
 def ignoreTag(tag):
-    left = re.compile(r'<%s\b.*?>' % tag, re.IGNORECASE) # both <ref> and <reference>
+    left = re.compile(r'<%s\b.*?>' % tag, re.IGNORECASE | re.DOTALL) # both <ref> and <reference>
     right = re.compile(r'</\s*%s>' % tag, re.IGNORECASE)
     ignored_tag_patterns.append((left, right))
 


### PR DESCRIPTION
Update for the previous Pull request: we need to add re.DOTALL so that multiline tag definitions are also matched. This happens often in template expansions:

    <div class="quotebox " style="
        margin: auto;
        padding: 6px;
        border: 2px solid #aaa;
        font-size: 88%;
        background-color: #F9F9F9;
        ">