### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ The script is invoked with a Wikipedia dump file as an argument.
 The output is stored in several files of similar size in a given directory.
 Each file will contains several documents in this [document format](http://medialab.di.unipi.it/wiki/Document_Format).
 
-    usage: WikiExtractor.py [-h] [-o OUTPUT] [-b n[KMG]] [-c] [--html] [-l] [-s]
-                            [--lists] [-ns ns1,ns2] [-xns ns1,ns2]
-                            [--templates TEMPLATES] [--no-templates]
-                            [-r] [--min_text_length MIN_TEXT_LENGTH]
-                            [--filter_disambig_pages] [--processes PROCESSES] [-q]
-                            [--debug] [-a] [-v]
+    usage: WikiExtractor.py [-h] [-o OUTPUT] [-b n[KMG]] [-c] [--json] [--html]
+                            [-l] [-s] [--lists] [-ns ns1,ns2]
+                            [--templates TEMPLATES] [--no-templates] [-r]
+                            [--min_text_length MIN_TEXT_LENGTH]
+                            [--filter_disambig_pages] [-it abbr,b,big]
+                            [-de gallery,timeline,noinclude] [--keep_tables]
+                            [--processes PROCESSES] [-q] [--debug] [-a] [-v]
                             input
 
     Wikipedia Extractor:
@@ -50,6 +51,12 @@ Each file will contains several documents in this [document format](http://media
             ...
             </doc>
 
+    If the program is invoked with the --json flag, then each file will
+    contain several documents formatted as json ojects, one per line, with
+    the following structure
+
+        {"id": "", "revid": "", "url":"", "title": "", "text": "..."}
+
     Template expansion requires preprocesssng first the whole dump and
     collecting template definitions.
 
@@ -58,7 +65,8 @@ Each file will contains several documents in this [document format](http://media
 
     optional arguments:
       -h, --help            show this help message and exit
-      --processes PROCESSES number of processes to use (default: number of CPU cores)
+      --processes PROCESSES
+                            Number of processes to use (default 1)
 
     Output:
       -o OUTPUT, --output OUTPUT
@@ -67,6 +75,7 @@ Each file will contains several documents in this [document format](http://media
       -b n[KMG], --bytes n[KMG]
                             maximum bytes per output file (default 1M)
       -c, --compress        compress output files using bzip
+      --json                write output in json format instead of the default one
 
     Processing:
       --html                produce HTML output, subsumes --links
@@ -74,9 +83,7 @@ Each file will contains several documents in this [document format](http://media
       -s, --sections        preserve sections
       --lists               preserve lists
       -ns ns1,ns2, --namespaces ns1,ns2
-                            accepted link namespaces
-      -xns ns1,ns2, --xml_namespaces ns1,ns2
-                            accepted page xml namespaces -- 0 for main/articles
+                            accepted namespaces in links
       --templates TEMPLATES
                             use or create file containing templates
       --no-templates        Do not expand templates
@@ -87,12 +94,14 @@ Each file will contains several documents in this [document format](http://media
       --filter_disambig_pages
                             Remove pages from output that contain disabmiguation
                             markup (default=False)
-      -it, --ignored_tags
-                            comma separated list of tags that will be dropped, keeping their content
-      -de, --discard_elements
-                            comma separated list of elements that will be removed from the article text
-      --keep_tables
-                            Preserve tables in the output article text (default=False)
+      -it abbr,b,big, --ignored_tags abbr,b,big
+                            comma separated list of tags that will be dropped,
+                            keeping their content
+      -de gallery,timeline,noinclude, --discard_elements gallery,timeline,noinclude
+                            comma separated list of elements that will be removed
+                            from the article text
+      --keep_tables         Preserve tables in the output article text
+                            (default=False)
 
     Special:
       -q, --quiet           suppress reporting progress info


### PR DESCRIPTION
Hi, I noticed that the current `README.md` doesn't match with the `WikiExtractor.py -h` output. I think that should be fixed. I was confused for a short time, trying to use `-xns` option.