### PR TITLE
Log timing

### DIFF
--- a/tools/report_page_timing.py
+++ b/tools/report_page_timing.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+report_page_timing.py
+
+Summarize --page_timing log output from WikiExtractor.py, so you don't
+have to read through the full (much smaller than --debug, but still
+substantial on a real run) log by hand.
+
+Reports two things:
+  1. The slowest pages that have actually finished so far, sorted by
+     elapsed time -- the usual suspects for "why is this taking so
+     long" even when nothing is fully stuck.
+  2. Any worker that logged a PAGE_START with no matching PAGE_TIMING
+     yet, AND the run as a whole hasn't finished -- i.e., a worker
+     that's currently stuck on a specific page, right now. Safe to run
+     against a log file that's still being actively written to.
+
+Usage:
+    python3 report_page_timing.py timing.log
+    python3 report_page_timing.py timing.log --top 20
+    python3 report_page_timing.py -                      # read from stdin
+"""
+
+import argparse
+import re
+import sys
+import time
+
+
+START_RE = re.compile(
+    r'PAGE_START pid=(\d+) ordinal=(\d+) id=(\S+) title=(.*?) start=(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d)\s*$'
+)
+TIMING_RE = re.compile(
+    r'PAGE_TIMING pid=(\d+) ordinal=(\d+) id=(\S+) title=(.*?) '
+    r'start=(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d) finish=(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d) '
+    r'elapsed=([\d.]+)s\s*$'
+)
+FINISHED_RE = re.compile(r'Finished \d+-process extraction')
+
+
+def parse_log(lines):
+    """
+    Returns (timings, in_progress):
+      timings: list of dicts (pid, ordinal, id, title, start, finish,
+               elapsed) -- one per page that has fully completed.
+      in_progress: dict of pid -> dict (ordinal, id, title, start) --
+               one per worker whose most recent PAGE_START has no
+               matching PAGE_TIMING yet.
+    Lines are processed in order, so a later PAGE_START for the same
+    pid correctly replaces an earlier, already-completed one, and a
+    matching PAGE_TIMING clears that pid's in-progress entry.
+    """
+    timings = []
+    in_progress = {}
+    finished_run = False
+
+    for line in lines:
+        if FINISHED_RE.search(line):
+            finished_run = True
+            continue
+
+        m = TIMING_RE.search(line)
+        if m:
+            pid, ordinal, page_id, title, start, finish, elapsed = m.groups()
+            pid = int(pid)
+            timings.append({
+                'pid': pid, 'ordinal': int(ordinal), 'id': page_id,
+                'title': title, 'start': start, 'finish': finish,
+                'elapsed': float(elapsed),
+            })
+            in_progress.pop(pid, None)
+            continue
+
+        m = START_RE.search(line)
+        if m:
+            pid, ordinal, page_id, title, start = m.groups()
+            in_progress[int(pid)] = {
+                'ordinal': int(ordinal), 'id': page_id, 'title': title,
+                'start': start,
+            }
+            continue
+
+    # If the run has finished, nothing is genuinely "stuck" anymore --
+    # process_dump() only prints this after every dispatched job has
+    # completed and been consumed, so any leftover in_progress entries
+    # at that point would just be a parsing artifact, not a real stall.
+    if finished_run:
+        in_progress = {}
+
+    return timings, in_progress
+
+
+def parse_timestamp(ts):
+    return time.mktime(time.strptime(ts, '%Y-%m-%d %H:%M:%S'))
+
+
+def report_trend(timings, buckets=10):
+    """
+    Splits completed pages into `buckets` chronological groups (by
+    start time) and reports the average elapsed time per group, so a
+    worsening trend (jobs taking progressively longer, e.g. from
+    growing memory pressure or worsening contention) is visible at a
+    glance, rather than buried in a flat top-N list that only shows
+    the single slowest outliers regardless of when they happened.
+    """
+    if len(timings) < buckets:
+        return
+    ordered = sorted(timings, key=lambda t: parse_timestamp(t['start']))
+    n = len(ordered)
+    bucket_size = n / buckets
+    print(f"=== Trend: average elapsed time across {buckets} chronological buckets "
+          f"({n} completed pages, oldest to newest) ===")
+    bucket_avgs = []
+    for i in range(buckets):
+        lo = int(i * bucket_size)
+        hi = int((i + 1) * bucket_size) if i < buckets - 1 else n
+        chunk = ordered[lo:hi]
+        if not chunk:
+            continue
+        avg = sum(t['elapsed'] for t in chunk) / len(chunk)
+        bucket_avgs.append(avg)
+        bar = '#' * min(80, int(avg / 5))
+        print(f"  bucket {i + 1:2}/{buckets} ({len(chunk):5} pages, "
+              f"{ordered[lo]['start']} to {ordered[hi - 1]['start']}): "
+              f"avg {avg:9.2f}s  {bar}")
+    if len(bucket_avgs) >= 2 and bucket_avgs[0] > 0:
+        ratio = bucket_avgs[-1] / bucket_avgs[0]
+        direction = "SLOWER" if ratio > 1.2 else ("faster" if ratio < 0.8 else "roughly flat")
+        print(f"  Last bucket is {ratio:.1f}x the first bucket's average -> {direction}")
+    print()
+
+
+def report_last_job_per_worker(timings, in_progress):
+    """
+    For every worker PID seen anywhere in the log, report when it most
+    recently received a job at all -- whether that job has since
+    completed or not. A worker with no current in-progress entry isn't
+    necessarily idle-and-fine: if its last known activity was hours
+    ago while the overall run is still going, that worker has gone
+    quiet, most likely blocked somewhere between finishing extraction
+    and looping back for its next job (e.g. output_queue.put()
+    blocking because the single reduce_process consuming it has fallen
+    behind or stalled) -- a step this instrumentation doesn't directly
+    log, so a dangling PAGE_START is not the only sign of a stuck
+    worker.
+    """
+    last_seen = {}
+    for t in timings:
+        pid = t['pid']
+        ts = parse_timestamp(t['start'])
+        if pid not in last_seen or ts > last_seen[pid][0]:
+            last_seen[pid] = (ts, t['start'], t['ordinal'], t['id'], t['title'], 'finished')
+    for pid, info in in_progress.items():
+        ts = parse_timestamp(info['start'])
+        if pid not in last_seen or ts > last_seen[pid][0]:
+            last_seen[pid] = (ts, info['start'], info['ordinal'], info['id'],
+                               info['title'], 'in progress')
+
+    if not last_seen:
+        return
+
+    now = time.time()
+    rows = sorted(last_seen.items(), key=lambda kv: kv[1][0])  # oldest activity first
+    print(f"=== When each of the {len(rows)} worker(s) last received a job "
+          f"(oldest first -- these are the ones to look at) ===")
+    for pid, (ts, start_str, ordinal, page_id, title, status) in rows:
+        idle_for = now - ts
+        print(f"  pid={pid:<10} last job started {start_str}  "
+              f"({idle_for:9.1f}s ago)  status={status:<12} "
+              f"ordinal={ordinal:<10} id={page_id:<12} title={title}")
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('input', help="Path to a --page_timing log file, or '-' for stdin")
+    ap.add_argument('--top', type=int, default=15,
+                     help='Show this many of the slowest completed pages (default 15)')
+    ap.add_argument('--trend-buckets', type=int, default=10,
+                     help='Number of chronological buckets for the trend report (default 10)')
+    args = ap.parse_args()
+
+    if args.input == '-':
+        lines = sys.stdin.readlines()
+    else:
+        with open(args.input, encoding='utf-8', errors='replace') as f:
+            lines = f.readlines()
+
+    timings, in_progress = parse_log(lines)
+
+    print(f"Parsed {len(timings)} completed page(s), "
+          f"{len(in_progress)} currently in progress.\n")
+
+    if timings:
+        top_n = sorted(timings, key=lambda t: -t['elapsed'])[:args.top]
+        print(f"=== {len(top_n)} slowest completed page(s) ===")
+        for t in top_n:
+            print(f"  {t['elapsed']:9.2f}s  pid={t['pid']:<8} ordinal={t['ordinal']:<10} "
+                  f"id={t['id']:<12} title={t['title']}")
+        print()
+
+        report_trend(timings, buckets=args.trend_buckets)
+
+    if in_progress:
+        now = time.time()
+        rows = []
+        for pid, info in in_progress.items():
+            try:
+                running_for = now - parse_timestamp(info['start'])
+                running_for_str = f"{running_for:9.1f}s"
+                sort_key = running_for
+            except ValueError:
+                running_for_str = "  unknown"
+                sort_key = -1
+            rows.append((sort_key, pid, info, running_for_str))
+        rows.sort(reverse=True)
+
+        print(f"=== {len(rows)} worker(s) appear STUCK right now "
+              f"(PAGE_START with no PAGE_TIMING yet) ===")
+        for _, pid, info, running_for_str in rows:
+            print(f"  pid={pid:<8} ordinal={info['ordinal']:<10} id={info['id']:<12} "
+                  f"running for {running_for_str}  (started {info['start']})  "
+                  f"title={info['title']}")
+        print()
+    else:
+        if timings:
+            print("No workers appear stuck right now "
+                  "(every logged PAGE_START has a matching PAGE_TIMING, "
+                  "or the run has already finished).\n"
+                  "NOTE: this only covers the extraction step itself -- a worker "
+                  "that finished extracting but is blocked handing its result off "
+                  "(e.g. output_queue full because reduce_process has fallen behind) "
+                  "would also show as 'not stuck' here. Check the per-worker "
+                  "last-job-received report below if the run isn't actually "
+                  "progressing despite no workers showing as stuck.\n")
+        else:
+            print("No PAGE_START/PAGE_TIMING lines found -- was --page_timing enabled?")
+
+    report_last_job_per_worker(timings, in_progress)
+
+
+if __name__ == '__main__':
+    main()

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -354,25 +354,57 @@ def safe_qsize(queue):
         return None
 
 
+def get_memory_usage_mb(pid):
+    """
+    Reads the current resident set size (RSS -- actual physical memory
+    currently in use, not virtual/reserved) for the given PID directly
+    from /proc, in megabytes. Returns None if the process has already
+    exited, if permission is denied, or on a non-Linux platform where
+    /proc doesn't exist -- callers should treat None as "unknown", not
+    as zero.
+    """
+    try:
+        with open('/proc/%d/status' % pid) as f:
+            for line in f:
+                if line.startswith('VmRSS:'):
+                    # format: "VmRSS:\t    1632 kB"
+                    kb = int(line.split()[1])
+                    return kb / 1024
+    except (FileNotFoundError, PermissionError, ValueError, ProcessLookupError):
+        return None
+    return None
+
+
 def watchdog(jobs_queue, output_queue, reduce_proc, workers, stop_event, interval=60):
     """
