### PR TITLE
added a new flag and it's usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Each file will contains several documents in this [document format](http://media
       --templates TEMPLATES
 			    use or create file containing templates
       --no-templates        Do not expand templates
+      --escapedoc           use to escape the contents of the output
+                            <doc>...</doc>
 
     Special:
       -q, --quiet           suppress reporting progress info


### PR DESCRIPTION
The new flag is --escapedoc and if set the clean function runs cgi.escape(text) before return this text to be included in <doc></doc>.

This is a non-breaking change in response to issue 6: https://github.com/attardi/wikiextractor/issues/6