### PR TITLE
error_replacement

### DIFF
--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -63,7 +63,7 @@ from io import StringIO
 from multiprocessing import Queue, get_context, cpu_count
 from timeit import default_timer
 
-from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces
+from extract import Extractor, ignoreTag, define_template, acceptedNamespaces
 
 # ===========================================================================
 


### PR DESCRIPTION
While using this program i got an error.Due to under problem it was not working
`from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces`

So i changed into 
`from extract import Extractor, ignoreTag, define_template, acceptedNamespaces`
where i remove the dot after from.

