### PR TITLE
Fixed print function in extractPage.py

### DIFF
--- a/wikiextractor/extractPage.py
+++ b/wikiextractor/extractPage.py
@@ -94,7 +94,7 @@ def process_data(input_file, id, templates=False):
         elif tag == '/page':
             if page:
                 page.append(line)
-                print ''.join(page).encode('utf-8')
+                print(''.join(page).encode('utf-8'))
                 if not templates:
                     break
             page = []


### PR DESCRIPTION
In Python 3 print is a function not a statement. The README.md says it requires Python 3 so I just changed this line.