### PR TITLE
updated import in WIkiExtractor.py

### DIFF
--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -63,7 +63,7 @@ from io import StringIO
 from multiprocessing import Queue, Process, cpu_count
 from timeit import default_timer
 
-from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces
+from extract import Extractor, ignoreTag, define_template, acceptedNamespaces
 
 # ===========================================================================
 


### PR DESCRIPTION
the format was wrong when run the file on python 3 I got import error:
`ImportError: attempted relative import with no known parent package`