### PR TITLE
New script and options for making offline web browsed content of mediawiki dump

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-01-03  Michal Svamberg  <svamberg@civ.zcu.cz>
+
+	* makehtmlfiles.pl: add new script for building web browsed content
+	This script build simple pages from output of WikiExtractor.
+
+	For more information read example section in README.md
+
 2017-01-15  Giuseppe Attardi  <attardi@di.unipi.it>
 
 	* WikiExtractor.py (process_dump): use text_type to decide whether

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,18 @@
 
 	For more information read example section in README.md
 
+	* WikiExtractor.py (keepPage): check for -xns option (or default = 0)
+	* WikiExtractor.py (replaceInternalLinks): 
+	  - Fix URL links to other pages
+	  - Add support for Image links (make html tag <img src="%s" alt="%s">)
+	* WikiExtractor.py (compact): add lines beginned by space into <tt> tag
+	* WikiExtractor.py (pages_from): insert redirect pages if option
+	--redirect_insert is enabled
+	* WikiExtractor.py (main): add new options used in above changes
+	  --all_links print links to all namespaces (independent of -xns or -ns)
+	  --xml_namespaces add numeric namespaces for search pages
+	  --redirect_insert create pages where used #REDIRECT wiki command
+
 2017-01-15  Giuseppe Attardi  <attardi@di.unipi.it>
 
 	* WikiExtractor.py (process_dump): use text_type to decide whether

