### PR TITLE
fix regex flag for python 3.11 and those higher

### DIFF
--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -380,12 +380,12 @@ wgUrlProtocols = [
 # as well as U+3000 is IDEOGRAPHIC SPACE for bug 19052
 EXT_LINK_URL_CLASS = r'[^][<>"\x00-\x20\x7F\s]'
 ExtLinkBracketedRegex = re.compile(
-    '\[(((?i)' + '|'.join(wgUrlProtocols) + ')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
-    re.S | re.U)
+    r'\[((' + '|'.join(wgUrlProtocols) + r')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
+    re.S | re.U | re.I)
 EXT_IMAGE_REGEX = re.compile(
     r"""^(http://|https://)([^][<>"\x00-\x20\x7F\s]+)
-    /([A-Za-z0-9_.,~%\-+&;#*?!=()@\x80-\xFF]+)\.((?i)gif|png|jpg|jpeg)$""",
-    re.X | re.S | re.U)
+    /([A-Za-z0-9_.,~%\-+&;#*?!=()@\x80-\xFF]+)\.(gif|png|jpg|jpeg)$""",
+    re.X | re.S | re.U | re.I)
 
 
 def replaceExternalLinks(text):


### PR DESCRIPTION
Hi there, thanks for the great repo. I am an NLP researcher and I use this repo all the time for the preprocessing of wikipedia text.

For the compatibility with newer version of python, I believe this update might be an effective fix.

The issue that I had was regarding the errors such as those below.

```
Traceback (most recent call last):
<unknown>:3: SyntaxWarning: "\[" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\["? A raw string is also an option.
<unknown>:2: SyntaxWarning: "\[" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\["? A raw string is also an option.
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/site-packages/wikiextractor/WikiExtractor.py", line 66, in <module>
    from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/site-packages/wikiextractor/extract.py", line 378, in <module>
    ExtLinkBracketedRegex = re.compile(
        '\[(((?i)' + '|'.join(wgUrlProtocols) + ')' + EXT_LINK_URL_CLASS + r'+)\s*([^\]\x00-\x08\x0a-\x1F]*?)\]',
        re.S | re.U)
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/__init__.py", line 289, in compile
    return _compile(pattern, flags)
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/__init__.py", line 350, in _compile
    p = _compiler.compile(pattern, flags)
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/_compiler.py", line 762, in compile
    p = _parser.parse(p, flags)
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/_parser.py", line 973, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/_parser.py", line 460, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                       not nested and not items))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/_parser.py", line 856, in _parse
    p = _parse_sub(source, state, sub_verbose, nested + 1)
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/_parser.py", line 460, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                       not nested and not items))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/_parser.py", line 856, in _parse
    p = _parse_sub(source, state, sub_verbose, nested + 1)
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/_parser.py", line 460, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                       not nested and not items))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/love-bird/anaconda3/envs/penguin-feather/lib/python3.14/re/_parser.py", line 834, in _parse
    raise source.error('global flags not at the start '
                       'of the expression',
                       source.tell() - start)
re.PatternError: global flags not at the start of the expression at position 4
```

The patch was for the regex, considering the recent recommendation on regex, regarding `(?i)` patterns.

I tested the patch locally for python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14.

I hope that it would be merged but even in such a case that it would not, I hope that one or two persons would find it helpful, if they encounter the same issue.

I tag seemingly related ones: #340 #342 #343 #348 