### PR TITLE
Issue 101 discard and ignore flags and keep_tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,5 @@ ENV/
 # Spyder project settings
 .spyderproject
 
-
+# Go files used for local testing
+*.go

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,3 @@ ENV/
 
 # Spyder project settings
 .spyderproject
-
-# Go files used for local testing
-*.go

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Each file will contains several documents in this [document format](http://media
       --filter_disambig_pages
                             Remove pages from output that contain disabmiguation
                             markup (default=False)
+      -it, --ignored_tags
+                            comma separated list of tags that will be dropped, keeping their content
+      -de, --discard_elements
+                            comma separated list of elements that will be removed from the article text
+      --keep_tables
+                            Preserve tables in the output article text (default=False)
 
     Special:
       -q, --quiet           suppress reporting progress info

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -525,11 +525,7 @@ class Extractor(object):
         #
         text = self.transform(text)
         text = self.wiki2text(text)
-        # the text is still present
-        # NOTE: Something in the combination of clean and compact is dropping the tables
-        # If we remove these calls thant the data is there but the odd wikiml formatting type characters remain
-        text = self.clean(text)
-        text = compact(text)
+        text = compact(self.clean(text))
         footer = "\n</doc>\n"
         if sum(len(line) for line in text) < Extractor.min_text_length:
             return

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -129,6 +129,7 @@ filter_disambig_page_pattern = re.compile("{{disambig(uation)?(\|[^}]*)?}}")
 # Drop tables from the article
 keep_tables = False
 
+
 ##
 # page filtering logic -- remove templates, undesired xml namespaces, and disambiguation pages
 def keepPage(ns, page):
@@ -324,6 +325,7 @@ class Template(list):
         tpl.append(TemplateText(body[start:]))  # leftover
         return tpl
 
+
     def subst(self, params, extractor, depth=0):
         # We perform parameter substitutions recursively.
         # We also limit the maximum number of iterations to avoid too long or
@@ -353,6 +355,7 @@ class Template(list):
 
 class TemplateText(text_type):
     """Fixed text of template"""
+
 
     def subst(self, params, extractor, depth):
         return self
@@ -390,6 +393,7 @@ class TemplateArg(object):
         else:
             return '{{{%s}}}' % self.name
 
+
     def subst(self, params, extractor, depth):
         """
         Substitute value for this argument from dict :param params:
@@ -418,11 +422,14 @@ class Frame(object):
         self.prev = prev
         self.depth = prev.depth + 1 if prev else 0
 
+
     def push(self, title, args):
         return Frame(title, args, self)
 
+
     def pop(self):
         return self.prev
+
 
     def __str__(self):
         res = ''
@@ -546,6 +553,7 @@ class Extractor(object):
             logging.warn("Template errors in article '%s' (%s): title(%d) recursion(%d, %d, %d)",
                          self.title, self.id, *errs)
 
+
     def transform(self, wikitext):
         """
         Transforms wiki markup.
@@ -561,6 +569,7 @@ class Extractor(object):
         res += self.transform1(wikitext[cur:])
         return res
 
+
     def transform1(self, text):
         """Transform text not containing <nowiki>"""
         if Extractor.expand_templates:
@@ -570,6 +579,7 @@ class Extractor(object):
         else:
             # Drop transclusions (template, parser functions)
             return dropNested(text, r'{{', r'}}')
+
 
     def wiki2text(self, text):
         #
@@ -625,6 +635,7 @@ class Extractor(object):
             cur = m.end()
         text = res + unescape(text[cur:])
         return text
+
 
     def clean(self, text):
         """
@@ -702,6 +713,7 @@ class Extractor(object):
     # check for template beginning
     reOpen = re.compile('(?<!{){{(?!{)', re.DOTALL)
 
+
     def expand(self, wikitext):
         """
         :param wikitext: the text to be expanded.
@@ -741,6 +753,7 @@ class Extractor(object):
         res += wikitext[cur:]
         # logging.debug('%*sexpand> %s', self.frame.depth, '', res)
         return res
+
 
     def templateParams(self, parameters):
         """
@@ -809,6 +822,7 @@ class Extractor(object):
                 templateParams[str(unnamedParameterCounter)] = param
         # logging.debug('%*stemplateParams> %s', self.frame.length, '', '|'.join(templateParams.values()))
         return templateParams
+
 
     def expandTemplate(self, body):
         """Expands template invocation.
@@ -1282,6 +1296,7 @@ def functionParams(args, vars):
         params[var] = value
     return params
 
+
 def string_sub(args):
     params = functionParams(args, ('s', 'i', 'j'))
     s = params.get('s', '')
@@ -1297,6 +1312,7 @@ def string_len(args):
     params = functionParams(args, ('s'))
     s = params.get('s', '')
     return len(s)
+
 
 def string_find(args):
     params = functionParams(args, ('source', 'target', 'start', 'plain'))

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -546,7 +546,6 @@ class Extractor(object):
             logging.warn("Template errors in article '%s' (%s): title(%d) recursion(%d, %d, %d)",
                          self.title, self.id, *errs)
 
-
     def transform(self, wikitext):
         """
         Transforms wiki markup.
@@ -561,7 +560,6 @@ class Extractor(object):
         # leftover
         res += self.transform1(wikitext[cur:])
         return res
-
 
     def transform1(self, text):
         """Transform text not containing <nowiki>"""
@@ -628,7 +626,6 @@ class Extractor(object):
         text = res + unescape(text[cur:])
         return text
 
-
     def clean(self, text):
         """
         Removes irrelevant parts from :param: text.
@@ -684,6 +681,9 @@ class Extractor(object):
         text = re.sub(r'\n\W+?\n', '\n', text, flags=re.U)  # lines with only punctuations
         text = text.replace(',,', ',').replace(',.', '.')
         if keep_tables:
+            # the following regular expressions are used to remove the wikiml chartacters around table strucutures
+            # yet keep the content. The order here is imporant so we remove certain markup like {| and then
+            # then the future html attributes such as 'style'. Finally we drop the remaining '|-' that delimits cells.
             text = re.sub(r'!(?:\s)?style=\"[a-z]+:(?:\d+)%;\"', r'', text)
             text = re.sub(r'!(?:\s)?style="[a-z]+:(?:\d+)%;[a-z]+:(?:#)?(?:[0-9a-z]+)?"', r'', text)
             text = text.replace('|-', '')

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -688,7 +688,8 @@ class Extractor(object):
         text = re.sub(r'\n\W+?\n', '\n', text, flags=re.U)  # lines with only punctuations
         text = text.replace(',,', ',').replace(',.', '.')
         if keep_tables:
-            text = re.sub(r'!(?:\s)?style=\"width:(?:\d+)%;\"', r'', text)
+            text = re.sub(r'!(?:\s)?style=\"[a-z]+:(?:\d+)%;\"', r'', text)
+            text = re.sub(r'!(?:\s)?style="[a-z]+:(?:\d+)%;[a-z]+:(?:#)?(?:[0-9a-z]+)?"', r'', text)
             text = text.replace('|-', '')
             text = text.replace('|', '')
         if Extractor.toHTML:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
                 'database dump',
     author='Giuseppe Attardi',
     author_email='attardi@di.unipi.it',
-    version='2.66',
+    version='2.69',
 
     url='https://github.com/attardi/wikiextractor',
 


### PR DESCRIPTION
This implements three new flags:
- --discard_elements that allows the caller to specify which elements to discard. If not specified this defaults to the original set - ensuring backwards compatibility
- --ignored_tags that allows the caller to specify which tags to ignore. If not specified this defaults to the original set - ensuring backwards compatibility
- --keep_tables that preserves the contents of any tables in the original article text.

