### PR TITLE
change cgi to html

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -60,7 +60,7 @@ import sys
 import argparse
 import bz2
 import codecs
-import cgi
+import html
 import fileinput
 import logging
 import os.path


### PR DESCRIPTION
If you execute it by specifying html as an argument, the error that html cannot be found at line:811 will occur.
I changed line63, "import cgi" to "import html".

I used GoogleTranslator.
thank you.