### PR TITLE
add encoding parameter in load_templates

### DIFF
--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -191,7 +191,7 @@ tagRE = re.compile(r'(.*?)<(/?\w+)[^>]*>(?:([^<]*)(<.*?>)?)?')
 #                    1     2               3      4
 
 
-def load_templates(file, output_file=None):
+def load_templates(file, output_file=None, encoding='utf-8'):
     """
     Load templates from :param file:.
     :param output_file: file where to save templates and modules.
@@ -205,7 +205,7 @@ def load_templates(file, output_file=None):
     page = []
     inText = False
     if output_file:
-        output = open(output_file, 'w')
+        output = open(output_file, 'w', encoding=encoding)
     for line in file:
         #line = line.decode('utf-8')
         if '<' not in line:  # faster than doing re.search()


### PR DESCRIPTION
Add an `encoding` parameter in the load_templates function. This is especially useful on Windows where utf-8 is not the default encoding.