### PR TITLE
Add argument to preserve unicode characters in json output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Each file will contains several documents in this [document format](https://gith
 
 ```
 usage: wikiextractor [-h] [-o OUTPUT] [-b n[KMG]] [-c] [--json] [--html] [-l] [-ns ns1,ns2]
-			 [--templates TEMPLATES] [--no-templates] [--html-safe HTML_SAFE] [--processes PROCESSES]
-			 [-q] [--debug] [-a] [-v]
+			 [--preserve-unicode] [--templates TEMPLATES] [--no-templates] [--html-safe HTML_SAFE] [--processes PROCESSES] [-q] [--debug] [-a] [-v]
 			 input
 
 Wikipedia Extractor:
@@ -93,6 +92,8 @@ Output:
 			    maximum bytes per output file (default 1M)
   -c, --compress        compress output files using bzip
   --json                write output in json format instead of the default <doc> format
+  --preserve-unicode
+          Do not convert unicode characters to ascii characters when using JSON output
 
 Processing:
   --html                produce HTML output, subsumes --links

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -548,6 +548,8 @@ def main():
                         help="compress output files using bzip")
     groupO.add_argument("--json", action="store_true",
                         help="write output in json format instead of the default <doc> format")
+    groupO.add_argument("--preserve-unicode", action="store_true",
+                        help="Do not convert unicode characters to ascii characters when using JSON output")
 
     groupP = parser.add_argument_group('Processing')
     groupP.add_argument("--html", action="store_true",
@@ -584,6 +586,7 @@ def main():
     if args.html:
         Extractor.keepLinks = True
     Extractor.to_json = args.json
+    Extractor.preserve_unicode = args.preserve_unicode
 
     try:
         power = 'kmg'.find(args.bytes[-1].lower()) + 1

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -982,7 +982,10 @@ class Extractor():
                 'title': self.title,
                 'text': "\n".join(text)
             }
-            out_str = json.dumps(json_data)
+            if self.preserve_unicode:
+                out_str = json.dumps(json_data, ensure_ascii=False)
+            else:
+                out_str = json.dumps(json_data)
             out.write(out_str)
             out.write('\n')
         else:


### PR DESCRIPTION
Here's a snippit from the Anthropology article before this code change using the --json argument.
```
Their New Latin ' derived from the combining forms of the Greek words \"\u00e1nthr\u014dpos\" (, \"human\") and \"l\u00f3gos\" (, \"study\").
```
Here it is after these code changes, using --json and --preserve-unicode
```
Their New Latin ' derived from the combining forms of the Greek words \"ánthrōpos\" (, \"human\") and \"lógos\" (, \"study\").
```
For text computing activities, it's nice to have the option to preserve these unicode characters in their true form, rather than ASCII representations.