-    Periodically logs queue depths and process liveness, so a stalled
-    run can be diagnosed even during long stretches with no per-page
-    activity to log at all -- e.g. the mapper itself blocked on
-    jobs_queue.put() because no worker is consuming, or reduce_process
-    having been killed outright (an OOM kill, for instance, leaves no
-    trace in the per-page logging at all: see the REDUCER_EXIT
-    docstring in reduce_process() for why). is_alive() queries actual
-    OS process state directly, rather than inferring it from log
-    silence.
+    Periodically logs queue depths, process liveness, and memory usage,
+    so a stalled run can be diagnosed even during long stretches with
+    no per-page activity to log at all -- e.g. the mapper itself
+    blocked on jobs_queue.put() because no worker is consuming, or
+    reduce_process having been killed outright (an OOM kill, for
+    instance, leaves no trace in the per-page logging at all: see the
+    REDUCER_EXIT docstring in reduce_process() for why -- SIGKILL
+    allows no Python-level cleanup, not even that). is_alive() queries
+    actual OS process state directly, rather than inferring it from
+    log silence. reduce_process's own memory usage is tracked
+    specifically because that's where ordering_buffer lives -- an
+    unbounded, growing figure there right up until it disappears
+    (rather than a REDUCER_EXIT line) is direct, rather than inferred,
+    evidence of an OOM kill.
     :param interval: seconds between checks.
     """
     while not stop_event.wait(interval):
         alive_workers = sum(1 for w in workers if w.is_alive())
+        reduce_mem = get_memory_usage_mb(reduce_proc.pid) if reduce_proc.pid else None
+        worker_mems = [m for m in (get_memory_usage_mb(w.pid) for w in workers if w.pid)
+                       if m is not None]
         logging.info(
-            "WATCHDOG jobs_queue=%s output_queue=%s reduce_alive=%s workers_alive=%d/%d",
-            safe_qsize(jobs_queue), safe_qsize(output_queue),
-            reduce_proc.is_alive(), alive_workers, len(workers))
+            "WATCHDOG jobs_queue=%s output_queue=%s reduce_alive=%s "
+            "reduce_mem_mb=%s workers_alive=%d/%d workers_total_mem_mb=%s",
+            safe_qsize(jobs_queue), safe_qsize(output_queue), reduce_proc.is_alive(),
+            "%.1f" % reduce_mem if reduce_mem is not None else "unknown",
+            alive_workers, len(workers),
+            "%.1f" % sum(worker_mems) if worker_mems else "unknown")
 
 
 def process_dump(input_file, template_file, out_file, file_size, file_compress,

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -63,6 +63,7 @@ import logging
 import os.path
 import re  # TODO use regex when it will be standard
 import sys
+import threading
 import time
 from io import StringIO
 from multiprocessing import Queue, get_context, cpu_count
@@ -340,6 +341,40 @@ def collect_pages(text):
             redirect = False
 
 
+def safe_qsize(queue):
+    """
+    Queue.qsize() is documented as an unreliable approximation in
+    general, and specifically raises NotImplementedError on macOS due
+    to a sem_getvalue() limitation there -- returns None instead of
+    crashing the watchdog on that platform.
+    """
+    try:
+        return queue.qsize()
+    except NotImplementedError:
+        return None
+
+
+def watchdog(jobs_queue, output_queue, reduce_proc, workers, stop_event, interval=60):
+    """
+    Periodically logs queue depths and process liveness, so a stalled
+    run can be diagnosed even during long stretches with no per-page
+    activity to log at all -- e.g. the mapper itself blocked on
+    jobs_queue.put() because no worker is consuming, or reduce_process
+    having been killed outright (an OOM kill, for instance, leaves no
+    trace in the per-page logging at all: see the REDUCER_EXIT
+    docstring in reduce_process() for why). is_alive() queries actual
+    OS process state directly, rather than inferring it from log
+    silence.
+    :param interval: seconds between checks.
+    """
+    while not stop_event.wait(interval):
+        alive_workers = sum(1 for w in workers if w.is_alive())
+        logging.info(
+            "WATCHDOG jobs_queue=%s output_queue=%s reduce_alive=%s workers_alive=%d/%d",
+            safe_qsize(jobs_queue), safe_qsize(output_queue),
+            reduce_proc.is_alive(), alive_workers, len(workers))
+
+
 def process_dump(input_file, template_file, out_file, file_size, file_compress,
                  process_count, html_safe, expand_templates=True, page_timing=False):
     """
