### PR TITLE
Specify python 3.6 version to be the required version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WikiExtractor
 [WikiExtractor.py](http://medialab.di.unipi.it/wiki/Wikipedia_Extractor) is a Python script that extracts and cleans text from a [Wikipedia database dump](https://dumps.wikimedia.org/).
 
-The tool is written in Python and requires Python 3.6 but no additional library.
+The tool is written in Python and requires Python 3.5 but no additional library.
 **Warning**: problems have been reported on Windows due to poor support for `StringIO` in the Python implementation on Windows.
 
 For further information, see the [Wiki](https://github.com/attardi/wikiextractor/wiki).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WikiExtractor
 [WikiExtractor.py](http://medialab.di.unipi.it/wiki/Wikipedia_Extractor) is a Python script that extracts and cleans text from a [Wikipedia database dump](https://dumps.wikimedia.org/).
 
-The tool is written in Python and requires Python 3 but no additional library.
+The tool is written in Python and requires Python 3.6 but no additional library.
 **Warning**: problems have been reported on Windows due to poor support for `StringIO` in the Python implementation on Windows.
 
 For further information, see the [Wiki](https://github.com/attardi/wikiextractor/wiki).


### PR DESCRIPTION
I thought the library wasn't working and it turned out it's only working with Python 3.6. but I was using Python 3.8 so I have added this info to the README file to avoid headaches to other users :)