### PR TITLE
Ensure that process_count >= 1

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -2762,6 +2762,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     # - pages to be processed are dispatched to workers
     # - a reduce process collects the results, sort them and print them.
 
+    process_count = max(1, process_count)
     maxsize = 10 * process_count
     # output queue
     output_queue = Queue(maxsize=maxsize)
@@ -2769,7 +2770,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     if out_file == '-':
         out_file = None
 
-    worker_count = max(1, process_count)
+    worker_count = process_count
 
     # load balancing
     max_spool_length = 10000
@@ -2963,7 +2964,7 @@ def main():
                         help="Minimum expanded text length required to write document (default=%(default)s)")
     groupP.add_argument("--filter_disambig_pages", action="store_true", default=filter_disambig_pages,
                         help="Remove pages from output that contain disabmiguation markup (default=%(default)s)")
-    default_process_count = cpu_count() - 1
+    default_process_count = max(1, cpu_count() - 1)
     parser.add_argument("--processes", type=int, default=default_process_count,
                         help="Number of processes to use (default %(default)s)")
 


### PR DESCRIPTION
## Problem 

In a single core environment (e.g. virtual machine), WikiExtractor consumes too many memories and is killed by OOM Killer after a few minutes.

```
$ python3 -V
Python 3.4.3
$ python3 -c 'from multiprocessing import cpu_count; print(cpu_count())'
1
$ python3 WikiExtractor.py --quiet enwiki-20170101-pages-articles1.xml-p000000010p000030302.bz2
Killed
```

Results are incomplete:

```
$ tree text/
text/
└── AA
    ├── wiki_00
    ├── wiki_01
    ├── wiki_02
    ├── wiki_03
    ├── wiki_04
    ├── wiki_05
    ├── wiki_06
    ├── wiki_07
    ├── wiki_08
    ├── wiki_09
    ├── wiki_10
    ├── wiki_11
    ├── wiki_12
    ├── wiki_13
    ├── wiki_14
    ├── wiki_15
    ├── wiki_16
    ├── wiki_17
    └── wiki_18

1 directory, 19 files
```

Note that using `--processes 1` can avoid this problem.

## Cause

In a single core environment, `process_count` becomes `cpu_count()  - 1 = 0` by default. This results in `maxsize = 0`, which is passed to `multiprocessing.Queue`. According to [the implementation of multiprocessing.Queue](https://github.com/python/cpython/blob/ed7156c9d26317f6bd84deb41a2878570563100c/Lib/multiprocessing/queues.py#L37-L39), when `maxsize = 0`,  a size of queue becomes `multiprocessing.synchronize.SEM_VALUE_MAX`, which is `2147483647` in my environment.

In this situation, a mapper process puts too many jobs to `jobs_queue` faster than they are consumed by a worker process. This results in out of memory.

## Changes

Ensure that process_count >= 1 even in a single core environment.