### PR TITLE
Support self-closing XML tags

### DIFF
--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -186,8 +186,8 @@ class OutputSplitter():
 # ----------------------------------------------------------------------
 # READER
 
-tagRE = re.compile(r'(.*?)<(/?\w+)[^>]*>(?:([^<]*)(<.*?>)?)?')
-#                    1     2               3      4
+tagRE = re.compile(r'(.*?)<(/?\w+)[^/>]*(/?)>(?:([^<]*)(<.*?>)?)?')
+#                    1     2             3        4       5
 
 
 def load_templates(file, output_file=None):
@@ -303,18 +303,18 @@ def collect_pages(text):
             page = []
             redirect = False
         elif tag == 'id' and not id:
-            id = m.group(3)
+            id = m.group(4)
         elif tag == 'id' and id: # <revision> <id></id> </revision>
-            revid = m.group(3)
+            revid = m.group(4)
         elif tag == 'title':
-            title = m.group(3)
+            title = m.group(4)
         elif tag == 'redirect':
             redirect = True
         elif tag == 'text':
             inText = True
-            line = line[m.start(3):m.end(3)]
+            line = line[m.start(4):m.end(4)]
             page.append(line)
-            if m.lastindex == 4:  # open-close
+            if m.lastindex == 5 or m.group(3) == "/":  # open-close
                 inText = False
         elif tag == '/text':
             if m.group(1):


### PR DESCRIPTION
# Issue

Current version of wikiextractor can't handle self-closing `<text />` tag -- which occurs in the wiki dump when the page is completely empty.

Current parser doesn't recognize self-closing tag, and treats it as an opening tag. It then sets the `inText` flag and continues until the next explicitly closing `</text>` tag.

For instance, the following two articles are merged into one with incorrect text and medatata.

```
<page>
    <title>Portal:Morocco/Morocco news</title>
    <id>2501281</id>
    <revision>
      ...
      <text bytes="0" sha1="phoiac9h4m842xq45sp7s6u21eteeq1" />
    </revision>
</page>
<page>
    <title>Obsidian (disambiguation)</title>
    <id>2501285</id>
    <revision>
      ...
      <text bytes="2085" sha1="kjwe64q274yupcbbfvlokltnyrcyz21" xml:space="preserve">
           {{wiktionary|obsidian}} '''[[Obsidian]]''' is a type of volcanic glass.
            ...
      </text>
    </revision>
</page>
```

The parsed object has the following properties:
```
id: 2501281 # id from the first article
title: Obsidian (disambiguation) # title from the second article
text: <revision> ... # a bunch of XML because it's mistakenly treated as text
```

# Proposal

This PR adjusts the regexp used to parse XML tags to recognize self-closing tags and handle then accordingly