@@ -436,6 +471,14 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
         extractor.start()
         workers.append(extractor)
 
+    watchdog_stop = threading.Event()
+    watchdog_thread = None
+    if page_timing:
+        watchdog_thread = threading.Thread(
+            target=watchdog, args=(jobs_queue, output_queue, reduce, workers, watchdog_stop),
+            daemon=True)
+        watchdog_thread.start()
+
     # Mapper process
 
     # we collect individual lines, since str.join() is significantly faster
@@ -445,6 +488,10 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     for id, revid, title, page in collect_pages(input):
         job = (id, revid, urlbase, title, page, ordinal)
         jobs_queue.put(job)  # goes to any available extract_process
+        if page_timing:
+            logging.info("JOB_QUEUED ordinal=%d id=%s title=%r time=%s",
+                         ordinal, id, title,
+                         time.strftime('%Y-%m-%d %H:%M:%S'))
         ordinal += 1
 
     input.close()
@@ -460,6 +507,10 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     output_queue.put(None)
     # wait for it to finish
     reduce.join()
+
+    watchdog_stop.set()
+    if watchdog_thread is not None:
+        watchdog_thread.join(timeout=5)
 
     extract_duration = default_timer() - extract_start
     extract_rate = ordinal / extract_duration

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -76,6 +76,43 @@ from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces
 # Program version
 __version__ = '3.0.8'
 
+# Separate from extract.py's own 'wikiextractor.extract' logger (which
+# covers the extraction mechanics themselves -- template substitution,
+# link processing, etc., under --debug): this one covers map/reduce
+# coordination -- per-page timing, queue dispatch, reducer progress,
+# and worker/reducer liveness -- under --debug_map_reduce. Named and
+# configured independently so either can be enabled without the other.
+mapreduce_logger = logging.getLogger('wikiextractor.mapreduce')
+
+
+def configure_mapreduce_logging(enabled):
+    """
+    Sets mapreduce_logger's level and gives it its own handler/format
+    (including a timestamp, %(asctime)s -- the root logger's own
+    format has none) with propagate=False, so its messages go out
+    through this handler only, not duplicated via the root logger's.
+
+    Must be called at the start of extract_process() and
+    reduce_process() specifically, not just once in the parent: both
+    are real multiprocessing.Process instances, and under the "spawn"
+    start method (unlike "fork"), a child re-imports the module fresh
+    and does NOT inherit a level set on the parent's already-running
+    logger after import -- confirmed directly (a spawned child's
+    logger showed effective level WARNING, not DEBUG, despite the
+    parent having set DEBUG on the same named logger beforehand).
+    Calling this at the top of each of those functions -- rather than
+    passing a boolean into every individual logging call -- is what
+    lets call sites just be unconditional mapreduce_logger.debug(...)
+    calls throughout the rest of this file.
+    """
+    mapreduce_logger.setLevel(logging.DEBUG if enabled else logging.WARNING)
+    if not mapreduce_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(
+            '%(levelname)s: %(asctime)s %(message)s'))
+        mapreduce_logger.addHandler(handler)
+    mapreduce_logger.propagate = False
+
 ##
 # Defined in <siteinfo>
 # We include as default Template, when loading external template file.
