### PR TITLE
The parameter set in WikiExtractor and used in extract is to_json

### DIFF
--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -921,7 +921,7 @@ class Extractor():
 
     ##
     # Whether to produce json instead of the default <doc> output format.
-    toJson = False
+    to_json = False
 
     ##
     # Obtained from TemplateNamespace


### PR DESCRIPTION
The parameter set in WikiExtractor and used in extract is to_json (could instead change the parameter -> toJson)