### PR TITLE
Name a package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Giuseppe Attardi',
     author_email='attardi@di.unipi.it',
     version='2.42',
+    packages=[''],
 
     url='https://github.com/attardi/wikiextractor',
 


### PR DESCRIPTION
I tried installing this package directory from Github with:
```
pip install 'git+git://github.com/attardi/wikiextractor@730cfc07f97353568318f679096851a0b9af704f'
```
However, that just links `bin/wikiextractor` without putting WikiExtractor.py on the path, so running `wikiextractor` causes an import error ("ImportError: No module named WikiExtractor").

In my testing locally, this change causes WikiExtractor.py (as well as the other Python files in the repository) to be packaged, and the `wikiextractor` command works.

 This isn't ideal though because the package name is not legal, so I see this error when installing the package with `python setup.py install`:
```
WARNING: '' not a valid package name; please use only .-separated package names in setup.py
```
I think it'd be more idiomatic to put the package files in subdirectory wikiextractor, i.e. wikiextractor/WikiExtractor.py (I was looking at [some other examples](https://github.com/mobolic/facebook-sdk/tree/8c0d34291aaafec00e02eaa71cc2a242790a0fcc)). I'm happy to update this PR if you're ok with that change. Thanks!