### PR TITLE
Decode binary types even in Python 3

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -73,11 +73,13 @@ if PY2:
     range = xrange  # Overwrite by Python 3 name
     chr = unichr    # Overwrite by Python 3 name
     text_type = unicode
+    binary_type = str
 else:
     from urllib.parse import quote
     from html.entities import name2codepoint
     from itertools import zip_longest
     text_type = str
+    binary_type = bytes
 
 
 # ===========================================================================
@@ -2637,7 +2639,7 @@ def pages_from(input):
     redirect = False
     title = None
     for line in input:
-        if PY2: line = line.decode('utf-8')
+        if isinstance(line, binary_type): line = line.decode('utf-8')
         if '<' not in line:  # faster than doing re.search()
             if inText:
                 page.append(line)
@@ -2707,7 +2709,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
 
     # collect siteinfo
     for line in input:
-        if PY2: line = line.decode('utf-8')
+        if isinstance(line, binary_type): line = line.decode('utf-8')
         m = tagRE.search(line)
         if not m:
             continue


### PR DESCRIPTION
## Problem

I found that the latest version 2.67 fails to process `.bz2` files in Python 3.

e.g.

```
$ python3 -V
Python 3.6.0
$ python3 WikiExtractor.py jawiki-20170101-pages-articles1.xml-p000000001p000168815.bz2
Traceback (most recent call last):
  File "WikiExtractor.py", line 3047, in <module>
    main()
  File "WikiExtractor.py", line 3043, in main
    args.compress, args.processes)
  File "WikiExtractor.py", line 2711, in process_dump
    m = tagRE.search(line)
TypeError: cannot use a string pattern on a bytes-like object
```

## Cause

When an input file is `.bz2` or `.gz`, the variable `line` can be a bytes even in Python 3. 

`fileinput.FileInput` with `openhook=fileinput.hook_compressed` delegates opening file to `bz2.BZ2File` when an input file is `.bz2`. `bz2.BZ2File` always returns bytes object.

## Changes

Decode `line` depending on its type not on Python version. This works well in both Python 2 and 3.