@@ -398,7 +435,7 @@ def watchdog(jobs_queue, output_queue, reduce_proc, workers, stop_event, interva
         reduce_mem = get_memory_usage_mb(reduce_proc.pid) if reduce_proc.pid else None
         worker_mems = [m for m in (get_memory_usage_mb(w.pid) for w in workers if w.pid)
                        if m is not None]
-        logging.info(
+        mapreduce_logger.debug(
             "WATCHDOG jobs_queue=%s output_queue=%s reduce_alive=%s "
             "reduce_mem_mb=%s workers_alive=%d/%d workers_total_mem_mb=%s",
             safe_qsize(jobs_queue), safe_qsize(output_queue), reduce_proc.is_alive(),
@@ -408,7 +445,7 @@ def watchdog(jobs_queue, output_queue, reduce_proc, workers, stop_event, interva
 
 
 def process_dump(input_file, template_file, out_file, file_size, file_compress,
-                 process_count, html_safe, expand_templates=True, page_timing=False):
+                 process_count, html_safe, expand_templates=True, debug_map_reduce=False):
     """
     :param input_file: name of the wikipedia dump file; '-' to read from stdin
     :param template_file: optional file with template definitions.
@@ -418,7 +455,9 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     :param process_count: number of extraction processes to spawn.
     :html_safe: whether to convert entities in text to HTML.
     :param expand_templates: whether to expand templates.
-    :param page_timing: whether to log each page's wall-clock start/finish/elapsed time.
+    :param debug_map_reduce: enables mapreduce_logger's DEBUG-level
+        messages (see configure_mapreduce_logging()) -- per-page
+        timing, queue dispatch, reducer progress, watchdog status.
     """
     global knownNamespaces
     global templateNamespace
@@ -487,7 +526,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
 
     # Reduce job that sorts and prints output
     reduce = Process(target=reduce_process,
-                      args=(output_queue, out_file, file_size, file_compress, page_timing))
+                      args=(output_queue, out_file, file_size, file_compress, debug_map_reduce))
     reduce.start()
 
     # initialize jobs queue
@@ -498,14 +537,14 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     workers = []
     for _ in range(max(1, process_count)):
         extractor = Process(target=extract_process,
-                            args=(jobs_queue, output_queue, html_safe, page_timing))
+                            args=(jobs_queue, output_queue, html_safe, debug_map_reduce))
         extractor.daemon = True  # only live while parent process lives
         extractor.start()
         workers.append(extractor)
 
     watchdog_stop = threading.Event()
     watchdog_thread = None
-    if page_timing:
+    if mapreduce_logger.isEnabledFor(logging.DEBUG):
         watchdog_thread = threading.Thread(
             target=watchdog, args=(jobs_queue, output_queue, reduce, workers, watchdog_stop),
             daemon=True)
@@ -520,10 +559,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     for id, revid, title, page in collect_pages(input):
         job = (id, revid, urlbase, title, page, ordinal)
         jobs_queue.put(job)  # goes to any available extract_process
-        if page_timing:
-            logging.info("JOB_QUEUED ordinal=%d id=%s title=%r time=%s",
-                         ordinal, id, title,
-                         time.strftime('%Y-%m-%d %H:%M:%S'))
+        mapreduce_logger.debug("JOB_QUEUED ordinal=%d id=%s title=%r", ordinal, id, title)
         ordinal += 1
 
     input.close()
@@ -554,42 +590,38 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
 # Multiprocess support
 
 
-def extract_process(jobs_queue, output_queue, html_safe, page_timing=False):
+def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False):
     """Pull tuples of raw page content, do CPU/regex-heavy fixup, push finished text
     :param jobs_queue: where to get jobs.
     :param output_queue: where to queue extracted text for output.
     :html_safe: whether to convert entities in text to HTML.
-    :param page_timing: whether to log each page's wall-clock start/finish/elapsed
-        time. Two lines per page (PAGE_START when a worker begins it, PAGE_TIMING
-        when it finishes), logged at INFO level (no --debug needed) -- useful for
-        isolating a specific slow/stuck page when extraction seems to hang: sort
-        PAGE_TIMING lines by elapsed time to spot an outlier directly, or, for a
-        page that never finishes at all (no amount of waiting produces a matching
-        PAGE_TIMING line for it), find that worker's PID's last PAGE_START line --
-        that's exactly the page it's stuck on, with no need to infer it from
-        surrounding pages or wait to see whether it was "just slow".
+    :param debug_map_reduce: configures this process's own copy of
+        mapreduce_logger (see configure_mapreduce_logging()) -- when
+        enabled, logs each page's wall-clock start/elapsed time (two
+        lines per page: PAGE_START when a worker begins it, PAGE_TIMING
+        when it finishes) -- useful for isolating a specific slow/stuck
+        page when extraction seems to hang: sort PAGE_TIMING lines by
+        elapsed time to spot an outlier directly, or, for a page that
+        never finishes at all (no amount of waiting produces a matching
+        PAGE_TIMING line for it), find that worker's PID's last
+        PAGE_START line -- that's exactly the page it's stuck on, with
+        no need to infer it from surrounding pages or wait to see
+        whether it was "just slow".
     """
