### PR TITLE
Fixed fileWrapper bug

### DIFF
--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -856,7 +856,7 @@ class Extractor():
         text = ''.join(self.page)
         text = self.clean_text(text, html_safe=html_safe)
 
-        if self.to_json:
+        if self.toJson:
             json_data = {
 		'id': self.id,
                 'revid': self.revid,


### PR DESCRIPTION
Hi there! 

I had some problems with running the utility that this pull request fixes. 
* Wrong variable name: In the extractor there was a variable typo `to_json` and `toJson`.
* IO wrapper pickling: One a new process starts it had problems pickling the output class since an 
open file reference is not serializable. I've made a quick workaround, it could be done in a more elegant way. Let me know if you have any ideas. 

I've tested it with a smaller wiki dump (10.000 pages) and it seems to work there. 
I've also uploaded a [small test dump](https://gist.github.com/Rotendahl/012ac1a92283b36baf7d614f746bcb53), it's only 10 pages, since gists have a limit of 1mb, you can run it and validate the output if you wish. 

Thanks for the groundwork on this utility! 
Even with having to make these small changes this utility saved me a significant amount of time. 

Cheers 
- Benjamin