### PR TITLE
Updating clean_markup function to be compatible with Extractor.__init…

### DIFF
--- a/wikiextractor/clean.py
+++ b/wikiextractor/clean.py
@@ -33,13 +33,12 @@ def clean_markup(markup, keep_links=False, ignore_headers=True):
     if not keep_links:
         ignoreTag('a')
 
-    extractor = Extractor(0, '', [])
+    extractor = Extractor(0, '', [], '', '')
 
     # returns a list of strings
     paragraphs = extractor.clean_text(markup,
                                       mark_headers=True,
-                                      expand_templates=False,
-                                      escape_doc=True)
+                                      expand_templates=False)
     resetIgnoredTags()
 
     if ignore_headers:


### PR DESCRIPTION
clean_markup function in clean.py seems outdated.

It's trying to call Extractor constructor and the Extractor's method clean_text with a wrong number of parameters.