--- a/README.md
+++ b/README.md
@@ -127,18 +127,23 @@ For further information, visit [the documentation](http://attardi.github.io/wiki
 
 ## Example: Howto make offline content of your MediaWiki as web pages
 Make dump of your mediawiki:
+
         php5 /var/lib/mediawiki/maintenance/dumpBackup.php --current > /tmp/dump.xml
 
 Extract data from dump to one big file (param --html is necessary):
+
         ./WikiExtractor.py -o - -xns 0,2,14,100,102,104,106,108,110,112,114,116 --links --all_links -b 200M --html --redirect_insert --keep_tables -q /tmp/dump.xml > /tmp/wiki.data 
 
 Create single html pages and index.html:
+
         cat /tmp/wiki.data | ./makehtmlfiles.pl /tmp/offline
 
 Optional you can copy images:
+
         cd /var/lib/mediawiki/images
         find 0 1 2 3 4 5 6 7 8 9 a b c d e f -type f -exec cp -f {} /tmp/offline/images/ \;
 
 View offline content of yout wikimedia (without skins, images, templates, ...):
+
         links file:///tmp/offline/index.html
 

--- a/README.md
+++ b/README.md
@@ -109,3 +109,21 @@ Option --no-templates significantly speeds up the extractor, avoiding the cost
 of expanding [MediaWiki templates](https://www.mediawiki.org/wiki/Help:Templates).
 
 For further information, visit [the documentation](http://attardi.github.io/wikiextractor).
+
+## Example: Howto make offline content of your MediaWiki as web pages
+Make dump of your mediawiki:
+        php5 /var/lib/mediawiki/maintenance/dumpBackup.php --current > /tmp/dump.xml
+
+Extract data from dump to one big file (param --html is necessary):
+        ./WikiExtractor.py -o - -xns 0,2,14,100,102,104,106,108,110,112,114,116 --links --all_links -b 200M --html --redirect_insert --keep_tables -q /tmp/dump.xml > /tmp/wiki.data 
+
+Create single html pages and index.html:
+        cat /tmp/wiki.data | ./makehtmlfiles.pl /tmp/offline
+
+Optional you can copy images:
+        cd /var/lib/mediawiki/images
+        find 0 1 2 3 4 5 6 7 8 9 a b c d e f -type f -exec cp -f {} /tmp/offline/images/ \;
+
+View offline content of yout wikimedia (without skins, images, templates, ...):
+        links file:///tmp/offline/index.html
+

--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ Each file will contains several documents in this [document format](http://media
                                 input
 
         Wikipedia Extractor:
-        Extracts and cleans text from a Wikipedia database dump and stores output in a number of files of similar size in a given directory.
+        Extracts and cleans text from a Wikipedia database dump and stores output in a number of files 
+        of similar size in a given directory.
         Each file will contain several documents in the format:
 
             <doc id="" revid="" url="" title="">
                 ...
                 </doc>
 
-        If the program is invoked with the --json flag, then each file will contain several documents formatted as json ojects, one per line, with the following structure
+        If the program is invoked with the --json flag, then each file will contain several documents 
+        formatted as json ojects, one per line, with the following structure
 
             {"id": "", "revid": "", "url":"", "title": "", "text": "..."}
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ For further information, visit [the documentation](http://attardi.github.io/wiki
         cd /var/lib/mediawiki/images
         find 0 1 2 3 4 5 6 7 8 9 a b c d e f -type f -exec cp -f {} /tmp/offline/images/ \;
 
-5. View offline content of yout wikimedia (without skins, images, templates, ...):
+5. View offline content ONLY (without skins, templates, scripts, ...) of your wikimedia:
 
         links file:///tmp/offline/index.html
 

--- a/README.md
+++ b/README.md
@@ -45,22 +45,18 @@ Each file will contains several documents in this [document format](http://media
                                 input
 
         Wikipedia Extractor:
-        Extracts and cleans text from a Wikipedia database dump and stores output in a
-        number of files of similar size in a given directory.
+        Extracts and cleans text from a Wikipedia database dump and stores output in a number of files of similar size in a given directory.
         Each file will contain several documents in the format:
 
             <doc id="" revid="" url="" title="">
                 ...
                 </doc>
 
-        If the program is invoked with the --json flag, then each file will
-        contain several documents formatted as json ojects, one per line, with
-        the following structure
+        If the program is invoked with the --json flag, then each file will contain several documents formatted as json ojects, one per line, with the following structure
 
             {"id": "", "revid": "", "url":"", "title": "", "text": "..."}
 
-        Template expansion requires preprocesssng first the whole dump and
-        collecting template definitions.
+        Template expansion requires preprocesssng first the whole dump and collecting template definitions.
 
         positional arguments:
           input                 XML wiki dump file
@@ -72,8 +68,7 @@ Each file will contains several documents in this [document format](http://media
 
         Output:
           -o OUTPUT, --output OUTPUT
-                                directory for extracted files (or '-' for dumping to
-                                stdout)
+                                directory for extracted files (or '-' for dumping to stdout)
           -b n[KMG], --bytes n[KMG]
                                 maximum bytes per output file (default 1M)
           -c, --compress        compress output files using bzip
@@ -94,34 +89,26 @@ Each file will contains several documents in this [document format](http://media
           --no-templates        Do not expand templates
           -r, --revision        Include the document revision id (default=False)
           --min_text_length MIN_TEXT_LENGTH
-                                Minimum expanded text length required to write
-                                document (default=0)
+                                Minimum expanded text length required to write document (default=0)
           --filter_disambig_pages
-                                Remove pages from output that contain disabmiguation
-                                markup (default=False)
+                                Remove pages from output that contain disabmiguation markup (default=False)
           -it abbr,b,big, --ignored_tags abbr,b,big
-                                comma separated list of tags that will be dropped,
-                                keeping their content
+                                comma separated list of tags that will be dropped, keeping their content
           -de gallery,timeline,noinclude, --discard_elements gallery,timeline,noinclude
-                                comma separated list of elements that will be removed
-                                from the article text
-          --keep_tables         Preserve tables in the output article text
-                                (default=False)
+                                comma separated list of elements that will be removed from the article text
+          --keep_tables         Preserve tables in the output article text (default=False)
           --redirect_insert     Insert redirect pages to output
 
         Special:
           -q, --quiet           suppress reporting progress info
           --debug               print debug info
-          -a, --article         analyze a file containing a single article (debug
-                                option)
+          -a, --article         analyze a file containing a single article (debug option)
           -v, --version         print program version
 
 
-Saving templates to a file will speed up performing extraction the next time,
-assuming template definitions have not changed.
+Saving templates to a file will speed up performing extraction the next time, assuming template definitions have not changed.
 
-Option --no-templates significantly speeds up the extractor, avoiding the cost
-of expanding [MediaWiki templates](https://www.mediawiki.org/wiki/Help:Templates).
+Option --no-templates significantly speeds up the extractor, avoiding the cost of expanding [MediaWiki templates](https://www.mediawiki.org/wiki/Help:Templates).
 
 For further information, visit [the documentation](http://attardi.github.io/wikiextractor).
 

--- a/README.md
+++ b/README.md
@@ -33,73 +33,88 @@ The script is invoked with a Wikipedia dump file as an argument.
 The output is stored in several files of similar size in a given directory.
 Each file will contains several documents in this [document format](http://medialab.di.unipi.it/wiki/Document_Format).
 
-    usage: WikiExtractor.py [-h] [-o OUTPUT] [-b n[KMG]] [-c] [--html] [-l] [-s]
-                            [--lists] [-ns ns1,ns2] [-xns ns1,ns2]
-                            [--templates TEMPLATES] [--no-templates]
-                            [-r] [--min_text_length MIN_TEXT_LENGTH]
-                            [--filter_disambig_pages] [--processes PROCESSES] [-q]
-                            [--debug] [-a] [-v]
-                            input
+        usage: WikiExtractor.py [-h] [-o OUTPUT] [-b n[KMG]] [-c] [--json] [--html]
+                                [-l] [--all_links] [-s] [--lists] [-ns ns1,ns2]
+                                [-xns ns1,ns2] [--templates TEMPLATES]
+                                [--no-templates] [-r]
+                                [--min_text_length MIN_TEXT_LENGTH]
+                                [--filter_disambig_pages] [-it abbr,b,big]
+                                [-de gallery,timeline,noinclude] [--keep_tables]
+                                [--processes PROCESSES] [--redirect_insert] [-q]
+                                [--debug] [-a] [-v]
+                                input
 
-    Wikipedia Extractor:
-    Extracts and cleans text from a Wikipedia database dump and stores output in a
-    number of files of similar size in a given directory.
-    Each file will contain several documents in the format:
+        Wikipedia Extractor:
+        Extracts and cleans text from a Wikipedia database dump and stores output in a
+        number of files of similar size in a given directory.
+        Each file will contain several documents in the format:
 
-        <doc id="" revid="" url="" title="">
-            ...
-            </doc>
+            <doc id="" revid="" url="" title="">
+                ...
+                </doc>
 
-    Template expansion requires preprocesssng first the whole dump and
-    collecting template definitions.
+        If the program is invoked with the --json flag, then each file will
+        contain several documents formatted as json ojects, one per line, with
+        the following structure
 
-    positional arguments:
-      input                 XML wiki dump file
+            {"id": "", "revid": "", "url":"", "title": "", "text": "..."}
 
-    optional arguments:
-      -h, --help            show this help message and exit
-      --processes PROCESSES number of processes to use (default: number of CPU cores)
+        Template expansion requires preprocesssng first the whole dump and
+        collecting template definitions.
 
-    Output:
-      -o OUTPUT, --output OUTPUT
-                            directory for extracted files (or '-' for dumping to
-                            stdout)
-      -b n[KMG], --bytes n[KMG]
-                            maximum bytes per output file (default 1M)
-      -c, --compress        compress output files using bzip
+        positional arguments:
+          input                 XML wiki dump file
 
-    Processing:
-      --html                produce HTML output, subsumes --links
-      -l, --links           preserve links
-      -s, --sections        preserve sections
-      --lists               preserve lists
-      -ns ns1,ns2, --namespaces ns1,ns2
-                            accepted link namespaces
-      -xns ns1,ns2, --xml_namespaces ns1,ns2
-                            accepted page xml namespaces -- 0 for main/articles
-      --templates TEMPLATES
-                            use or create file containing templates
-      --no-templates        Do not expand templates
-      -r, --revision        Include the document revision id (default=False)
-      --min_text_length MIN_TEXT_LENGTH
-                            Minimum expanded text length required to write
-                            document (default=0)
-      --filter_disambig_pages
-                            Remove pages from output that contain disabmiguation
-                            markup (default=False)
-      -it, --ignored_tags
-                            comma separated list of tags that will be dropped, keeping their content
-      -de, --discard_elements
-                            comma separated list of elements that will be removed from the article text
-      --keep_tables
-                            Preserve tables in the output article text (default=False)
+        optional arguments:
+          -h, --help            show this help message and exit
+          --processes PROCESSES
+                                Number of processes to use (default 3)
 
-    Special:
-      -q, --quiet           suppress reporting progress info
-      --debug               print debug info
-      -a, --article         analyze a file containing a single article (debug
-                            option)
-      -v, --version         print program version
+        Output:
+          -o OUTPUT, --output OUTPUT
+                                directory for extracted files (or '-' for dumping to
+                                stdout)
+          -b n[KMG], --bytes n[KMG]
+                                maximum bytes per output file (default 1M)
+          -c, --compress        compress output files using bzip
+          --json                write output in json format instead of the default one
+
+        Processing:
+          --html                produce HTML output, subsumes --links
+          -l, --links           preserve links
+          --all_links           preserve all links (with links to all namespaces)
+          -s, --sections        preserve sections
+          --lists               preserve lists
+          -ns ns1,ns2, --namespaces ns1,ns2
+                                accepted namespaces in links
+          -xns ns1,ns2, --xml_namespaces ns1,ns2
+                                accepted page xml namespaces -- 0 for main/articles
+          --templates TEMPLATES
+                                use or create file containing templates
+          --no-templates        Do not expand templates
+          -r, --revision        Include the document revision id (default=False)
+          --min_text_length MIN_TEXT_LENGTH
+                                Minimum expanded text length required to write
+                                document (default=0)
+          --filter_disambig_pages
+                                Remove pages from output that contain disabmiguation
+                                markup (default=False)
+          -it abbr,b,big, --ignored_tags abbr,b,big
+                                comma separated list of tags that will be dropped,
+                                keeping their content
+          -de gallery,timeline,noinclude, --discard_elements gallery,timeline,noinclude
+                                comma separated list of elements that will be removed
+                                from the article text
+          --keep_tables         Preserve tables in the output article text
+                                (default=False)
+          --redirect_insert     Insert redirect pages to output
+
+        Special:
+          -q, --quiet           suppress reporting progress info
+          --debug               print debug info
+          -a, --article         analyze a file containing a single article (debug
+                                option)
+          -v, --version         print program version
 
 
 Saving templates to a file will speed up performing extraction the next time,

--- a/README.md
+++ b/README.md
@@ -126,24 +126,24 @@ of expanding [MediaWiki templates](https://www.mediawiki.org/wiki/Help:Templates
 For further information, visit [the documentation](http://attardi.github.io/wikiextractor).
 
 ## Example: Howto make offline content of your MediaWiki as web pages
-Make dump of your mediawiki:
+1. Make dump of your mediawiki:
 
         php5 /var/lib/mediawiki/maintenance/dumpBackup.php --current > /tmp/dump.xml
 
-Extract data from dump to one big file (param --html is necessary):
+2. Extract data from dump to one big file (param --html is necessary):
 
         ./WikiExtractor.py -o - -xns 0,2,14,100,102,104,106,108,110,112,114,116 --links --all_links -b 200M --html --redirect_insert --keep_tables -q /tmp/dump.xml > /tmp/wiki.data 
 
-Create single html pages and index.html:
+3. Create single html pages and index.html:
 
         cat /tmp/wiki.data | ./makehtmlfiles.pl /tmp/offline
 
-Optional you can copy images:
+4. Optional you can copy images:
 
         cd /var/lib/mediawiki/images
         find 0 1 2 3 4 5 6 7 8 9 a b c d e f -type f -exec cp -f {} /tmp/offline/images/ \;
 
-View offline content of yout wikimedia (without skins, images, templates, ...):
+5. View offline content of yout wikimedia (without skins, images, templates, ...):
 
         links file:///tmp/offline/index.html
 

--- a/makehtmlfiles.pl
+++ b/makehtmlfiles.pl
@@ -1,0 +1,108 @@
+#!/usr/bin/perl
+
+# vystup z wikiextractor ve formatu html rozseka podle tagu 'doc' na jednotlive
+# soubory, prida k nim html hlavicku/paticku a upravi odkazy
+use strict;
+use URI::Escape;
+use File::Basename;
+use File::Path qw(make_path);
+use HTML::Entities;
+
+my ($out_dir) = @ARGV;
+if (not defined $out_dir) {
+  die "Missing param, usage: makehtmlfiles.pl <output_dir>\n";
+}
+
+my $html_head_tmpl = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>OFFLINE MEDIAWIKI</title>
+</head>
+<body>';
+my $html_head = '';
+
+my $html_foot = "\n</body></html>\n";
+
+my $basedir = '';
+my $title = '';
+my $suffix = 'html';
+my $filename = '';
+my $filename_index = "index.$suffix";
+my $line = '';
+my $FILE;
+my $INDEX;
+my %index = ();
+my $indx = ''; # sorted index
+my $relative_path = '';
+
+make_path("$out_dir/pages", 0700) unless(-d "$out_dir/pages" );
+make_path("$out_dir/images", 0700) unless(-d "$out_dir/images" );
+
+foreach $line ( <STDIN> ) {
+    chomp( $line );
+    if ($line =~ /^\s*<doc.*title="(.*?)".*>\s*$/) {
+        $title = "$1";
+        #$filename = uri_escape("$title") . ".$suffix";
+        $filename = "$title" . ".$suffix";
+        # print "$title \t-> $filename\n";
+        
+        $filename =~ s/\s/_/g; 
+        $basedir = dirname("$filename");
+        # print "MKDIR $basedir\n";
+        make_path("$out_dir/pages/$basedir", 0700) unless(-d "$out_dir/pages/$basedir" );        
+
+        open($FILE, ">", "$out_dir/pages/$filename") or die "cannot open > $out_dir/$filename: $!";
+
+        $html_head = $html_head_tmpl;
+        $html_head =~ s#<title>OFFLINE MEDIAWIKI</title>#<title>$title</title>#;
+        print $FILE "$html_head";
+        print $FILE "\n<!-- $line -->\n";
+        # insert to index
+        $index{"$title"} = uri_escape("$filename");
+
+        # prepare relative path - update URI references
+        $relative_path = $basedir;
+        $relative_path =~ s#[^/]+#..#g if $relative_path !~ /^\.$/;
+        $relative_path .= "/";
+        $relative_path = '' if $relative_path =~ m#^./$#;
+        # print "$basedir -> $relative_path\n";
+
+        next;
+    }
+
+    if ($line =~ /^\s*<\/doc>\s*$/) {
+        print $FILE "$html_foot";
+        close $FILE;
+        next;
+    }
+   
+    # fix URI 
+    decode_entities($line);
+    $line =~ s#href="(.*?)"#href="$relative_path\1.$suffix"#g;
+    $line =~ s/(?<=href=")([^"]*)/($a=$1)=~s, |%20,_,g;"$a"/ge ;
+    $line =~ s/(?<=href="http)([^"]*)/($a=$1)=~s,%3A,:,g;"$a"/ge ;
+
+    # fix images
+    $line =~ s#img src="(.*?)"#img src="$relative_path../images/\u\1"#g;
+    $line =~ s/(?<=img src=")([^"]*)/($a=$1)=~s, |%20,_,g;"$a"/ge ;
+    $line =~ s/(?<=img src="http)([^"]*)/($a=$1)=~s,%3A,:,g;"$a"/ge ;
+
+    print $FILE "$line";
+}
+
+# make index.html
+open($INDEX, ">", "$out_dir/$filename_index") or die "cannot open > $out_dir/$filename_index: $!";
+$html_head = $html_head_tmpl;
+$html_head =~ s#<title>OFFLINE MEDIAWIKI</title>#<title>Index of MediaWiki dump</title>#;
+print $INDEX "$html_head";
+
+foreach $indx (sort keys %index) {
+    print $INDEX "<a href=\"pages/$index{$indx}\">$indx</a><br>";
+}
+
+print $INDEX "$html_foot";
+close $INDEX;
+
+exit 0;
+


### PR DESCRIPTION
New options (and some improvements) in WikiExtractor.py are used in makehtmlfiles.pl for building tree of html files. For further information read README.md in last Example section.