### PR TITLE
to comply with python 3.12

### DIFF
--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -168,8 +168,8 @@ def clean(extractor, text, expand_templates=False, html_safe=True):
     text = text.replace('\t', ' ')
     text = spaces.sub(' ', text)
     text = dots.sub('...', text)
-    text = re.sub(r' (,:\.\)\]»)', r'\1', text)
-    text = re.sub(r'(\[\(«) ', r'\1', text)
+    text = re.sub(' (,:\.\)\]»)', r'\1', text)
+    text = re.sub('(\[\(«) ', r'\1', text)
     text = re.sub(r'\n\W+?\n', '\n', text, flags=re.U)  # lines with only punctuations
     text = text.replace(',,', ',').replace(',.', '.')
     if html_safe:
@@ -386,8 +386,7 @@ ExtLinkBracketedRegex = re.compile(
 EXT_IMAGE_REGEX = re.compile(
     r"""^(http://|https://)([^][<>"\x00-\x20\x7F\s]+)
     /([A-Za-z0-9_.,~%\-+&;#*?!=()@\x80-\xFF]+)\.(gif|png|jpg|jpeg)$""",
-    re.X | re.I
-)
+    re.X | re.I)
 
 
 def replaceExternalLinks(text):
@@ -1765,7 +1764,7 @@ parserFunctions = {
 
     'int': lambda string, *rest: str(int(string)),
 
-    'padleft': lambda char, width, string: string.ljust(int(width), char), # CHECK_ME
+    'padleft': lambda char, width, string: string.ljust(char, int(pad)), # CHECK_ME
 
 }
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -380,7 +380,7 @@ wgUrlProtocols = [
 # as well as U+3000 is IDEOGRAPHIC SPACE for bug 19052
 EXT_LINK_URL_CLASS = r'[^][<>"\x00-\x20\x7F\s]'
 ExtLinkBracketedRegex = re.compile(
-    r'\[(((?i)' + r'|'.join(wgUrlProtocols) + r')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
+    r'(?i)\[((' + r'|'.join(wgUrlProtocols) + r')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
     re.S | re.U)
 EXT_IMAGE_REGEX = re.compile(
     r"""^(http://|https://)([^][<>"\x00-\x20\x7F\s]+)

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -30,8 +30,8 @@ import time
 # ----------------------------------------------------------------------
 
 # match tail after wikilink
-tailRE = re.compile('\w+')
-syntaxhighlight = re.compile('&lt;syntaxhighlight .*?&gt;(.*?)&lt;/syntaxhighlight&gt;', re.DOTALL)
+tailRE = re.compile(r'\w+')
+syntaxhighlight = re.compile(r'&lt;syntaxhighlight .*?&gt;(.*?)&lt;/syntaxhighlight&gt;', re.DOTALL)
 
 ## PARAMS ####################################################################
 
@@ -380,7 +380,7 @@ wgUrlProtocols = [
 # as well as U+3000 is IDEOGRAPHIC SPACE for bug 19052
 EXT_LINK_URL_CLASS = r'[^][<>"\x00-\x20\x7F\s]'
 ExtLinkBracketedRegex = re.compile(
-    '\[(((?i)' + '|'.join(wgUrlProtocols) + ')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
+    r'\[(((?i)' + r'|'.join(wgUrlProtocols) + r')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
     re.S | re.U)
 EXT_IMAGE_REGEX = re.compile(
     r"""^(http://|https://)([^][<>"\x00-\x20\x7F\s]+)
@@ -621,7 +621,7 @@ class MagicWords():
     )
 
 
-magicWordsRE = re.compile('|'.join(MagicWords.switches))
+magicWordsRE = re.compile(r'|'.join(MagicWords.switches))
 
 
 # =========================================================================
@@ -1010,7 +1010,7 @@ class Extractor():
     maxParameterRecursionLevels = 16
 
     # check for template beginning
-    reOpen = re.compile('(?<!{){{(?!{)', re.DOTALL)
+    reOpen = re.compile(r'(?<!{){{(?!{)', re.DOTALL)
 
     def expandTemplates(self, wikitext):
         """
@@ -1394,11 +1394,11 @@ def findMatchingBraces(text, ldelim=0):
     #   {{{link|{{ucfirst:{{{1}}}}}} interchange}}}
 
     if ldelim:  # 2-3
-        reOpen = re.compile('[{]{%d,}' % ldelim)  # at least ldelim
-        reNext = re.compile('[{]{2,}|}{2,}')  # at least 2 open or close bracces
+        reOpen = re.compile(r'[{]{%d,}' % ldelim)  # at least ldelim
+        reNext = re.compile(r'[{]{2,}|}{2,}')  # at least 2 open or close bracces
     else:
-        reOpen = re.compile('{{2,}|\[{2,}')
-        reNext = re.compile('{{2,}|}{2,}|\[{2,}|]{2,}')  # at least 2
+        reOpen = re.compile(r'{{2,}|\[{2,}')
+        reNext = re.compile(r'{{2,}|}{2,}|\[{2,}|]{2,}')  # at least 2
 
     cur = 0
     while True:
@@ -1474,7 +1474,7 @@ def findBalanced(text, openDelim, closeDelim):
     """
     openPat = '|'.join([re.escape(x) for x in openDelim])
     # patter for delimiters expected after each opening delimiter
-    afterPat = {o: re.compile(openPat + '|' + c, re.DOTALL) for o, c in zip(openDelim, closeDelim)}
+    afterPat = {o: re.compile(openPat + r'|' + c, re.DOTALL) for o, c in zip(openDelim, closeDelim)}
     stack = []
     start = 0
     cur = 0

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -160,7 +160,7 @@ def clean(extractor, text, expand_templates=False, html_safe=True):
             text = text.replace(match.group(), '%s_%d' % (placeholder, index))
             index += 1
 
-    text = text.replace('<<', u'«').replace('>>', u'»')
+    text = text.replace('<<', '«').replace('>>', '»')
 
     #############################################
 
@@ -168,8 +168,8 @@ def clean(extractor, text, expand_templates=False, html_safe=True):
     text = text.replace('\t', ' ')
     text = spaces.sub(' ', text)
     text = dots.sub('...', text)
-    text = re.sub(u' (,:\.\)\]»)', r'\1', text)
-    text = re.sub(u'(\[\(«) ', r'\1', text)
+    text = re.sub(r' (,:\.\)\]»)', r'\1', text)
+    text = re.sub(r'(\[\(«) ', r'\1', text)
     text = re.sub(r'\n\W+?\n', '\n', text, flags=re.U)  # lines with only punctuations
     text = text.replace(',,', ',').replace(',.', '.')
     if html_safe:
@@ -730,7 +730,7 @@ def unescape(text):
                 else:
                     return chr(int(code))
             else:  # named entity
-                return chr(name2codepoint[code])
+                return chr([code])
         except:
             return text  # leave as is
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -380,12 +380,14 @@ wgUrlProtocols = [
 # as well as U+3000 is IDEOGRAPHIC SPACE for bug 19052
 EXT_LINK_URL_CLASS = r'[^][<>"\x00-\x20\x7F\s]'
 ExtLinkBracketedRegex = re.compile(
-    r'(?i)\[((' + r'|'.join(wgUrlProtocols) + r')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
+    r'(?i)\[((' + r'|'.join(wgUrlProtocols) + ')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
     re.S | re.U)
+
 EXT_IMAGE_REGEX = re.compile(
     r"""^(http://|https://)([^][<>"\x00-\x20\x7F\s]+)
-    /([A-Za-z0-9_.,~%\-+&;#*?!=()@\x80-\xFF]+)\.((?i)gif|png|jpg|jpeg)$""",
-    re.X | re.S | re.U)
+    /([A-Za-z0-9_.,~%\-+&;#*?!=()@\x80-\xFF]+)\.(gif|png|jpg|jpeg)$""",
+    re.X | re.I
+)
 
 
 def replaceExternalLinks(text):

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -732,7 +732,7 @@ def unescape(text):
                 else:
                     return chr(int(code))
             else:  # named entity
-                return chr([code])
+                return chr(name2codepoint[code])
         except:
             return text  # leave as is
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -1763,7 +1763,7 @@ parserFunctions = {
 
     'int': lambda string, *rest: str(int(string)),
 
-    'padleft': lambda char, width, string: string.ljust(char, int(pad)), # CHECK_ME
+    'padleft': lambda char, width, string: string.ljust(int(width), char), # CHECK_ME
 
 }
 


### PR DESCRIPTION
fixed regex patterns and else; 
otherwise it didn't work if installed with pip [ver 3.0.6] or didn't install directly from github [ver 3.0.7]