### PR TITLE
bug fix in OutputSplitter regarding file handling for bz2 type

### DIFF
--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -162,23 +162,21 @@ class OutputSplitter():
         self.file = self.open(self.nextFile.next())
 
     def reserve(self, size):
-        if self.file.tell() + size > self.max_file_size:
+        if self.size + size > self.max_file_size:
             self.close()
             self.file = self.open(self.nextFile.next())
 
     def write(self, data):
         self.reserve(len(data))
-        if self.compress:
-            self.file.write(data)
-        else:
-            self.file.write(data)
+        self.size += self.file.write(data)
 
     def close(self):
         self.file.close()
 
     def open(self, filename):
+        self.size = 0
         if self.compress:
-            return bz2.BZ2File(filename + '.bz2', 'w')
+            return bz2.open(filename + '.bz2', 'wt')
         else:
             return open(filename, 'w')
 


### PR DESCRIPTION
Previously the bz2 file handling was done in an unsafe manner, I met with some exceptions when trying to write it as a bz2 file. This commit only handles issues in the `class OutputSplitter` from the file `WikiExtractor.py`. 