### PR TITLE
Clean up a wider variety of <br> tags

### DIFF
--- a/tests/test_br_tag_handling.py
+++ b/tests/test_br_tag_handling.py
@@ -1,0 +1,202 @@
+"""
+Tests for two related br/hr fixes:
+
+1. Missing-trailing-slash matching (selfClosing_tag_patterns /
+   lineBreak_tag_patterns): old-style HTML4 syntax like <br clear=all>
+   (no trailing slash) previously never matched at all, surviving into
+   extracted text HTML-escaped as literal "&lt;br clear=all&gt;". A
+   bare <br> with no attributes had exactly the same problem.
+
+2. Word-merging on deletion (this file's main focus): even where a
+   br/hr tag WAS correctly matched, it was deleted with nothing
+   substituted in its place (dropSpans() just concatenates the text on
+   either side of a removed span). If there was no surrounding
+   whitespace in the source -- a real, confirmed case on Saraiki
+   Wikipedia, "اُٹھا<br>رب" with no spaces at all around the tag --
+   deleting it merges two separate words into one ("اُٹھارب").
+
+The fix: br/hr are pulled out into their own lineBreakTags group,
+matched with the same permissive (optional trailing slash) pattern as
+before, but substituted with a single space instead of being folded
+into the generic drop-with-nothing spans mechanism.
+
+nobr/ref/references/nowiki are NOT affected by the space-substitution
+part of this fix (see RefTagSafetyTests / NobrTagTests below):
+"no line break" doesn't call for inserting a space where the tag was,
+and ref's self-closing form has a distinct, real meaning from its
+paired form (see test_br_tag_handling's sibling investigation) that
+must not be disturbed.
+
+Run with:
+    python -m unittest tests.test_br_tag_handling -v
+or, from the tests/ directory:
+    python -m unittest test_br_tag_handling -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+from wikiextractor.extract import Extractor
+import wikiextractor.extract as ex
+
+
+class VoidElementTestCase(unittest.TestCase):
+
+    def setUp(self):
+        ex.templates.clear()
+        ex.templateCache.clear()
+        ex.redirects.clear()
+        ex.Extractor.templatePrefix = "Template:"
+
+    def get_result(self, article_text):
+        extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
+                               "Test Article", [article_text])
+        return extractor.clean_text(article_text, expand_templates=True)
+
+
+class WordMergingRegressionTests(VoidElementTestCase):
+    """The core bug this fix addresses: br/hr with no surrounding
+    whitespace in the source must not merge adjacent words together.
+    """
+
+    def test_real_saraiki_example_no_word_merging(self):
+        # The exact real example found on Saraiki Wikipedia: <br> sits
+        # directly between two words with no whitespace anywhere.
+        text = "وطنوں اُٹھا<br>رب جانڑے کِیہ جیا قاتل ھِے جس آڈھے خان نوں کُٹھا"
+        result = self.get_result(text)
+        self.assertEqual(
+            result,
+            ["وطنوں اُٹھا رب جانڑے کِیہ جیا قاتل ھِے جس آڈھے خان نوں کُٹھا"]
+        )
+        # The specific failure mode being guarded against: words fused
+        # together with no separator at all.
+        self.assertNotIn("اُٹھارب", result[0])
+
+    def test_old_style_br_with_attribute_no_surrounding_space(self):
+        text = "اُٹھا<br clear=all>رب"
+        result = self.get_result(text)
+        self.assertEqual(result, ["اُٹھا رب"])
+
+    def test_self_closed_br_no_surrounding_space(self):
+        text = "اُٹھا<br/>رب"
+        result = self.get_result(text)
+        self.assertEqual(result, ["اُٹھا رب"])
+
+    def test_no_double_space_when_source_already_has_spaces(self):
+        # If the source already had whitespace around the tag, the
+        # substituted space must not create a visible double space in
+        # the final output.
+        text = "اُٹھا <br> رب"
+        result = self.get_result(text)
+        self.assertEqual(result, ["اُٹھا رب"])
+
+
+class BrTagMatchingVariantsTests(VoidElementTestCase):
+    """Every real-world variant of <br> should be recognized and
+    replaced with a space, whether or not it has attributes and
+    whether or not it's self-closed.
+    """
+
+    def test_old_style_br_with_attribute_no_slash(self):
+        text = "Line one.<br clear=all>Line two."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one. Line two."])
+
+    def test_old_style_br_with_quoted_attribute_no_slash(self):
+        text = 'Line one.<br clear="all">Line two.'
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one. Line two."])
+
+    def test_bare_br_no_attributes_no_slash(self):
+        text = "Line one.<br>Line two."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one. Line two."])
+
+    def test_self_closed_br_no_space(self):
+        text = "Line one.<br/>Line two."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one. Line two."])
+
+    def test_self_closed_br_with_space(self):
+        text = "Line one.<br />Line two."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one. Line two."])
+
+
+class HrTagVariantsTests(VoidElementTestCase):
+    """hr is the same class of genuinely void, line-break-carrying
+    element as br.
+    """
+
+    def test_bare_hr_no_slash(self):
+        text = "Line one.<hr>Line two."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one. Line two."])
+
+    def test_hr_with_attribute_no_slash(self):
+        text = "Line one.<hr noshade>Line two."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one. Line two."])
+
+
+class RefTagSafetyTests(VoidElementTestCase):
+    """Critical safety check: ref/references must NOT be affected by
+    either fix. A real paired <ref>...</ref> tag must continue to be
+    handled as a genuine pair, not misidentified as self-closing just
+    because its opening tag happens to lack a trailing slash (which is
+    normal -- paired tags never have one) -- and self-closing ref
+    reuse must not have a space substituted in its place, since that
+    has no real-content-separation justification the way br/hr do.
+    """
+
+    def test_real_paired_ref_tag_still_handled_as_a_pair(self):
+        text = 'See citation.<ref name="foo">Some Real Citation Text</ref> more text.'
+        result = self.get_result(text)
+        self.assertEqual(result, ["See citation. more text."])
+        self.assertNotIn("Some Real Citation Text", result[0])
+
+    def test_self_closing_ref_reuse_no_space_substituted(self):
+        # <ref name="x" /> is deleted with nothing substituted, same
+        # as before this fix -- only br/hr get space substitution.
+        text = 'word<ref name="foo" />word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+    def test_adjacent_br_and_ref_do_not_interfere(self):
+        text = 'Line one.<br><ref name="x">cite</ref>Line two.'
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one. Line two."])
+
+
+class NobrTagTests(VoidElementTestCase):
+    """nobr keeps the permissive (optional trailing slash) matching,
+    but stays in the pure-deletion group: "no line break" doesn't call
+    for inserting a space where the tag was.
+    """
+
+    def test_bare_nobr_no_space_substituted(self):
+        text = "word<nobr>word"
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+
+class UnrelatedTagHandlingUnaffectedTests(VoidElementTestCase):
+    """Sanity check that ignoredTags (b, i, nowiki, etc.) -- an
+    entirely separate code path -- are unaffected by either fix.
+    """
+
+    def test_ignored_tags_still_drop_wrapper_keep_content(self):
+        text = "Some <b>bold</b> and <i>italic</i> text."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Some bold and italic text."])
+
+    def test_nowiki_still_preserves_literal_content(self):
+        text = "<nowiki>literal [[not a link]] text</nowiki>"
+        result = self.get_result(text)
+        self.assertEqual(result, ["literal not a link text"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_br_tag_handling.py
+++ b/tests/test_br_tag_handling.py
@@ -182,6 +182,50 @@ class NobrTagTests(VoidElementTestCase):
         self.assertEqual(result, ["wordword"])
 
 
+class LineBoundaryTests(VoidElementTestCase):
+    """A line-break tag sitting at the very start/end of a line (or
+    the whole text) should not get a space substituted on that side --
+    there's nothing on the empty side to merge with, so adding one
+    just creates an invisible leading/trailing space that clutters
+    diffs without affecting meaning. This is what a real large diff on
+    Saraiki Wikipedia surfaced: many lines showing as "changed" in a
+    diff while looking completely identical, because of an invisible
+    trailing space where a <br/> had been at the end of the line.
+    """
+
+    def test_br_at_very_start_of_text_no_leading_space(self):
+        text = "<br>Line one."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one."])
+
+    def test_br_at_very_end_of_text_no_trailing_space(self):
+        text = "Line one.<br>"
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one."])
+
+    def test_br_immediately_after_a_newline_no_leading_space(self):
+        text = "Line one.\n<br>Line two."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one.", "Line two."])
+
+    def test_br_immediately_before_a_newline_no_trailing_space(self):
+        text = "Line one.<br>\nLine two."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one.", "Line two."])
+
+    def test_br_alone_on_its_own_line(self):
+        text = "Line one.\n<br>\nLine two."
+        result = self.get_result(text)
+        self.assertEqual(result, ["Line one.", "Line two."])
+
+    def test_middle_of_line_still_gets_a_space(self):
+        # The regression check: boundary-awareness must not accidentally
+        # disable the original word-merging fix for the common case.
+        text = "وطنوں اُٹھا<br>رب جانڑے"
+        result = self.get_result(text)
+        self.assertEqual(result, ["وطنوں اُٹھا رب جانڑے"])
+
+
 class UnrelatedTagHandlingUnaffectedTests(VoidElementTestCase):
     """Sanity check that ignoredTags (b, i, nowiki, etc.) -- an
     entirely separate code path -- are unaffected by either fix.

