### PR TITLE
Fix progress report

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -2405,11 +2405,12 @@ def output_process(ordering_queue, docs_queue, out_file, file_size, file_compres
             if next_ordinal in ordering_buffer:
                 output.write(ordering_buffer.pop(next_ordinal))
                 ordering_queue.task_done()
-                if (next_ordinal+1) % 100000 == 0:
-                    interval_rate = (next_ordinal-interval_count) / (default_timer()/interval_start)
-                    logging.info("Extracted %d articles (%.1f/s)", next_ordinal, interval_rate)
+                count_done = next_ordinal + 1
+                if count_done % 100000 == 0:
+                    interval_rate = (count_done - interval_count) / (default_timer() - interval_start)
+                    logging.info("Extracted %d articles (%.1f/s)", count_done, interval_rate)
                     interval_start = default_timer()
-                    interval_count = next_ordinal
+                    interval_count = count_done
                 break
             ordinal, text = docs_queue.get()
             ordering_buffer[ordinal] = text


### PR DESCRIPTION
Reported count and rate of processing were wrong:

* Reported number of extracted articles was fewer than the true value by 1.
* Reported rate of processing was completely different from the true value.

### Before

```
$ python2 WikiExtractor.py --no-templates -o jawiki-20150805-pages-articles.before.txt jawiki-20150805-pages-articles.xml.bz2
INFO: Starting page extraction from jawiki-20150805-pages-articles.xml.bz2.
INFO: Using 4 extract processes.
INFO: Extracted 99999 articles (99999.0/s)
INFO: Extracted 199999 articles (100000.0/s)
INFO: Extracted 299999 articles (100000.0/s)
INFO: Extracted 399999 articles (100000.0/s)
INFO: Extracted 499999 articles (100000.0/s)
INFO: Extracted 599999 articles (100000.0/s)
INFO: Extracted 699999 articles (100000.0/s)
INFO: Extracted 799999 articles (100000.0/s)
INFO: Extracted 899999 articles (100000.0/s)
INFO: Finished 4-process extraction of 976152 articles in 2402.6s (406.3/s)
```

### After

```
$ python2 WikiExtractor.py --no-templates -o jawiki-20150805-pages-articles.after.txt jawiki-20150805-pages-articles.xml.bz2
INFO: Starting page extraction from jawiki-20150805-pages-articles.xml.bz2.
INFO: Using 4 extract processes.
INFO: Extracted 100000 articles (224.7/s)
INFO: Extracted 200000 articles (349.5/s)
INFO: Extracted 300000 articles (433.7/s)
INFO: Extracted 400000 articles (507.3/s)
INFO: Extracted 500000 articles (492.2/s)
INFO: Extracted 600000 articles (505.1/s)
INFO: Extracted 700000 articles (495.3/s)
INFO: Extracted 800000 articles (489.1/s)
INFO: Extracted 900000 articles (355.9/s)
INFO: Finished 4-process extraction of 976152 articles in 2441.4s (399.8/s)
```