+    configure_mapreduce_logging(debug_map_reduce)
     while True:
         job = jobs_queue.get()  # job is (id, revid, urlbase, title, page, ordinal)
         if job:
-            if page_timing:
-                page_id, _, _, title, _, ordinal = job
-                start = time.time()
-                logging.info(
-                    "PAGE_START pid=%d ordinal=%d id=%s title=%r start=%s",
-                    os.getpid(), ordinal, page_id, title,
-                    time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(start)))
+            page_id, _, _, title, _, ordinal = job
+            start = time.time()
+            mapreduce_logger.debug("PAGE_START pid=%d ordinal=%d id=%s title=%r",
+                                   os.getpid(), ordinal, page_id, title)
             out = StringIO()  # memory buffer
             Extractor(*job[:-1]).extract(out, html_safe)  # (id, urlbase, title, page)
-            if page_timing:
-                finish = time.time()
-                logging.info(
-                    "PAGE_TIMING pid=%d ordinal=%d id=%s title=%r "
-                    "start=%s finish=%s elapsed=%.2fs",
-                    os.getpid(), ordinal, page_id, title,
-                    time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(start)),
-                    time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(finish)),
-                    finish - start)
+            finish = time.time()
+            mapreduce_logger.debug(
+                "PAGE_TIMING pid=%d ordinal=%d id=%s title=%r elapsed=%.2fs",
+                os.getpid(), ordinal, page_id, title, finish - start)
             text = out.getvalue()
             output_queue.put((job[-1], text))  # (ordinal, extracted_text)
             out.close()
@@ -597,16 +629,18 @@ def extract_process(jobs_queue, output_queue, html_safe, page_timing=False):
             break
 
 
-def reduce_process(output_queue, out_file, file_size, file_compress, page_timing=False):
+def reduce_process(output_queue, out_file, file_size, file_compress, debug_map_reduce=False):
     """
     Pull finished article text, write series of files (or stdout)
     :param output_queue: text to be output.
     :param out_file: path to write output to, or '-' for stdout.
     :param file_size: max size per output file (see OutputSplitter).
     :param file_compress: whether to bzip2-compress output files.
-    :param page_timing: whether to log REDUCER_PROGRESS for every page
-        written (ordinal, current buffer depth, timestamp) -- shares
-        the same flag as the workers' PAGE_START/PAGE_TIMING logging.
+    :param debug_map_reduce: configures this process's own copy of
+        mapreduce_logger (see configure_mapreduce_logging()) -- when
+        enabled, logs REDUCER_PROGRESS for every page written (ordinal,
+        current buffer depth) -- shares the same logger as the workers'
+        PAGE_START/PAGE_TIMING logging.
 
     Builds its own output/OutputSplitter here, rather than receiving
     an already-open one constructed by the parent process: an open
@@ -622,6 +656,7 @@ def reduce_process(output_queue, out_file, file_size, file_compress, page_timing
     On exit, always logs the status of the exit (except in the case
     of a SIGKILL)
     """
+    configure_mapreduce_logging(debug_map_reduce)
     if out_file == '-':
         output = sys.stdout
         if file_compress:
@@ -641,11 +676,8 @@ def reduce_process(output_queue, out_file, file_size, file_compress, page_timing
             if next_ordinal in ordering_buffer:
                 output.write(ordering_buffer.pop(next_ordinal))
                 next_ordinal += 1
-                if page_timing:
-                    logging.info(
-                        "REDUCER_PROGRESS ordinal=%d buffered=%d time=%s",
-                        next_ordinal - 1, len(ordering_buffer),
-                        time.strftime('%Y-%m-%d %H:%M:%S'))
+                mapreduce_logger.debug("REDUCER_PROGRESS ordinal=%d buffered=%d",
+                                       next_ordinal - 1, len(ordering_buffer))
                 # progress report
                 if next_ordinal % period == 0:
                     interval_rate = period / (default_timer() - interval_start)
@@ -660,7 +692,8 @@ def reduce_process(output_queue, out_file, file_size, file_compress, page_timing
                 ordinal, text = pair
                 ordering_buffer[ordinal] = text
     finally:
-        # Always logged (not gated by page_timing): whether this
+        # Always logged (on the root logger, not gated by
+        # --debug_map_reduce at all): whether this
         # process is exiting cleanly (every buffered page successfully
         # written, nothing left over) or with pages still stuck in
         # ordering_buffer -- which would mean the sentinel arrived
@@ -744,17 +777,19 @@ def main():
                         help="suppress reporting progress info")
     groupS.add_argument("--debug", action="store_true",
                         help="print debug info")
-    groupS.add_argument("--page_timing", action="store_true",
-                        help="log wall-clock start (PAGE_START) and finish/elapsed "
-                             "(PAGE_TIMING) time for every extracted page, at the "
-                             "default INFO log level -- does not require --debug, "
-                             "and is far less noisy. A page that never finishes "
-                             "still leaves its PAGE_START line behind, so a stuck "
-                             "worker's last page is identifiable even without "
-                             "waiting for it to complete. Useful for finding a "
-                             "specific slow or stuck page when extraction seems to "
-                             "hang: sort PAGE_TIMING lines by elapsed time to spot "
-                             "an outlier, or find a PID's dangling PAGE_START.")
+    groupS.add_argument("--debug_map_reduce", action="store_true",
+                        help="enable map/reduce coordination diagnostics: PAGE_START "
+                             "and PAGE_TIMING (elapsed) for every extracted page, "
+                             "JOB_QUEUED for every dispatched page, REDUCER_PROGRESS "
+                             "for every page written, and a periodic WATCHDOG status "
+                             "line (queue depths, memory, process liveness). "
+                             "Independent of --debug (which covers extraction "
+                             "mechanics in extract.py instead), and far less noisy. "
+                             "A page that never finishes still leaves its PAGE_START "
+                             "line behind, so a stuck worker's last page is "
+                             "identifiable even without waiting for it to complete: "
+                             "sort PAGE_TIMING lines by elapsed time to spot an "
+                             "outlier, or find a PID's dangling PAGE_START.")
     groupS.add_argument("-a", "--article", action="store_true",
                         help="analyze a file containing a single article (debug option)")
     groupS.add_argument("-v", "--version", action="version",
@@ -829,9 +864,10 @@ def main():
             logging.error('Could not create: %s', output_path)
             return
 
+    configure_mapreduce_logging(args.debug_map_reduce)
     process_dump(input_file, args.templates, output_path, file_size,
                  args.compress, args.processes, args.html_safe, not args.no_templates,
-                 args.page_timing)
+                 args.debug_map_reduce)
 
 if __name__ == '__main__':
     main()

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -63,6 +63,7 @@ import logging
 import os.path
 import re  # TODO use regex when it will be standard
 import sys
+import time
 from io import StringIO
 from multiprocessing import Queue, get_context, cpu_count
 from timeit import default_timer
@@ -340,7 +341,7 @@ def collect_pages(text):
 
 
 def process_dump(input_file, template_file, out_file, file_size, file_compress,
-                 process_count, html_safe, expand_templates=True):
+                 process_count, html_safe, expand_templates=True, page_timing=False):
     """
     :param input_file: name of the wikipedia dump file; '-' to read from stdin
     :param template_file: optional file with template definitions.
@@ -350,6 +351,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     :param process_count: number of extraction processes to spawn.
     :html_safe: whether to convert entities in text to HTML.
     :param expand_templates: whether to expand templates.
+    :param page_timing: whether to log each page's wall-clock start/finish/elapsed time.
     """
     global knownNamespaces
     global templateNamespace
