### PR TITLE
fix reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ If you find this code useful, please refer it in publications as:
 
 ~~~
 @misc{Wikiextractor2015,
-  author = {Giusepppe Attardi},
+  author = {Giuseppe Attardi},
   title = {WikiExtractor},
   year = {2015},
   publisher = {GitHub},


### PR DESCRIPTION
There is a typo in a reference to WikiExtractor in README.md.

The author's name is Giuseppe Attardi, not Giusepppe Attardi.