--- a/tests/test_br_tag_handling.py
+++ b/tests/test_br_tag_handling.py
@@ -225,6 +225,18 @@ class LineBoundaryTests(VoidElementTestCase):
         result = self.get_result(text)
         self.assertEqual(result, ["وطنوں اُٹھا رب جانڑے"])
 
+    def test_existing_single_space_before_tag_no_double_space(self):
+        # A plain space (not a newline) already adjacent to the tag
+        # must count as a boundary too -- otherwise this function can
+        # produce a double space on its own, relying on some other,
+        # unrelated part of the pipeline to clean it up afterward.
+        result = ex.substituteLineBreakTag(ex.lineBreak_tag_patterns[0], "text <br>more")
+        self.assertEqual(result, "text more")
+
+    def test_existing_single_space_after_tag_no_double_space(self):
+        result = ex.substituteLineBreakTag(ex.lineBreak_tag_patterns[0], "text<br> more")
+        self.assertEqual(result, "text more")
+
 
 class UnrelatedTagHandlingUnaffectedTests(VoidElementTestCase):
     """Sanity check that ignoredTags (b, i, nowiki, etc.) -- an

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -130,6 +130,17 @@ def clean(extractor, text, expand_templates=False, html_safe=True):
     for m in comment.finditer(text):
         spans.append((m.start(), m.end()))
 
+    # br/hr carry genuine line-break semantics: unlike a comment or a
+    # citation marker, deleting one with nothing in its place can
+    # merge two adjacent words together if there was no surrounding
+    # whitespace in the source (a real, confirmed case on Saraiki
+    # Wikipedia: "اُٹھا<br>رب" with no spaces at all around the tag,
+    # which would otherwise become "اُٹھارب" -- two words fused into
+    # one). Substitute these with a space directly, rather than
+    # folding them into the generic drop-with-nothing spans below.
+    for pattern in lineBreak_tag_patterns:
+        text = pattern.sub(' ', text)
+
     # Drop self-closing tags
     for pattern in selfClosing_tag_patterns:
         for m in pattern.finditer(text):
@@ -661,7 +672,8 @@ magicWordsRE = re.compile('|'.join(MagicWords.switches))
 
 # ------------------------------------------------------------------------------
 
-selfClosingTags = ('br', 'hr', 'nobr', 'ref', 'references', 'nowiki')
+lineBreakTags = ('br', 'hr')
+selfClosingTags = ('nobr', 'ref', 'references', 'nowiki')
 
 # These tags are dropped, keeping their content.
 # handle 'a' separately, depending on keepLinks
@@ -762,7 +774,34 @@ for tag in ignoredTags:
 
 # Match selfClosing HTML tags
 selfClosing_tag_patterns = [
-    re.compile(r'<\s*%s\b[^>]*/\s*>' % tag, re.DOTALL | re.IGNORECASE) for tag in selfClosingTags
+    # nobr is treated the same permissive way as br/hr for matching
+    # purposes (optional trailing slash), since a bare, unclosed
+    # <nobr> is the same kind of stray/orphaned tag -- but unlike
+    # br/hr, "no line break" doesn't call for inserting a space where
+    # the tag was, so it stays in the pure-deletion group below rather
+    # than moving to lineBreak_tag_patterns.
+    #
+    # ref/references/nowiki are NOT treated this way: for these, the
+    # self-closing form has a distinct, real meaning (e.g. <ref
+    # name="x" /> reuses an earlier-defined reference) from the
+    # non-self-closing form (<ref name="x">actual citation text</ref>,
+    # a genuine paired tag with real content). Making the slash
+    # optional for these would misidentify the OPENING of a real
+    # paired tag as if it were self-closing.
+    re.compile(r'<\s*%s\b[^>]*/?\s*>' % tag if tag == 'nobr'
+               else r'<\s*%s\b[^>]*/\s*>' % tag,
+               re.DOTALL | re.IGNORECASE)
+    for tag in selfClosingTags
+]
+
+# br/hr carry genuine line-break semantics (see the substitution site
+# in clean() above): matched the same permissive way as nobr (trailing
+# slash optional, since old-style HTML4 syntax like <br clear=all> --
+# or even a bare <br> -- is just as valid a "line break" instance as
+# <br/>), but substituted with a space instead of bulk-deleted.
+lineBreak_tag_patterns = [
+    re.compile(r'<\s*%s\b[^>]*/?\s*>' % tag, re.DOTALL | re.IGNORECASE)
+    for tag in lineBreakTags
 ]
 
 # Match HTML placeholder tags

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -815,11 +815,24 @@ def substituteLineBreakTag(pattern, text):
     """
     Replace each match of a line-break tag pattern (br/hr) with a
     space, EXCEPT when the match sits at the very start/end of the