@@ -418,7 +420,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
 
     # Reduce job that sorts and prints output
     reduce = Process(target=reduce_process,
-                      args=(output_queue, out_file, file_size, file_compress))
+                      args=(output_queue, out_file, file_size, file_compress, page_timing))
     reduce.start()
 
     # initialize jobs queue
@@ -429,7 +431,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     workers = []
     for _ in range(max(1, process_count)):
         extractor = Process(target=extract_process,
-                            args=(jobs_queue, output_queue, html_safe))
+                            args=(jobs_queue, output_queue, html_safe, page_timing))
         extractor.daemon = True  # only live while parent process lives
         extractor.start()
         workers.append(extractor)
@@ -469,17 +471,42 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
 # Multiprocess support
 
 
-def extract_process(jobs_queue, output_queue, html_safe):
+def extract_process(jobs_queue, output_queue, html_safe, page_timing=False):
     """Pull tuples of raw page content, do CPU/regex-heavy fixup, push finished text
     :param jobs_queue: where to get jobs.
     :param output_queue: where to queue extracted text for output.
     :html_safe: whether to convert entities in text to HTML.
+    :param page_timing: whether to log each page's wall-clock start/finish/elapsed
+        time. Two lines per page (PAGE_START when a worker begins it, PAGE_TIMING
+        when it finishes), logged at INFO level (no --debug needed) -- useful for
+        isolating a specific slow/stuck page when extraction seems to hang: sort
+        PAGE_TIMING lines by elapsed time to spot an outlier directly, or, for a
+        page that never finishes at all (no amount of waiting produces a matching
+        PAGE_TIMING line for it), find that worker's PID's last PAGE_START line --
+        that's exactly the page it's stuck on, with no need to infer it from
+        surrounding pages or wait to see whether it was "just slow".
     """
     while True:
-        job = jobs_queue.get()  # job is (id, revid, urlbase, title, page)
+        job = jobs_queue.get()  # job is (id, revid, urlbase, title, page, ordinal)
         if job:
+            if page_timing:
+                page_id, _, _, title, _, ordinal = job
+                start = time.time()
+                logging.info(
+                    "PAGE_START pid=%d ordinal=%d id=%s title=%r start=%s",
+                    os.getpid(), ordinal, page_id, title,
+                    time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(start)))
             out = StringIO()  # memory buffer
             Extractor(*job[:-1]).extract(out, html_safe)  # (id, urlbase, title, page)
+            if page_timing:
+                finish = time.time()
+                logging.info(
+                    "PAGE_TIMING pid=%d ordinal=%d id=%s title=%r "
+                    "start=%s finish=%s elapsed=%.2fs",
+                    os.getpid(), ordinal, page_id, title,
+                    time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(start)),
+                    time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(finish)),
+                    finish - start)
             text = out.getvalue()
             output_queue.put((job[-1], text))  # (ordinal, extracted_text)
             out.close()
@@ -487,13 +514,16 @@ def extract_process(jobs_queue, output_queue, html_safe):
             break
 
 
-def reduce_process(output_queue, out_file, file_size, file_compress):
+def reduce_process(output_queue, out_file, file_size, file_compress, page_timing=False):
     """
     Pull finished article text, write series of files (or stdout)
     :param output_queue: text to be output.
     :param out_file: path to write output to, or '-' for stdout.
     :param file_size: max size per output file (see OutputSplitter).
     :param file_compress: whether to bzip2-compress output files.
+    :param page_timing: whether to log REDUCER_PROGRESS for every page
+        written (ordinal, current buffer depth, timestamp) -- shares
+        the same flag as the workers' PAGE_START/PAGE_TIMING logging.
 
     Builds its own output/OutputSplitter here, rather than receiving
     an already-open one constructed by the parent process: an open
@@ -505,6 +535,9 @@ def reduce_process(output_queue, out_file, file_size, file_compress):
     workaround, and this process opening (and, importantly, properly
     closing) the file itself is also what fixes a separate real bug:
     see the comment on close() below.
+
+    On exit, always logs the status of the exit (except in the case
+    of a SIGKILL)
     """
     if out_file == '-':
         output = sys.stdout
