### PR TITLE
Fix broken disambiguation articles filtering 

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -206,8 +206,8 @@ templateKeys = set(['10', '828'])
 
 ##
 # Regex for identifying disambig pages
-filter_disambig_page_pattern = re.compile("{{disambig(uation)?(\|[^}]*)?}}")
-
+filter_disambig_page_pattern = re.compile(
+    "(\(disambiguation\))|([Dd]isambig(uation)?(\|[^}]*)?}})")
 ##
 # page filtering logic -- remove templates, undesired xml namespaces, and disambiguation pages
 def keepPage(ns, page):


### PR DESCRIPTION
Hi!

It looks like the Wikipedia disambiguation markup has changed and now disambiguation pages are not being filtered properly. Please consider my pull request fixing this issue.

Fix issue #127 