### PR TITLE
multiprocess speedup; stdin/stdout/single-file options; stable ordering; sparser progress logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,23 @@ Each file will contains several documents in this [document format](http://media
 
     usage: WikiExtractor.py [-h] [-o OUTPUT] [-b n[KMG]] [-c] [--html] [-l]
 			    [-ns ns1,ns2] [-s] [--templates TEMPLATES]
-			    [--no-templates] [--threads THREADS] [-q] [--debug]
+			    [--no-templates] [--processes PROCESSES] [-q] [--debug]
 			    [-a] [-v]
 			    input
 
     positional arguments:
-      input                 XML wiki dump file
+      input                 XML wiki dump file; use '-' to read from stdin
 
     optional arguments:
       -h, --help            show this help message and exit
-      --threads THREADS     Number of threads to use (default 2)
+      --processes PROCESSES number of processes to use (default number of CPU cores)
 
     Output:
       -o OUTPUT, --output OUTPUT
-			    output directory
+			    output path; a file if no max bytes per file set, 
+			    otherwise a directory to collect files. use '-' for stdout.
       -b n[KMG], --bytes n[KMG]
-			    put specified bytes per output file (default is 1M)
+			    maximum bytes per output file (default is no limit: one file)
       -c, --compress        compress output files using bzip
 
     Processing:

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -1998,8 +1998,8 @@ def compact(text):
         if not line:
             continue
         # Handle section titles
-###        m = section.match(line)
-        if False:  ### m:
+        m = section.match(line)
+        if m:
             title = m.group(2)
             lev = len(m.group(1))
             if Extractor.toHTML:

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -2418,9 +2418,9 @@ def main():
                         help="use or create file containing templates")
     groupP.add_argument("--no-templates", action="store_false",
                         help="Do not expand templates")
-    default_process_count = multiprocessing.cpu_count()-1
+    default_process_count = multiprocessing.cpu_count()
     parser.add_argument("--processes", type=int, default=default_process_count,
-                        help="Number of extract processes; default is one less than CPU cores (%d)"%default_process_count)
+                        help="Number of extract processes; default is count of CPU cores (%d)"%default_process_count)
 
     groupS = parser.add_argument_group('Special')
     groupS.add_argument("-q", "--quiet", action="store_true",


### PR DESCRIPTION
(#4) Converted threading approach that was hampered by the Python GIL to a multiple-process approach for a potentially big speedup on multicore machines. (On an 8-core machine, a `--no-templates` extraction that took 500 minutes is down to about 80 minutes.) 

Use the renamed `--processes` argument to set the number of extractor-processes to use. (By default, a number equal to the detected number of CPU cores will be used.)

Additional changes:

* input may now be specified as '-', which means to read from stdin. (Since stdin can't be read in two passes, if applying templates to a dump fed by stdin, templates *must* be supplied by `--templates`.)

* output (`-o`) may now be specified as '-', which means write to stdout, or a filename to write a single large file. To support stdout and single-file options, the default `-b` setting is now empty (unlimited size). To match prior behavior, set a byte-limit (eg `-b 1M`) – then `-o` output path will be treated as a directory, to receive the same 'AA/wiki_##' split files.

* extracted docs will be written in the exact order they appear in the original dump (whether in one file or many splits) - making multiple runs identical

* adjacent duplicate articles with the same ID will be discarded (there are 2 in the 2015-06-02 dump)

• some logging thinned (no line for every article, most template errors rolled up into a single line per article); other logging expanded to show progress/total/rate/duration info

