### PR TITLE
Let's keep paragraph separators.

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -704,6 +704,7 @@ class Extractor(object):
         text = re.sub('(\[\(«) ', r'\1', text)
         text = re.sub(r'\n\W+?\n', '\n', text, flags=re.U)  # lines with only punctuations
         text = text.replace(',,', ',').replace(',.', '.')
+
         if Extractor.toHTML:
             text = cgi.escape(text)
         return text
@@ -2379,7 +2380,6 @@ listClose = {'*': '</ul>', '#': '</ol>', ';': '</dl>', ':': '</dl>'}
 listItem = {'*': '<li>%s</li>', '#': '<li>%s</<li>', ';': '<dt>%s</dt>',
             ':': '<dd>%s</dd>'}
 
-
 def compact(text):
     """Deal with headers, lists, empty sections, residuals of tables.
     :param text: convert to HTML.
@@ -2392,8 +2392,12 @@ def compact(text):
 
     for line in text.split('\n'):
 
-        if not line:
-            continue
+        # Let's keep only one empty line that indicates the end of a paragraph
+        if line.strip() == '':
+          l=len(page)
+          if l > 0 and page[l-1] != '':
+            page.append('')
+          continue
         # Handle section titles
         m = section.match(line)
         if m:


### PR DESCRIPTION
Thank you for this nice text extractor! It extracts and cleans up text really well. It is also useful that you can get what separate paragraphs are, b/c there is a newline. However, in rare cases a newline occurs only because a user entered it while editing a Wikipedia article.

Check, for example, [this paragraph ](https://en.wikipedia.org/w/index.php?title=Alain_Connes&action=edit&section=1&editintro=Template:BLP_editintro). There is an editor-introduced newline after the phrase ``which culminated in the``. This newline is then propagated to the extracted text. 

So, this prevents me from correctly splitting the text into paragraphs sometimes. As a simplest fix, I suggest keeping one empty line as an indicator for a paragraph separator.

Thanks!