### PR TITLE
fix issue #85: Empty-element tag in wikipedia dump leads to wrong document id attribution

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -2642,6 +2642,8 @@ def pages_from(input):
             if inText:
                 page.append(line)
             continue
+        if '<text xml:space="preserve" />' in line: # fix issue #63: wrong article ID saved
+            line = '<text xml:space="preserve"></text>\n' # fix issue #63: wrong article ID saved
         m = tagRE.search(line)
         if not m:
             continue


### PR DESCRIPTION
## Issue #85 
Some documents in the non-article-namespace have no document text. 

Instead of an element with no content (`<text xml:space="preserve"></text>`) a  empty-element tag is used (`<text xml:space="preserve" />`)

The regular expression used for grouping  (`tagRE = re.compile(r'(.*?)<(/?\w+)[^>]*>(?:([^<]*)(<.*?>)?)?')`) can not match an empty-element tag and searches for an end-tag (`</text>`).

This leads to not identifying the document correctly and saving the wrong document id

## Fix
Add the following code after line 2644:
```
        if '<text xml:space="preserve" />' in line: 
            line = '<text xml:space="preserve"></text>\n' 
```

A better solution would be altering the regular expression, I was not able to do this.

## Minimum working example:
### Wikipedia xml dump
Taken from simple.wikipedia.org
```
<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.10/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.10/ http://www.mediawiki.org/xml/export-0.10.xsd" version="0.10" xml:lang="en">
  <siteinfo>
    <sitename>Wikipedia</sitename>
    <dbname>simplewiki</dbname>
    <base>https://simple.wikipedia.org/wiki/Main_Page</base>
    <generator>MediaWiki 1.28.0-wmf.16</generator>
    <case>first-letter</case>
    <namespaces>
      <namespace key="-2" case="first-letter">Media</namespace>
      <namespace key="-1" case="first-letter">Special</namespace>
      <namespace key="0" case="first-letter" />
      <namespace key="1" case="first-letter">Talk</namespace>
      <namespace key="2" case="first-letter">User</namespace>
      <namespace key="3" case="first-letter">User talk</namespace>
      <namespace key="4" case="first-letter">Wikipedia</namespace>
      <namespace key="5" case="first-letter">Wikipedia talk</namespace>
      <namespace key="6" case="first-letter">File</namespace>
      <namespace key="7" case="first-letter">File talk</namespace>
      <namespace key="8" case="first-letter">MediaWiki</namespace>
      <namespace key="9" case="first-letter">MediaWiki talk</namespace>
      <namespace key="10" case="first-letter">Template</namespace>
      <namespace key="11" case="first-letter">Template talk</namespace>
      <namespace key="12" case="first-letter">Help</namespace>
      <namespace key="13" case="first-letter">Help talk</namespace>
      <namespace key="14" case="first-letter">Category</namespace>
      <namespace key="15" case="first-letter">Category talk</namespace>
      <namespace key="828" case="first-letter">Module</namespace>
      <namespace key="829" case="first-letter">Module talk</namespace>
      <namespace key="2300" case="first-letter">Gadget</namespace>
      <namespace key="2301" case="first-letter">Gadget talk</namespace>
      <namespace key="2302" case="case-sensitive">Gadget definition</namespace>
      <namespace key="2303" case="case-sensitive">Gadget definition talk</namespace>
      <namespace key="2600" case="first-letter">Topic</namespace>
    </namespaces>
  </siteinfo>
  <page>
    <title>MediaWiki:Fundraising notice</title>
    <ns>8</ns>
    <id>4948</id>
    <revision>
      <id>39998</id>
      <parentid>11997</parentid>
      <timestamp>2004-07-14T13:25:52Z</timestamp>
      <contributor>
        <username>Angela</username>
        <id>2</id>
      </contributor>
      <minor />
      <model>wikitext</model>
      <format>text/x-wiki</format>
      <text xml:space="preserve" />
      <sha1>phoiac9h4m842xq45sp7s6u21eteeq1</sha1>
    </revision>
  </page>
  <page>
    <title>The Young and the Restless</title>
    <ns>0</ns>
    <id>4949</id>
    <revision>
      <id>5437955</id>
      <parentid>4618788</parentid>
      <timestamp>2016-07-10T23:20:53Z</timestamp>
      <contributor>
        <username>Brted</username>
        <id>339607</id>
      </contributor>
      <comment>Comment text</comment>
      <model>wikitext</model>
      <format>text/x-wiki</format>
      <text xml:space="preserve">Document text</text>
      <sha1>5qcu2tb9shq3kxw01mza5lpw6d2azwj</sha1>
    </revision>
  </page>
</mediawiki>
```

### command line output before fix:
```
python3 WikiExtractor.py ../bad-article.xml.bz2 
INFO: Loaded 0 templates in 0.0s
INFO: Starting page extraction from ../bad-article.xml.bz2.
INFO: Using 3 extract processes.
INFO: 4948	The Young and the Restless
INFO: Finished 3-process extraction of 1 articles in 0.1s (17.6 art/s)
```

### file output before fix:
```
<doc id="4948" url="https://simple.wikipedia.org/wiki?curid=4948" title="The Young and the Restless">
The Young and the Restless

Document text

</doc>
```

### command line output after fix:
```
python3 WikiExtractor.py ../bad-article.xml.bz2 
INFO: Loaded 0 templates in 0.0s
INFO: Starting page extraction from ../bad-article.xml.bz2.
INFO: Using 3 extract processes.
INFO: 4949	The Young and the Restless
INFO: Finished 3-process extraction of 1 articles in 0.1s (19.6 art/s)
```

### file output after fix:
```
<doc id="4949" url="https://simple.wikipedia.org/wiki?curid=4949" title="The Young and the Restless">
The Young and the Restless

Document text

</doc>
```