### PR TITLE
Remove python2 extract utf8 encoding and log extract exceptions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-06-20  Seth Cleveland <scleveland@turnitin.com>
+
+	* WikiExtractor.py: Fix string encoding error for python 2 and log
+	extract exceptions.
+
 2016-06-19  Giuseppe Attardi  <attardi@di.unipi.it>
 
 	* WikiExtractor.py: support for Python 3 by orangain@gmail.com

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -82,7 +82,7 @@ else:
 # ===========================================================================
 
 # Program version
-version = '2.57'
+version = '2.58'
 
 ## PARAMS ####################################################################
 
@@ -508,7 +508,7 @@ class Extractor(object):
         self.magicWords['currentday'] = time.strftime('%d')
         self.magicWords['currenthour'] = time.strftime('%H')
         self.magicWords['currenttime'] = time.strftime('%H:%M:%S')
-        text = [line.encode('utf-8') for line in compact(self.clean())]
+        text = compact(self.clean())
         footer = "\n</doc>\n"
         if sum(len(line) for line in text) < Extractor.min_text_length:
             return
@@ -2642,7 +2642,7 @@ def extract_process(i, jobs_queue, output_queue):
                 text = out.getvalue()
             except:
                 text = ''
-                logging.error('Processing page: %s %s', id, title)
+                logging.exception('Processing page: %s %s', id, title)
 
             output_queue.put((page_num, text))
             out.truncate(0)


### PR DESCRIPTION
@attardi: The strings coming back from compact were a "unicode" type. I'm guessing the unicode.encode("utr-8") converted those strings to type str. I was seeing the exception below.

```
ERROR: Processing page: 4653 Michelangelo
Traceback (most recent call last):
  File "./wikiextractor/WikiExtractor.py", line 2644, in extract_process
    e.extract(out)
  File "./wikiextractor/WikiExtractor.py", line 520, in extract
    out.write(line)
TypeError: unicode argument expected, got 'str'```