-    text or is already adjacent to a newline on one side -- in that
-    case, omit the space on that side entirely, since there's nothing
-    on the empty side to merge with. Prevents adding an invisible
-    leading/trailing space to a line that only clutters diffs without
-    affecting meaning.
+    text or is already adjacent to whitespace (any kind -- space, tab,
+    newline, non-breaking space -- not just newline specifically) on
+    one side -- in that case, omit the space on that side entirely,
+    since there's already something separating it from whatever's
+    there, or nothing at all to separate it from. Checking for any
+    whitespace rather than just newline matters: without it, this
+    function can produce a double space on its own when the source
+    already had one space adjacent to the tag (verified directly), and
+    isn't otherwise self-sufficient -- relying on some other,
+    unrelated part of the pipeline to clean up after it is fragile
+    compared to just not creating the extra space to begin with.
+
+    Verified this doesn't over-match invisible RTL-script formatting
+    characters that aren't real separators (e.g. zero-width
+    non-joiner/joiner, the Arabic letter mark, all common in the
+    Perso-Arabic-script wikis this project works with) -- Python's
+    str.isspace() correctly excludes those while still recognizing a
+    non-breaking space as a genuine (if non-wrapping) separator.
     """
     result = []
     cur = 0
@@ -828,8 +841,8 @@ def substituteLineBreakTag(pattern, text):
         if m.start() < cur:
             continue  # overlapping match already consumed
         result.append(text[cur:m.start()])
-        before_is_boundary = (m.start() == 0) or (text[m.start() - 1] == '\n')
-        after_is_boundary = (m.end() == n) or (text[m.end()] == '\n')
+        before_is_boundary = (m.start() == 0) or text[m.start() - 1].isspace()
+        after_is_boundary = (m.end() == n) or text[m.end()].isspace()
         if not (before_is_boundary or after_is_boundary):
             result.append(' ')
         cur = m.end()

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -136,10 +136,16 @@ def clean(extractor, text, expand_templates=False, html_safe=True):
     # whitespace in the source (a real, confirmed case on Saraiki
     # Wikipedia: "اُٹھا<br>رب" with no spaces at all around the tag,
     # which would otherwise become "اُٹھارب" -- two words fused into
-    # one). Substitute these with a space directly, rather than
-    # folding them into the generic drop-with-nothing spans below.
+    # one). Substitute these with a space, but only where there's
+    # actually something to merge with on both sides -- a line-break
+    # tag sitting at the very start/end of a line (immediately next to
+    # a newline, or at the start/end of the text) needs no additional
+    # separator, since there's nothing on the empty side to merge
+    # with; adding one there just creates an invisible leading or
+    # trailing space that doesn't affect meaning but does clutter
+    # every diff against such a line.
     for pattern in lineBreak_tag_patterns:
-        text = pattern.sub(' ', text)
+        text = substituteLineBreakTag(pattern, text)
 
     # Drop self-closing tags
     for pattern in selfClosing_tag_patterns:
@@ -803,6 +809,32 @@ lineBreak_tag_patterns = [
     re.compile(r'<\s*%s\b[^>]*/?\s*>' % tag, re.DOTALL | re.IGNORECASE)
     for tag in lineBreakTags
 ]
+
+
+def substituteLineBreakTag(pattern, text):
+    """
+    Replace each match of a line-break tag pattern (br/hr) with a
+    space, EXCEPT when the match sits at the very start/end of the
+    text or is already adjacent to a newline on one side -- in that
+    case, omit the space on that side entirely, since there's nothing
+    on the empty side to merge with. Prevents adding an invisible
+    leading/trailing space to a line that only clutters diffs without
+    affecting meaning.
+    """
+    result = []
+    cur = 0
+    n = len(text)
+    for m in pattern.finditer(text):
+        if m.start() < cur:
+            continue  # overlapping match already consumed
+        result.append(text[cur:m.start()])
+        before_is_boundary = (m.start() == 0) or (text[m.start() - 1] == '\n')
+        after_is_boundary = (m.end() == n) or (text[m.end()] == '\n')
+        if not (before_is_boundary or after_is_boundary):
+            result.append(' ')
+        cur = m.end()
+    result.append(text[cur:])
+    return ''.join(result)
 
 # Match HTML placeholder tags
 placeholder_tag_patterns = [


### PR DESCRIPTION
Produced with the help of Claude

- in addition to `<br/>`, clean up `<br>` and `<br clear=all>`, etc
- replace those tags with ` ` so that words don't get merged when a newline is replaced....
- except if the `<br>` is already surrounded by a space, in which case adding the space would be wasteful