### PR TITLE
Added option to include section title hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Each file will contains several documents in this [document format](http://media
       --html                produce HTML output, subsumes --links
       -l, --links           preserve links
       -s, --sections        preserve sections
+      -sh, --section_hierarchy
+                            preserve section hierarchy
       --lists               preserve lists
       -ns ns1,ns2, --namespaces ns1,ns2
                             accepted namespaces in links


### PR DESCRIPTION
Additional flag that allows to keep section titles hierarchy e.g.:
`Section::::Anarchist schools of thought.:Classical.:Mutualism.` in [Anarchism - Wikipedia](https://en.wikipedia.org/wiki?curid=12).