### PR TITLE
Support Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,89 @@
+### https://raw.github.com/github/gitignore/c699a4f4684e9e294c9c550f820ca330f019b6f9/python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask instance folder
+instance/
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WikiExtractor
 [WikiExtractor.py](http://medialab.di.unipi.it/wiki/Wikipedia_Extractor) is a Python script that extracts and cleans text from a [Wikipedia database dump](http://download.wikimedia.org/).
 
-The tool is written in Python and requires Python 2.7 but no additional library.
+The tool is written in Python and requires Python 2.7 or Python 3.3+ but no additional library.
 
 For further information, see the [project Home Page](http://medialab.di.unipi.it/wiki/Wikipedia_Extractor) or the [Wiki](https://github.com/attardi/wikiextractor/wiki).
 

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -2593,6 +2593,7 @@ def extract_process(i, jobs_queue, output_queue):
                 logging.error('Processing page: %s %s', id, title)
             output_queue.put((page_num, text))
             out.truncate(0)
+            out.seek(0)
         else:
             logging.debug('Quit extractor')
             break

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -458,7 +458,6 @@ class Extractor(object):
         header = '<doc id="%s" url="%s" title="%s">\n' % (self.id, url, self.title)
         # Separate header from text with a newline.
         header += self.title + '\n\n'
-        header = header.encode('utf-8')
         self.magicWords['pagename'] = self.title
         self.magicWords['fullpagename'] = self.title
         self.magicWords['currentyear'] = time.strftime('%Y')
@@ -470,7 +469,7 @@ class Extractor(object):
         footer = "\n</doc>\n"
         out.write(header)
         for line in compact(text):
-            out.write(line.encode('utf-8'))
+            out.write(line)
             out.write('\n')
         out.write(footer)
         errs = (self.template_title_errs,
@@ -2316,7 +2315,7 @@ class OutputSplitter(object):
         if self.compress:
             return bz2.BZ2File(filename + '.bz2', 'w')
         else:
-            return open(filename, 'w')
+            return open(filename, 'wb')
 
 
 # ----------------------------------------------------------------------
@@ -2615,7 +2614,7 @@ def reduce_process(output_queue, spool_length,
         nextFile = NextFile(out_file)
         output = OutputSplitter(nextFile, file_size, file_compress)
     else:
-        output = sys.stdout
+        output = sys.stdout if PY2 else sys.stdout.buffer
         if file_compress:
             logging.warn("writing to stdout, so no output compression (use an external tool)")
     
@@ -2625,7 +2624,7 @@ def reduce_process(output_queue, spool_length,
     next_page = 0     # sequence numbering of page
     while True:
         if next_page in spool:
-            output.write(spool.pop(next_page))
+            output.write(spool.pop(next_page).encode('utf-8'))
             next_page += 1
             # tell mapper our load:
             spool_length.value = len(spool)

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -46,7 +46,7 @@ Template expansion requires preprocesssng first the whole dump and
 collecting template definitions.
 """
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, division
 
 import sys
 import argparse
@@ -2276,7 +2276,7 @@ class NextFile(object):
 
     def _dirname(self):
         char1 = self.dir_index % 26
-        char2 = self.dir_index / 26 % 26
+        char2 = self.dir_index // 26 % 26
         return os.path.join(self.path_name, '%c%c' % (ord('A') + char2, ord('A') + char1))
 
     def _filepath(self):

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# This test must pass both in Python 2 and 3.
+from __future__ import unicode_literals
+
+import sys
+import unittest
+
+from WikiExtractor import (
+    normalizeTitle, unescape, ucfirst, lcfirst, splitParts,
+    fullyQualifiedTemplateTitle, NextFile
+)
+
+
+class TestNormalizeTitle(unittest.TestCase):
+
+    def test_known_namespace(self):
+        self.assertEqual(normalizeTitle("Template:  Births"), "Template:Births")
+        self.assertEqual(normalizeTitle(" template:  births_"), "Template:Births")
+
+    def test_not_known_namespace(self):
+        self.assertEqual(normalizeTitle("Category:  Births"), "Category: Births")
+        self.assertEqual(normalizeTitle("_category:  births___"), "Category: Births")
+
+    def test_no_namespace(self):
+        self.assertEqual(normalizeTitle("python"), "Python")
+        self.assertEqual(normalizeTitle("python 3"), "Python 3")
+        self.assertEqual(normalizeTitle("python__3"), "Python 3")
+
+
+class TestStringUtils(unittest.TestCase):
+
+    def test_unescape(self):
+        self.assertEqual(unescape('&#34;'), '"')
+        self.assertEqual(unescape('&#38;'), '&')
+        self.assertEqual(unescape('&#x3042;'), '\u3042')
+        if sys.maxunicode > 0xFFFF:
+            # Python 3 or UCS-4 build of Python 2
+            self.assertEqual(unescape('&#x1D546;'), '\U0001D546')
+            self.assertEqual(unescape('&#x1d4c1;'), '\U0001d4c1')
+        else:
+            # UCS-2 build of Python 2
+            self.assertEqual(unescape('&#x1D546;'), '&#x1D546;')
+            self.assertEqual(unescape('&#x1d4c1;'), '&#x1d4c1;')
+
+    def test_ucfirst(self):
+        self.assertEqual(ucfirst('python'), 'Python')
+
+    def test_lcfirst(self):
+        self.assertEqual(lcfirst('Python'), 'python')
+
+
+class TestSplitParts(unittest.TestCase):
+
+    def test_simple(self):
+        self.assertEqual(splitParts("p=q|q=r|r=s"), ['p=q', 'q=r', 'r=s'])
+
+    def test_complex(self):
+        self.assertEqual(splitParts('{{#if: {{{1}}} | {{lc:{{{1}}} | "parameter missing"}}'),
+                         ['{{#if: {{{1}}} ', ' {{lc:{{{1}}} ', ' "parameter missing"}}'])
+
+        self.assertEqual(splitParts('''{{if:|
+      |{{#if:the president|
+           |{{#if:|
+               [[Category:Hatnote templates|A{{PAGENAME}}]]
+            }}
+       }}
+     }}'''), ['''{{if:|
+      |{{#if:the president|
+           |{{#if:|
+               [[Category:Hatnote templates|A{{PAGENAME}}]]
+            }}
+       }}
+     }}'''])
+
+
+class TestFullyQualifiedTemplateTitle(unittest.TestCase):
+
+    def test_main_namespace(self):
+        self.assertEqual(fullyQualifiedTemplateTitle(':Python'), 'Python')
+        self.assertEqual(fullyQualifiedTemplateTitle(':python'), 'Python')
+
+    def test_other_namespace(self):
+        self.assertEqual(fullyQualifiedTemplateTitle('User:Orange'), 'User:Orange')
+
+
+class TestNextFile(unittest.TestCase):
+
+    def test_next(self):
+        f = NextFile('out')
+        self.assertEqual(next(f), 'out/AA/wiki_00')
+        self.assertEqual(next(f), 'out/AA/wiki_01')
+        for _ in range(97):
+            next(f)
+        self.assertEqual(next(f), 'out/AA/wiki_99')
+        self.assertEqual(next(f), 'out/AB/wiki_00')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[tox]
+envlist = py27, py33, py34, py35
+[testenv]
+commands=python tests.py


### PR DESCRIPTION
This fixes #65.

Though this PR increases complexity a little, `WikiExtractor.py` now supports both Python 2.7 and 3.3+. I've confirmed that `WikiExtractor.py` works [almost the same](https://gist.github.com/orangain/4ecf605ff665f1a6103135b2071a40ab) in both Python 2.7 and Python 3.5 by the following commands using wiki dump of Japanese:

```
$ git checkout master
$ python2 WikiExtractor.py --lists --links -b 100M in/jawiki-20150805-pages-articles.xml.bz2 -o out-py2-master
$ git checkout support-python3
$ python2 WikiExtractor.py --lists --links -b 100M in/jawiki-20150805-pages-articles.xml.bz2 -o out-py2-support-python3
$ python3 WikiExtractor.py --lists --links -b 100M in/jawiki-20150805-pages-articles.xml.bz2 -o out-py3-support-python3
```

In addition, I've added a very limited test, `tests.py`. The test can be run by:

```
$ python2 tests.py
$ python3 tests.py
````

Using [tox](https://tox.readthedocs.io/en/latest/), you can easily run tests in both Python 2.7, 3.3, 3.4 and 3.5 just by:

```
$ tox
```