@@ -525,6 +558,11 @@ def reduce_process(output_queue, out_file, file_size, file_compress):
             if next_ordinal in ordering_buffer:
                 output.write(ordering_buffer.pop(next_ordinal))
                 next_ordinal += 1
+                if page_timing:
+                    logging.info(
+                        "REDUCER_PROGRESS ordinal=%d buffered=%d time=%s",
+                        next_ordinal - 1, len(ordering_buffer),
+                        time.strftime('%Y-%m-%d %H:%M:%S'))
                 # progress report
                 if next_ordinal % period == 0:
                     interval_rate = period / (default_timer() - interval_start)
@@ -539,6 +577,25 @@ def reduce_process(output_queue, out_file, file_size, file_compress):
                 ordinal, text = pair
                 ordering_buffer[ordinal] = text
     finally:
+        # Always logged (not gated by page_timing): whether this
+        # process is exiting cleanly (every buffered page successfully
+        # written, nothing left over) or with pages still stuck in
+        # ordering_buffer -- which would mean the sentinel arrived
+        # while next_ordinal's own entry had still never shown up on
+        # output_queue at all, a real, distinct problem from a page
+        # merely being slow. If this process gets SIGKILLed instead of
+        # exiting through this path at all, this line simply never
+        # appears -- the absence of it, following the last
+        # REDUCER_PROGRESS line, is itself the signal.
+        if ordering_buffer:
+            logging.warning(
+                "REDUCER_EXIT incomplete: next_ordinal=%d, %d page(s) still "
+                "buffered and never written: ordinals=%s",
+                next_ordinal, len(ordering_buffer),
+                sorted(ordering_buffer.keys())[:20])
+        else:
+            logging.info("REDUCER_EXIT clean: wrote %d article(s) total",
+                         next_ordinal)
         # This process's own writes are buffered in its own memory.
         # Since this process now opens its own output itself (rather
         # than receiving an already-open copy from the parent), there
@@ -604,6 +661,17 @@ def main():
                         help="suppress reporting progress info")
     groupS.add_argument("--debug", action="store_true",
                         help="print debug info")
+    groupS.add_argument("--page_timing", action="store_true",
+                        help="log wall-clock start (PAGE_START) and finish/elapsed "
+                             "(PAGE_TIMING) time for every extracted page, at the "
+                             "default INFO log level -- does not require --debug, "
+                             "and is far less noisy. A page that never finishes "
+                             "still leaves its PAGE_START line behind, so a stuck "
+                             "worker's last page is identifiable even without "
+                             "waiting for it to complete. Useful for finding a "
+                             "specific slow or stuck page when extraction seems to "
+                             "hang: sort PAGE_TIMING lines by elapsed time to spot "
+                             "an outlier, or find a PID's dangling PAGE_START.")
     groupS.add_argument("-a", "--article", action="store_true",
                         help="analyze a file containing a single article (debug option)")
     groupS.add_argument("-v", "--version", action="version",
@@ -679,7 +747,8 @@ def main():
             return
 
     process_dump(input_file, args.templates, output_path, file_size,
-                 args.compress, args.processes, args.html_safe, not args.no_templates)
+                 args.compress, args.processes, args.html_safe, not args.no_templates,
+                 args.page_timing)
 
 if __name__ == '__main__':
     main()

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -27,6 +27,14 @@ from html.entities import name2codepoint
 import logging
 import time
 
+# Named separately from WikiExtractor.py's own 'wikiextractor.mapreduce'
+# logger: this one covers extraction mechanics specifically -- template
+# substitution, invocation, link processing -- gated by --debug, while
+# the mapreduce one covers pipeline coordination under
+# --debug_map_reduce. Named and configured independently so either can
+# be enabled without the other.
+logger = logging.getLogger('wikiextractor.extract')
+
 # ----------------------------------------------------------------------
 
 # match tail after wikilink
@@ -949,7 +957,7 @@ class Template(list):
         # {{ppp|q=r|p=q}} gives r, but using Template:tvvv containing
         # "{{{{{{{{{p}}}}}}}}}", {{tvvv|p=q|q=r|r=s}} gives s.
 
-        logging.debug('subst tpl (%d, %d) %s', len(extractor.frame), depth, self)
+        logger.debug('subst tpl (%d, %d) %s', len(extractor.frame), depth, self)
 
         if depth > extractor.maxParameterRecursionLevels:
             extractor.recursion_exceeded_3_errs += 1
@@ -983,7 +991,7 @@ class TemplateArg():
 
         # any parts in a tplarg after the first (the parameter default) are
         # ignored, and an equals sign in the first part is treated as plain text.
-        #logging.debug('TemplateArg %s', parameter)
+        #logger.debug('TemplateArg %s', parameter)
 
         parts = splitParts(parameter)
         self.name = Template.parse(parts[0])
@@ -1015,7 +1023,7 @@ class TemplateArg():
         elif self.default:            # use the default value
             defaultValue = self.default.subst(params, extractor, depth+1)
             res =  extractor.expandTemplates(defaultValue)
-        #logging.debug('subst arg %d %s -> %s' % (depth, paramName, res))
+        #logger.debug('subst arg %d %s -> %s' % (depth, paramName, res))
         return res
 
 
