### PR TITLE
Fix problems that occurred when a list was the first thing in a section.

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -2527,6 +2527,7 @@ def compact(text):
                         page.append(listClose[c])
                 listLevel = []
                 listCount = []
+                emptySection = False
             elif page and page[-1]:
                 page.append('')
             continue
@@ -2591,10 +2592,11 @@ def compact(text):
             line = line[i:].strip()
             if line:  # FIXME: n is '"'
                 if options.keepLists:
-                    # emit open sections
-                    items = sorted(headers.items())
-                    for _, v in items:
-                        page.append(v)
+                    if options.keepSections:
+                        # emit open sections
+                        items = sorted(headers.items())
+                        for _, v in items:
+                            page.append(v)
                     headers.clear()
                     # use item count for #-lines
                     listCount[i - 1] += 1


### PR DESCRIPTION
There were bugs that caused content to be dropped or erroneously included if a list was the first thing in a section and --lists was specified.  This change should fix #117 and #118.