@@ -1099,7 +1107,7 @@ class Extractor():
         :param out: a memory file.
         :param html_safe: whether to escape HTML entities.
         """
-        logging.debug("%s\t%s", self.id, self.title)
+        logger.debug("%s\t%s", self.id, self.title)
         text = ''.join(self.page)
         text = self.clean_text(text, html_safe=html_safe)
 
@@ -1135,7 +1143,7 @@ class Extractor():
                 self.recursion_exceeded_3_errs,
                 self.template_loop_errs)
         if any(errs):
-            logging.warn("Template errors in article '%s' (%s): title(%d) recursion(%d, %d, %d) loop(%d)",
+            logger.warning("Template errors in article '%s' (%s): title(%d) recursion(%d, %d, %d) loop(%d)",
                          self.title, self.id, *errs)
 
     # ----------------------------------------------------------------------
@@ -1174,7 +1182,7 @@ class Extractor():
             self.recursion_exceeded_1_errs += 1
             return res
 
-        # logging.debug('<expandTemplates ' + str(len(self.frame)))
+        # logger.debug('<expandTemplates ' + str(len(self.frame)))
 
         cur = 0
         # look for matching {{...}}
@@ -1183,7 +1191,7 @@ class Extractor():
             cur = e
         # leftover
         res += wikitext[cur:]
-        # logging.debug('   expandTemplates> %d %s', len(self.frame), res)
+        # logger.debug('   expandTemplates> %d %s', len(self.frame), res)
         return res
 
     def templateParams(self, parameters):
@@ -1195,7 +1203,7 @@ class Extractor():
 
         if not parameters:
             return templateParams
-        logging.debug('<templateParams: %s', '|'.join(parameters))
+        logger.debug('<templateParams: %s', '|'.join(parameters))
 
         # Parameters can be either named or unnamed. In the latter case, their
         # name is defined by their ordinal position (1, 2, 3, ...).
@@ -1255,7 +1263,7 @@ class Extractor():
                 if ']]' not in param:  # if the value does not contain a link, trim whitespace
                     param = param.strip()
                 templateParams[str(unnamedParameterCounter)] = param
-        logging.debug('   templateParams> %s', '|'.join(templateParams.values()))
+        logger.debug('   templateParams> %s', '|'.join(templateParams.values()))
         return templateParams
 
     def expandTemplate(self, body):
@@ -1305,14 +1313,14 @@ class Extractor():
 
         if len(self.frame) >= self.maxTemplateRecursionLevels:
             self.recursion_exceeded_2_errs += 1
-            # logging.debug('   INVOCATION> %d %s', len(self.frame), body)
+            # logger.debug('   INVOCATION> %d %s', len(self.frame), body)
             return ''
 
-        logging.debug('INVOCATION %d %s', len(self.frame), body)
+        logger.debug('INVOCATION %d %s', len(self.frame), body)
 
         parts = splitParts(body)
         # title is the portion before the first |
-        logging.debug('TITLE %s', parts[0].strip())
+        logger.debug('TITLE %s', parts[0].strip())
         title = self.expandTemplates(parts[0].strip())
 
         # SUBST
@@ -1360,7 +1368,7 @@ class Extractor():
             # The page being included could not be identified
             return ''
 
-        # logging.debug('TEMPLATE %s: %s', title, template)
+        # logger.debug('TEMPLATE %s: %s', title, template)
 
         # tplarg          = "{{{" parts "}}}"
         # parts           = [ title *( "|" part ) ]
@@ -1421,7 +1429,7 @@ class Extractor():
             loopKey = (self.id, title)
             if loopKey not in self.warned_loop_keys:
                 self.warned_loop_keys.add(loopKey)
-                logging.warning("Template loop detected: %s (article %s, id %s) -- "
+                logger.warning("Template loop detected: %s (article %s, id %s) -- "
                                  "leaving unexpanded (further repeats in this "
                                  "article are counted but not logged)",
                                  title, self.title, self.id)
@@ -1433,10 +1441,10 @@ class Extractor():
         # 21637542 in enwiki.
         self.frame.append((title, params))
         instantiated = template.subst(params, self)
-        # logging.debug('instantiated %d %s', len(self.frame), instantiated)
+        # logger.debug('instantiated %d %s', len(self.frame), instantiated)
         value = self.expandTemplates(instantiated)
         self.frame.pop()
-        # logging.debug('   INVOCATION> %s %d %s', title, len(self.frame), value)
+        # logger.debug('   INVOCATION> %s %d %s', title, len(self.frame), value)
         return value
 
 
@@ -1512,7 +1520,7 @@ def splitParts(paramsList):
         else:
             parameters = par
 
-    # logging.debug('splitParts %s %s\nparams: %s', sep, paramsList, str(parameters))
+    # logger.debug('splitParts %s %s\nparams: %s', sep, paramsList, str(parameters))
     return parameters
 
 
@@ -1872,7 +1880,7 @@ def sharp_invoke(module, function, frame):
             # template invocation
             templateTitle = fullyQualifiedTemplateTitle(function)
             if not templateTitle:
-                logging.warn("Template with empty title")
+                logger.warning("Template with empty title")
             pair = next((x for x in frame if x[0] == templateTitle), None)
             if pair:
                 params = pair[1]
@@ -1944,11 +1952,11 @@ def callParserFunction(functionName, args, frame):
         if functionName == '#invoke':
             # special handling of frame
             ret = sharp_invoke(args[0].strip(), args[1].strip(), frame)
-            # logging.debug('parserFunction> %s %s', args[1], ret)
+            # logger.debug('parserFunction> %s %s', args[1], ret)
             return ret
         if functionName in parserFunctions:
             ret = parserFunctions[functionName](*args)
-            # logging.debug('parserFunction> %s(%s) %s', functionName, args, ret)
+            # logger.debug('parserFunction> %s(%s) %s', functionName, args, ret)
             return ret
     except:
         return ""  # FIXME: fix errors
@@ -2016,5 +2024,5 @@ def define_template(title, page):
 
     if text:
         if title in templates and templates[title] != text:
-            logging.warn('Redefining: %s', title)
+            logger.warning('Redefining: %s', title)
         templates[title] = text


### PR DESCRIPTION
With the help of Claude, add a large block of logging to WikiExtractor.py.  This logging is useful for detecting when processes die (OOM, for example, or some other way) or detecting when the processing of the pages is slowing down.  It uses a different argparse flag than the extract.py logging, since both are quite noisy and would be difficult to disentangle