### PR TITLE
Fix double brackets

### DIFF
--- a/tests/test_link_bracket_collapse.py
+++ b/tests/test_link_bracket_collapse.py
@@ -118,26 +118,53 @@ class AsymmetricDoublingTests(unittest.TestCase):
 
 class AmbiguousComplexCaseTests(unittest.TestCase):
     """A doubled outer wrapper around content containing several
-    genuinely separate real links -- the excess closes only appear at
-    the very end, not right after the first inner link's own close, so
-    this doesn't resolve as a clean symmetric match. All three real
-    inner links must still be correctly recovered; a small residue at
-    the very end is an accepted, documented limitation for this
-    narrower, more ambiguous shape (safer than guessing at a merge that
-    could misinterpret genuine link structure).
+    genuinely separate real links: the excess closes only appear at
+    the very end, not right after the first inner link's own close,
+    and there's more text after that first inner close -- so this
+    doesn't resolve as a clean symmetric match, and per
+    collapseDoubledLinkBrackets()'s docstring, is left completely
+    untouched rather than partially collapsed.
+
+    An earlier version of this fix partially collapsed this shape
+    (just the opening side) instead, recovering the individual real
+    links with a small residue left over. That was reverted after a
+    real Saraiki Wikipedia case (بزمِ کیفی جامپوری, id 902) showed
+    partial collapse can turn a case that was ACCIDENTALLY correct on
+    the original, fully-unmodified text into something newly broken:
+    [[[[سرائیکی]] زبان|سرائیکی]] already resolves correctly without
+    any fix at all (findBalanced() matches the whole thing as one
+    piece, and the pipe hides the embedded garbage behind a clean
+    label) -- but collapsing just the opening side made the first
+    inner closing pair look like a complete match on its own, ending
+    too early and stranding "زبان|سرائیکی]]" as newly-visible leftover
+    text that was never visible before. See
+    test_real_saraiki_case_that_forced_this_design_change below.
+
+    Leaving this shape completely untouched means the fix can only
+    ever improve on the unmodified behavior, never make a previously-
+    correct case worse -- at the cost of not attempting to also
+    recover the individual real links in this more complex shape,
+    which fall back to exactly what findBalanced() would have done
+    without this fix at all (visible embedded brackets, same as
+    before any of this work existed).
     """
 
-    def test_multi_link_case_recovers_all_real_links(self):
+    def test_real_saraiki_case_that_forced_this_design_change(self):
+        # The case that revealed partial-collapse could regress a
+        # previously-correct result. Must match the original,
+        # completely-unmodified behavior exactly.
+        text = "بزم دے [[اردو]] /[[[[سرائیکی]] زبان|سرائیکی]] شعراء کرام"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "بزم دے اردو /سرائیکی شعراء کرام")
+
+    def test_multi_link_case_left_untouched_not_partially_collapsed(self):
         # Real example from Sindhi Wikipedia (a motorway infobox row).
+        # This must now match exactly what findBalanced() alone would
+        # produce with no bracket-collapse fix applied at all: the
+        # whole span treated as one piece, embedded brackets visible.
         text = "[[[[کراچی]] تا [[لاہور]] [[موٹر وے]] (KLM)]]"
         result = ex.replaceInternalLinks(text)
-
-        self.assertIn("کراچی", result)
-        self.assertIn("لاہور", result)
-        self.assertIn("موٹر وے", result)
-        self.assertNotIn("[[", result)
-        # Documented, accepted residue for this specific ambiguous shape.
-        self.assertEqual(result, "کراچی تا لاہور موٹر وے (KLM)]]")
+        self.assertEqual(result, "[[کراچی]] تا [[لاہور]] [[موٹر وے]] (KLM)")
 
 
 class NormalLinkRegressionTests(unittest.TestCase):

--- a/tests/test_link_bracket_collapse.py
+++ b/tests/test_link_bracket_collapse.py
@@ -1,0 +1,274 @@
+"""
+Tests for the doubled-link-bracket collapse fix in replaceInternalLinks()
+(collapseDoubledLinkBrackets()).
+
+Background
+----------
+A real, surprisingly common wikitext authoring mistake -- doubled link
+brackets like [[[[title]]]] instead of [[title]] -- was found at
+meaningful scale on multiple language wikis: ~150/25000 articles on
+Saraiki Wikipedia, ~15000 on Urdu Wikipedia, and (on Sindhi Wikipedia)
+baked directly into a widely-transcluded interwiki/sister-projects
+table template (e.g. [[[[w:]]]], [[[[wiktionary:]]]], one row per
+sister project) -- meaning a single buggy template can by itself
+account for a large share of the total occurrences on a given wiki.
+
+Before any fix, findBalanced()'s stack-based bracket matcher treated
+the outermost bracket pair as the link delimiter and passed the inner
+bracket pair through untouched as literal text in the link's
+title/label -- i.e. [[[[title]]]] -> [[title]] in the final output
+(brackets reduced but not eliminated).
+
+An earlier version of this fix only collapsed the *opening* side
+(runs of 3+ "[" down to exactly 2), which correctly recovered the
+title but left a residue of stray trailing "]" characters behind in
+the symmetric case (e.g. "title]]"). collapseDoubledLinkBrackets()
+improves on this: it detects when the closing side has a *matching*
+excess immediately following the link's natural close, and in that
+case strips both sides symmetrically for a fully clean result with no
+residue at all. This covers the two most common real-world shapes
+found (fully symmetric doubling, and asymmetric doubling where only
+the opening side was duplicated) with zero residue.
+
+Where the excess doesn't resolve to a clean symmetric match -- e.g. a
+doubled outer wrapper around content that itself contains several
+genuinely separate real links, where the excess closing brackets only
+appear at the very end, not immediately after the first inner link's
+own close -- the fix safely falls back to collapsing just the opening
+side. This still correctly recovers all the real inner links; it just
+may leave a small trailing residue in that narrower, more ambiguous
+case, rather than guessing at a merge that could misinterpret genuine
+structure.
+
+The fix deliberately never touches the closing side on its own, in
+isolation: adjacent closing brackets legitimately occur in real
+wikitext, e.g. [[File:x.jpg|[[real link]]]], where a nested real link
+is the very last thing before the outer link's own close.
+
+Run with:
+    python -m unittest tests.test_link_bracket_collapse -v
+or, from the tests/ directory:
+    python -m unittest test_link_bracket_collapse -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+
+
+class SymmetricDoublingTests(unittest.TestCase):
+    """The common case: excess opens AND a matching excess of closes
+    immediately following the link's natural close -- should resolve
+    with zero residue.
+    """
+
+    def test_quadruple_bracket_link_resolves_with_no_residue(self):
+        text = "کشمیر دے [[[[پاکستان]]]] دے نال"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "کشمیر دے پاکستان دے نال")
+
+    def test_triple_bracket_variant_no_residue(self):
+        text = "اوہ [[[پاکستان]]] گیا"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "اوہ پاکستان گیا")
+
+    def test_quintuple_bracket_variant_no_residue(self):
+        text = "اوہ [[[[[پاکستان]]]]] گیا"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "اوہ پاکستان گیا")
+
+    def test_interwiki_table_entry_no_residue(self):
+        # Real example from Sindhi Wikipedia's sister-projects/interwiki
+        # table template -- baked into the template itself, so
+        # transcluded (and repeated) across every page that includes it.
+        text = "[[[[w:]]]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "w:")
+
+    def test_symmetric_piped_link_no_residue(self):
+        # Real example from Sindhi Wikipedia (a book citation).
+        text = "[[[[ڀيرو مل مهرچند آڏواڻي|ڀيرومل مهرچند آڏواڻي]]]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "ڀيرومل مهرچند آڏواڻي")
+
+
+class AsymmetricDoublingTests(unittest.TestCase):
+    """Excess opens with no matching excess closes -- these were
+    already clean with the simpler opens-only fix, and remain so here.
+    """
+
+    def test_asymmetric_airport_list_entry_no_residue(self):
+        # Real example from Sindhi Wikipedia (an {{airport-dest-list}}
+        # template usage): 4 opens, only 2 closes.
+        text = "[[[[يوني ايئر(Uni Air)]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "يوني ايئر(Uni Air)")
+
+    def test_asymmetric_category_link(self):
+        # Real example from Sindhi Wikipedia: 4 opens, 2 closes, a
+        # category link (which gets dropped entirely regardless, by
+        # separate pre-existing category-handling logic).
+        text = "[[[[زمرو:دستاويز سانچا]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "")
+
+
+class AmbiguousComplexCaseTests(unittest.TestCase):
+    """A doubled outer wrapper around content containing several
+    genuinely separate real links -- the excess closes only appear at
+    the very end, not right after the first inner link's own close, so
+    this doesn't resolve as a clean symmetric match. All three real
+    inner links must still be correctly recovered; a small residue at
+    the very end is an accepted, documented limitation for this
+    narrower, more ambiguous shape (safer than guessing at a merge that
+    could misinterpret genuine link structure).
+    """
+
+    def test_multi_link_case_recovers_all_real_links(self):
+        # Real example from Sindhi Wikipedia (a motorway infobox row).
+        text = "[[[[کراچی]] تا [[لاہور]] [[موٹر وے]] (KLM)]]"
+        result = ex.replaceInternalLinks(text)
+
+        self.assertIn("کراچی", result)
+        self.assertIn("لاہور", result)
+        self.assertIn("موٹر وے", result)
+        self.assertNotIn("[[", result)
+        # Documented, accepted residue for this specific ambiguous shape.
+        self.assertEqual(result, "کراچی تا لاہور موٹر وے (KLM)]]")
+
+
+class NormalLinkRegressionTests(unittest.TestCase):
+    """Ordinary, well-formed links must be completely unaffected."""
+
+    def test_normal_simple_link_unaffected(self):
+        text = "اوہ [[پاکستان]] گیا"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "اوہ پاکستان گیا")
+
+    def test_normal_piped_link_unaffected(self):
+        text = "اوہ [[پاکستان|ملک]] گیا"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "اوہ ملک گیا")
+
+    def test_two_adjacent_separate_links_unaffected(self):
+        # Two genuinely separate, non-nested links with nothing between
+        # them -- must not be mistaken for one doubled-bracket link.
+        text = "[[پاکستان]][[بھارت]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "پاکستانبھارت")
+
+    def test_log_paste_with_space_separated_brackets_untouched(self):
+        # Real example from Sindhi Wikipedia: a maintenance-script log
+        # pasted into a page, containing "[[ [[" with a space between --
+        # genuinely unrelated to the doubled-bracket typo, and must be
+        # left completely alone (the fix only triggers on immediately
+        # adjacent brackets with zero separator).
+        text = "dbk=[[ [[وڪيپيڊيا:اسان_سان_رابطو_ڪريو]] -> foo"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, text)
+
+
+class LegitimateNestedLinkRegressionTests(unittest.TestCase):
+    """The critical regression check: genuine nested links (real-world
+    pattern for file/image captions containing an actual link) must
+    behave identically to the unpatched baseline.
+    """
+
+    def test_nested_link_with_trailing_caption_text_unaffected(self):
+        # Baseline (unpatched) result for this input: ''
+        text = "[[File:x.jpg|thumb|caption with a [[real link]] inside]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "")
+
+    def test_nested_link_as_last_thing_before_outer_close_unaffected(self):
+        # The exact case that a naive "collapse both sides blindly"
+        # fix breaks: adjacent closing brackets here are genuinely two
+        # separate closes (inner link, then outer link), not a typo.
+        # Baseline (unpatched) result for this input: ''
+        text = "[[File:x.jpg|[[real link]]]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "")
+
+
+class LinkTrailTests(unittest.TestCase):
+    """The "trail" mechanism (tailRE = r'\\w+') is a deliberate,
+    pre-existing MediaWiki feature, not something introduced by the
+    bracket-collapse fix: word characters immediately following a
+    link's closing "]]" get concatenated onto the label with NO space,
+    e.g. [[cat]]s -> "cats" (used constantly on English Wikipedia too).
+    This is worth confirming explicitly because a real Saraiki
+    Wikipedia article was found where a simple, well-formed link with a
+    trail ([[پاکستان]]ی, intended to render as "پاکستانی" -- "Pakistani")
+    was failing to convert at all before this fix, apparently due to a
+    separate doubled-bracket instance earlier in the same article
+    corrupting findBalanced()'s stack for everything downstream. The
+    bracket-collapse fix resolved that as a side effect, so it's worth
+    locking in that trails keep working correctly, both on their own
+    and specifically when combined with a doubled-bracket link.
+    """
+
+    def test_simple_trail_concatenates_with_no_space(self):
+        text = "the [[cat]]s sat down"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "the cats sat down")
+
+    def test_real_saraiki_trail_example(self):
+        # The real case found in the wild: a normal, non-doubled link
+        # with a trail suffix forming the adjectival form "Pakistani".
+        text = "آزاد کشمیر اسمبلی ، [[پاکستان]]ی کشمیر دا قانون"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "آزاد کشمیر اسمبلی ، پاکستانی کشمیر دا قانون")
+
+    def test_trail_on_a_doubled_bracket_link_still_works(self):
+        # Combining both mechanisms: a doubled-bracket link (which goes
+        # through collapseDoubledLinkBrackets first) should still have
+        # its trail suffix correctly attached afterward, with no space
+        # and no leftover brackets.
+        text = "the [[[[cat]]]]s sat down"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "the cats sat down")
+
+
+class DoubledBracketWithGenuineNestingTests(unittest.TestCase):
+    """A doubled-bracket link whose content itself contains a genuinely
+    separate, properly-nested real link (e.g. a File: caption with an
+    actual [[link]] inside it) -- found in the wild on a real Saraiki
+    Wikipedia article (id 786, "امڑی"): a doubled File: link wrapping an
+    image caption that itself links to [[غلام]].
+
+    This is harder than the plain symmetric case: a naive "find the
+    first ']]'" scan gets fooled by the inner link's own closing pair,
+    mistaking it for the outer link's natural close, and ends up
+    consuming only one of the outer link's several excess closing
+    brackets -- leaving stray residue behind even though the whole
+    thing should disappear entirely (File: links are dropped by
+    existing, separate namespace-handling logic). The fix uses
+    findBalanced() itself (via a small "pseudo" prefix trick) to find
+    the outer link's true natural close, correctly skipping over the
+    inner nested link, rather than a naive first-match scan.
+    """
+
+    def test_doubled_file_link_with_nested_real_link_fully_dropped(self):
+        # Real example from Saraiki Wikipedia.
+        text = "[[[[فائل:G M Lakha.jpg|thumb|[[غلام]] مرتضٰی لاکھا]]]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "")
+
+    def test_doubled_plain_link_with_nested_real_link_resolves_cleanly(self):
+        # A non-File: variant of the same shape, to confirm the fix
+        # generalizes and isn't specific to File: links being dropped.
+        # Note: the nested [[real link]] inside the label isn't itself
+        # recursively re-converted in a single pass -- that's
+        # pre-existing behavior unrelated to this fix. What matters
+        # here is that the OUTER doubled brackets resolve cleanly with
+        # no residue.
+        text = "[[[[Some Page|caption with a [[real link]] inside]]]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "caption with a [[real link]] inside")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_link_bracket_collapse.py
+++ b/tests/test_link_bracket_collapse.py
@@ -160,15 +160,27 @@ class NormalLinkRegressionTests(unittest.TestCase):
         result = ex.replaceInternalLinks(text)
         self.assertEqual(result, "پاکستانبھارت")
 
-    def test_log_paste_with_space_separated_brackets_untouched(self):
+    def test_log_paste_second_link_processed_independently_of_first_unclosed_bracket(self):
         # Real example from Sindhi Wikipedia: a maintenance-script log
-        # pasted into a page, containing "[[ [[" with a space between --
-        # genuinely unrelated to the doubled-bracket typo, and must be
-        # left completely alone (the fix only triggers on immediately
-        # adjacent brackets with zero separator).
+        # pasted into a page, containing "[[ [[" -- the first "[[" is
+        # genuinely unclosed (2 opens, only 1 close in this snippet),
+        # unrelated to the doubled-bracket-typo pattern this module
+        # targets. Before neutralizeUnclosedLinkOpens() existed, that
+        # one unclosed bracket coincidentally poisoned everything after
+        # it too, leaving the whole line untouched -- but that was
+        # never verified as "correct", just whatever the old bug
+        # happened to produce. Now the genuinely unclosed first
+        # bracket is correctly isolated, and the second, structurally
+        # well-formed link gets processed on its own merit -- and
+        # since "وڪيپيڊيا" (localized Wikipedia-namespace prefix) isn't
+        # in acceptedNamespaces, it correctly drops to '', same as any
+        # other non-accepted-namespace link. This is more accurate,
+        # not a regression: real MediaWiki's parser doesn't know this
+        # text is "log output" either, and would also attempt to
+        # process that second link on its own.
         text = "dbk=[[ [[وڪيپيڊيا:اسان_سان_رابطو_ڪريو]] -> foo"
         result = ex.replaceInternalLinks(text)
-        self.assertEqual(result, text)
+        self.assertEqual(result, "dbk=[[  -> foo")
 
 
 class LegitimateNestedLinkRegressionTests(unittest.TestCase):
@@ -268,6 +280,113 @@ class DoubledBracketWithGenuineNestingTests(unittest.TestCase):
         text = "[[[[Some Page|caption with a [[real link]] inside]]]]"
         result = ex.replaceInternalLinks(text)
         self.assertEqual(result, "caption with a [[real link]] inside")
+
+
+class UnclosedLinkOpenTests(unittest.TestCase):
+    """A single genuinely unclosed link opening (e.g. [[1198 -- an
+    ordinary, easy-to-make typo: forgetting the closing "]]") should
+    not poison findBalanced()'s stack for the rest of the article.
+    Before neutralizeUnclosedLinkOpens() existed, one such typo
+    anywhere would silently disable ALL subsequent link conversion,
+    even for several unrelated, perfectly well-formed links much
+    later in the same article -- found in the wild on a real Saraiki
+    Wikipedia article ("ابن رشد" / Averroes, id 296).
+
+    Detection is deliberately NOT bounded to a single paragraph. An
+    earlier version bounded it that way specifically to avoid a
+    genuinely unclosed bracket accidentally pairing with an unrelated
+    stray "]]" much later in the same article -- but that turned out
+    to cause a worse, CONFIRMED problem: a real File: link (English
+    Wikipedia, "Asterix", id 2101) has a <ref>...</ref> citation nested
+    in its image caption that itself contains a genuine blank line
+    before its closing tag (untidy but entirely legitimate wikitext).
+    Paragraph-bounding incorrectly treated the File: link's opening as
+    unclosed, since its true closing "]]" was one blank line away --
+    causing the whole link to survive as literal text instead of being
+    cleanly dropped, which is what it correctly does without this fix
+    at all. See test_real_asterix_file_link_with_blank_line_in_ref
+    below.
+    """
+
+    def test_real_asterix_file_link_with_blank_line_in_ref(self):
+        # Real example from English Wikipedia ("Asterix", id 2101): a
+        # File: link's caption contains a nested real link AND a
+        # <ref>...</ref> citation with a genuine blank line inside it,
+        # before the outer File: link's own closing "]]". The whole
+        # File: link (including the nested link inside its caption)
+        # must still be dropped entirely, exactly as it is without any
+        # of this fix -- and the later, unrelated links in the
+        # following paragraph must also correctly convert.
+        text = (
+            "==Publication history==\n"
+            "[[File:Evariste-Vital Luminais - Goths traversant une rivière.jpg"
+            "|thumb|[[Évariste Vital Luminais]]' (1821\u20131896) paintings of Goths "
+            "had been rather popular in France and are a possible model for the "
+            "''Asterix'' series.<ref>{{Cite book|title = Luminais Musée des "
+            "beaux-arts|publisher = Dominique Dussol: Evariste Vital|year = 2002"
+            "|page = 32}}\n\n&nbsp;\n</ref>]]\n"
+            "Prior to creating the ''Asterix'' series, Goscinny and Uderzo had "
+            "had success with their series ''[[Oumpah-pah]]'', which was "
+            "published in ''[[Tintin (magazine)|Tintin]]'' magazine."
+        )
+        result = ex.replaceInternalLinks(text)
+
+        self.assertNotIn("[[File:", result)
+        self.assertNotIn("Évariste Vital Luminais", result)  # dropped along with the whole File: link
+        self.assertIn("Oumpah-pah", result)
+        self.assertNotIn("[[Oumpah-pah", result)
+        self.assertIn("Tintin", result)
+        self.assertNotIn("[[Tintin", result)
+
+    def test_real_ibn_rushd_example_recovers_all_later_links(self):
+        # Real example from Saraiki Wikipedia. The malformed [[1198ء)
+        # (missing its closing "]]") must stay exactly as broken as it
+        # was, while فلکیات and مذہب -- perfectly well-formed links
+        # appearing later in the same text -- must now correctly
+        # convert instead of being silently swallowed.
+        text = (
+            "وفات: 10 دسمبر [[1198ء) مسلم فلسفی، ماہر [[فلکیات]] تے مقنن ہن۔\n"
+            "[[مذہب]] تے فلسفیانہ حقیقت"
+        )
+        result = ex.replaceInternalLinks(text)
+
+        self.assertIn("[[1198ء)", result)  # left exactly as broken
+        self.assertIn("فلکیات", result)
+        self.assertNotIn("[[فلکیات", result)
+        self.assertIn("مذہب", result)
+        self.assertNotIn("[[مذہب", result)
+
+    def test_unclosed_open_does_not_affect_an_earlier_closed_link(self):
+        # The precise-detection check: a properly closed link BEFORE
+        # the genuinely unclosed one must not be misidentified as the
+        # broken one. A naive "neutralize the first N excess opens"
+        # heuristic would get this wrong.
+        text = "[[A]] and [[B stays open"
+        result = ex.replaceInternalLinks(text)
+        self.assertEqual(result, "A and [[B stays open")
+
+    def test_multiple_well_formed_links_after_an_unclosed_one_all_recover(self):
+        text = "[[broken (no close and [[first]] and [[second]] and [[third]]"
+        result = ex.replaceInternalLinks(text)
+        self.assertIn("[[broken (no close", result)
+        self.assertIn("first", result)
+        self.assertNotIn("[[first", result)
+        self.assertIn("second", result)
+        self.assertNotIn("[[second", result)
+        self.assertIn("third", result)
+        self.assertNotIn("[[third", result)
+
+    def test_unclosed_bracket_with_no_match_anywhere_does_not_affect_a_later_real_link(self):
+        # Note: this text happens to contain a blank line between the
+        # two parts, but that's not what makes it work -- "[[unclosed"
+        # has no matching "]]" anywhere in this text at all (not just
+        # within its own paragraph), so it's correctly identified as
+        # genuinely unclosed regardless of paragraph boundaries.
+        text = "First paragraph has [[unclosed (no close here\n\nSecond paragraph has [[a real link]] in it"
+        result = ex.replaceInternalLinks(text)
+        self.assertIn("[[unclosed", result)
+        self.assertIn("a real link", result)
+        self.assertNotIn("[[a real link", result)
 
 
 if __name__ == '__main__':

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -535,52 +535,88 @@ def collapseDoubledLinkBrackets(text):
     [[File:x.jpg|[[real link]]]] where a nested real link is the last
     thing before the outer link's own close.
     """
+    # Fast path: the vast majority of documents contain no run of 3+
+    # consecutive opening brackets at all (measured: a small fraction
+    # of articles even on the wikis where this pattern shows up).
+    # "[[[" appearing as a substring is exactly equivalent to "a run of
+    # 3+ consecutive '[' exists somewhere" (if such a run exists, its
+    # first 3 characters are that substring; if that substring exists,
+    # those are 3 consecutive '[' by definition) -- so this is a fully
+    # safe, exact short-circuit, not an approximation, and lets the
+    # (relatively expensive) per-character scan below be skipped
+    # entirely for documents that don't need it.
+    if '[[[' not in text:
+        return text
+
     result = []
-    i = 0
+    cur = 0
     n = len(text)
-    while i < n:
-        if text[i] == '[':
-            j = i
-            while j < n and text[j] == '[':
-                j += 1
-            open_run = j - i
-            if open_run >= 3:
-                excess = open_run - 2
-                # Find where a normal, correctly-nested single link
-                # starting at position j would naturally close, using
-                # findBalanced() itself rather than a naive first-']]'
-                # scan -- this correctly skips over any genuinely
-                # nested real link in between (e.g. a File: link whose
-                # caption itself contains an actual [[link]]), rather
-                # than mistaking that inner link's own close for the
-                # outer one's.
-                pseudo = '[[' + text[j:]
-                match = next(iter(findBalanced(pseudo, ['[['], [']]'])), None)
-                if match is not None:
-                    _, pseudo_end = match
-                    close_pos = j + (pseudo_end - 2) - 2
-                    k = close_pos + 2
-                    trailing_closes = 0
-                    while k < n and text[k] == ']' and trailing_closes < excess:
-                        trailing_closes += 1
-                        k += 1
-                    if trailing_closes == excess:
-                        result.append('[[')
-                        result.append(text[j:close_pos + 2])
-                        i = close_pos + 2 + excess
-                        continue
-                # Fallback: collapse just the opens; the closing side
-                # is left as-is (may leave a small residue, same as
-                # not attempting the symmetric case at all).
+    pos = 0
+    while True:
+        m = _tripleOpenRE.search(text, pos)
+        if not m:
+            break
+        i, j = m.start(), m.end()
+        if i < cur:
+            # This run sits inside content already emitted as part of
+            # a previous occurrence's processed output (e.g. a nested
+            # run inside a caption we already consumed) -- skip it
+            # rather than reprocessing already-handled text.
+            pos = cur
+            continue
+        result.append(text[cur:i])
+        open_run = j - i
+        excess = open_run - 2
+        # Find where a normal, correctly-nested single link
+        # starting at position j would naturally close, using
+        # findBalanced() itself rather than a naive first-']]'
+        # scan -- this correctly skips over any genuinely
+        # nested real link in between (e.g. a File: link whose
+        # caption itself contains an actual [[link]]), rather
+        # than mistaking that inner link's own close for the
+        # outer one's.
+        #
+        # text[j-2:j] is already "[[" (the last two characters
+        # of the run of 3+ opens we just matched), so slicing
+        # from j-2 gives the same "starts with [[" property as
+        # concatenating a synthetic '[[' prefix onto text[j:]
+        # would, but as a single slice rather than a second
+        # string-building step.
+        pseudo = text[j - 2:]
+        match = next(findBalanced(pseudo, _LINK_OPEN_DELIM, _LINK_CLOSE_DELIM), None)
+        if match is not None:
+            _, pseudo_end = match
+            close_pos = j + (pseudo_end - 2) - 2
+            k = close_pos + 2
+            trailing_closes = 0
+            while k < n and text[k] == ']' and trailing_closes < excess:
+                trailing_closes += 1
+                k += 1
+            if trailing_closes == excess:
                 result.append('[[')
-                i = j
+                result.append(text[j:close_pos + 2])
+                cur = close_pos + 2 + excess
+                pos = cur
                 continue
-        result.append(text[i])
-        i += 1
+        # Fallback: collapse just the opens; the closing side
+        # is left as-is (may leave a small residue, same as
+        # not attempting the symmetric case at all).
+        result.append('[[')
+        cur = j
+        pos = j
+    result.append(text[cur:])
+    return ''.join(result)
     return ''.join(result)
 
 
 _bracketPairRE = re.compile(r'\[\[|\]\]')
+_tripleOpenRE = re.compile(r'\[{3,}')
+
+# Reused by collapseDoubledLinkBrackets()'s pseudo-prefix findBalanced()
+# call below -- allocated once at module load rather than as fresh list
+# objects on every call.
+_LINK_OPEN_DELIM = ['[[']
+_LINK_CLOSE_DELIM = [']]']
 
 
 def findUnclosedLinkOpenPositions(text):
@@ -1804,11 +1840,16 @@ def findMatchingBraces(text, ldelim=0):
                 cur = end
 
 
-def findBalanced(text, openDelim, closeDelim):
+def findBalanced(text, openDelim, closeDelim, search_start=0):
     """
     Assuming that text contains a properly balanced expression using
     :param openDelim: as opening delimiters and
     :param closeDelim: as closing delimiters.
+    :param search_start: character position to begin searching from
+      (default 0, i.e. the whole text). Useful for scanning from
+      partway through a large string without copying/slicing it first --
+      regex .search(text, pos) already supports an arbitrary start
+      position natively, without any copy.
     :return: an iterator producing pairs (start, end) of start and end
     positions in text containing a balanced expression.
     """
@@ -1817,7 +1858,7 @@ def findBalanced(text, openDelim, closeDelim):
     afterPat = {o: re.compile(openPat + '|' + c, re.DOTALL) for o, c in zip(openDelim, closeDelim)}
     stack = []
     start = 0
-    cur = 0
+    cur = search_start
     # end = len(text)
     startSet = False
     startPat = re.compile(openPat)

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -512,23 +512,44 @@ def collapseDoubledLinkBrackets(text):
 
     A valid link target can never legitimately start with "[[" as its
     own first two characters, so a run of 3+ opening brackets is never
-    genuine nesting -- only ever this mistake. Where the closing side
-    has a matching excess (the common case: someone doubled the whole
-    [[...]] wrapper symmetrically), both sides are stripped and the
-    result is fully clean with no residue. An asymmetric mistake (fewer
-    closing brackets than opens) also comes out fully clean, since
-    there's nothing extra on the closing side to begin with -- the
-    opening collapse alone recovers the real content with no residue.
-    Residue only shows up in a narrower, more ambiguous case: a doubled
-    outer wrapper around content that itself contains several
-    genuinely separate real links, where the excess closing brackets
-    exist but only appear at the very end, not immediately after the
-    first inner link's own close. There, this function safely falls
-    back to collapsing just the opening side rather than guessing at a
-    merge that could misinterpret the real link structure --
-    findBalanced() still recovers all the real inner links correctly,
-    just with a couple of stray trailing "]" characters left over in
-    that specific case.
+    genuine nesting -- only ever this mistake. Three distinct cases:
+
+    1. The closing side has a matching excess immediately after the
+       first natural close (the common case: someone doubled the whole
+       [[...]] wrapper symmetrically) -- both sides are stripped and
+       the result is fully clean with no residue.
+
+    2. No natural close is found at all anywhere in the rest of the
+       text (an asymmetric mistake: fewer closing brackets than opens,
+       e.g. the real Sindhi Wikipedia "[[[[يوني ايئر(Uni Air)]]" case:
+       4 opens, only 2 closes). Collapsing just the opening side is
+       safe here and comes out fully clean, since there's nothing else
+       to strand.
+
+    3. A natural close IS found, but nothing extra immediately follows
+       it -- there's some other, different structure in between
+       before wherever a true excess (if any) actually sits, e.g. the
+       real Saraiki Wikipedia case [[[[سرائیکی]] زبان|سرائیکی]] (the
+       true outer close is on the far side of a whole separate
+       "زبان|..." phrase, not immediately after the first inner
+       close). This is the one case where this function does NOT
+       modify anything, leaving the run entirely untouched instead of
+       collapsing just the opens. Collapsing just the opens here would
+       be unsafe: findBalanced() on the original, fully-unmodified
+       text already matches the whole (globally-balanced) span as one
+       piece, and when a pipe happens to hide embedded garbage behind
+       a clean label, that already produces correct output on its own
+       -- but collapsing just the opens would make the first inner
+       closing pair look like a complete, separate match, ending too
+       early and stranding everything after it as newly-visible
+       leftover text that was never visible before. Leaving it
+       untouched means this function can only ever improve on the
+       unmodified behavior, never make a previously-correct case
+       worse -- at the cost of not attempting to also recover the
+       individual real links in more complex versions of this shape
+       (e.g. a doubled wrapper around several separate real links),
+       which remain exactly as findBalanced() would have handled them
+       without this function at all.
 
     Deliberately does not touch the closing side on its own: adjacent
     closing brackets legitimately occur in real nesting, e.g.
@@ -598,14 +619,51 @@ def collapseDoubledLinkBrackets(text):
                 cur = close_pos + 2 + excess
                 pos = cur
                 continue
-        # Fallback: collapse just the opens; the closing side
-        # is left as-is (may leave a small residue, same as
-        # not attempting the symmetric case at all).
+            if close_pos + 2 == n:
+                # The found natural close is the very last thing in
+                # the text -- nothing follows it at all, e.g. the real
+                # Sindhi Wikipedia "[[[[يوني ايئر(Uni Air)]]" case: 4
+                # opens, only 2 closes, and the found close ends
+                # exactly at the end of the text. Collapsing just the
+                # opens is safe here: there's nothing left afterward
+                # that could be stranded.
+                result.append('[[')
+                cur = j
+                pos = j
+                continue
+            # A natural close WAS found here, but nothing extra
+            # immediately follows it, AND there's still more text
+            # after it -- some other, different structure exists in
+            # between before wherever a true excess (if any) actually
+            # sits, e.g. the real Saraiki Wikipedia case
+            # [[[[سرائیکی]] زبان|سرائیکی]] (the true outer close is on
+            # the far side of a whole separate "زبان|..." phrase, not
+            # immediately after the first inner close). Collapsing
+            # just the opens here is unsafe: it can turn a case that
+            # was ACCIDENTALLY working correctly on the original,
+            # fully-unmodified text into something worse. findBalanced()
+            # on the original text would match the whole (globally-
+            # balanced) span as one piece, and if a pipe happens to
+            # hide embedded garbage behind a clean label, that already
+            # produces correct output -- but collapsing just the opens
+            # makes the first inner closing pair look like a complete,
+            # separate match on its own, ending too early and
+            # stranding everything after it as newly-visible leftover
+            # text that was never visible before. Leave this run
+            # completely untouched instead, and defer entirely to what
+            # findBalanced() would already do.
+            result.append(text[i:j])
+            cur = j
+            pos = j
+            continue
+        # No natural close found at all anywhere in the rest of the
+        # text. Collapsing just the opens is safe here too, for the
+        # same reason as the "nothing follows" case above: there's
+        # nothing left afterward that could be stranded.
         result.append('[[')
         cur = j
         pos = j
     result.append(text[cur:])
-    return ''.join(result)
     return ''.join(result)
 
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -580,6 +580,95 @@ def collapseDoubledLinkBrackets(text):
     return ''.join(result)
 
 
+_bracketPairRE = re.compile(r'\[\[|\]\]')
+
+
+def findUnclosedLinkOpenPositions(text):
+    """
+    Return the character positions of "[[" occurrences that never find
+    a matching "]]" within the given text, using simple stack logic
+    that mirrors findBalanced()'s own semantics (an opening delimiter
+    that's still on the stack once the text ends never gets yielded as
+    part of any match).
+
+    Implemented via a single compiled-regex scan (finditer) rather than
+    a manual character-by-character loop: measured ~9x faster on
+    realistic article-length text with identical results, since regex
+    scanning runs as compiled code rather than interpreted per-
+    character indexing.
+    """
+    stack = []
+    for m in _bracketPairRE.finditer(text):
+        if m.group() == '[[':
+            stack.append(m.start())
+        elif stack:
+            stack.pop()
+    return stack
+
+
+def neutralizeUnclosedLinkOpens(text):
+    """
+    A single genuinely unclosed link opening -- e.g. [[1198 (a real,
+    very ordinary wikitext typo: someone forgot the closing "]]") --
+    would otherwise silently disable ALL SUBSEQUENT link conversion for
+    the rest of the article. This happens because findBalanced()'s
+    stack-based matcher only yields a match once the stack returns to
+    completely empty; one permanently-unmatched opening means the
+    stack can never empty again for anything that follows, even
+    several unrelated, perfectly well-formed links later in the same
+    article.
+
+    This neutralizes exactly the genuinely-unclosed openings (found via
+    findUnclosedLinkOpenPositions(), not merely "the first N excess
+    opens" -- a naive count-based heuristic could misidentify an
+    earlier, properly-closed link as the broken one) by temporarily
+    replacing them with a placeholder that findBalanced() won't
+    recognize as an opening delimiter. The placeholder is restored back
+    to a literal "[[" afterward, so the malformed link itself is left
+    exactly as broken as it was -- only its blast radius on later,
+    unrelated links is contained.
+
+    Deliberately NOT bounded to a single paragraph: findBalanced() and
+    findUnclosedLinkOpenPositions() use the exact same LIFO stack
+    logic, so this never "blames" a bracket that findBalanced() itself
+    wouldn't already treat the same way on the raw, uncollapsed text --
+    it only prevents one permanently-unmatched opening from poisoning
+    everything after it. An earlier version of this function bounded
+    detection to a single paragraph specifically to avoid long-distance
+    accidental pairing with an unrelated stray bracket elsewhere in the
+    same article, but that turned out to cause a worse, confirmed
+    problem in practice: a real File: link (English Wikipedia,
+    "Asterix") has a <ref>...</ref> citation, nested inside its image
+    caption, that itself contains a genuine blank line before its
+    closing tag -- entirely legitimate wikitext, just untidy
+    formatting. Paragraph-bounding incorrectly treated the File: link's
+    opening as unclosed (since its true close was one blank line away),
+    causing the whole link to survive as literal text instead of being
+    cleanly dropped, exactly the correct behavior it has without this
+    fix at all. Whole-text detection resolves this correctly, since the
+    true closing "]]" is found and paired normally, no differently
+    than findBalanced() would have paired it on its own.
+    """
+    unclosed = findUnclosedLinkOpenPositions(text)
+    if not unclosed:
+        return text
+    result = []
+    cur = 0
+    for pos in unclosed:
+        result.append(text[cur:pos])
+        result.append(LINK_OPEN_PLACEHOLDER)
+        cur = pos + 2
+    result.append(text[cur:])
+    return ''.join(result)
+
+
+# Placeholder used by neutralizeUnclosedLinkOpens(); chosen to be a
+# control-character sequence that can never legitimately appear in
+# wikitext, and restored back to a literal "[[" once link processing
+# for the rest of the text has completed.
+LINK_OPEN_PLACEHOLDER = '\x00\x00'
+
+
 def replaceInternalLinks(text):
     """
     Replaces external links of the form:
@@ -590,6 +679,7 @@ def replaceInternalLinks(text):
     # call this after removal of external links, so we need not worry about
     # triple closing ]]].
     text = collapseDoubledLinkBrackets(text)
+    text = neutralizeUnclosedLinkOpens(text)
 
     cur = 0
     res = ''
@@ -619,7 +709,7 @@ def replaceInternalLinks(text):
             label = inner[pipe + 1:].strip()
         res += text[cur:s] + makeInternalLink(title, label) + trail
         cur = end
-    return res + text[cur:]
+    return (res + text[cur:]).replace(LINK_OPEN_PLACEHOLDER, '[[')
 
 
 def makeInternalLink(title, label):

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -501,6 +501,85 @@ def makeExternalImage(url, alt=''):
 # Also: [[Help:IPA for Catalan|[andora]]]
 
 
+def collapseDoubledLinkBrackets(text):
+    """
+    Collapse a real, surprisingly common wikitext authoring mistake:
+    doubled link brackets, e.g. [[[[title]]]] instead of [[title]].
+    Found at meaningful scale on multiple language wikis -- sometimes
+    as an isolated typo, sometimes baked into a widely-transcluded
+    template (e.g. a sister-projects/interwiki table), in which case a
+    single buggy template can produce very many instances.
+
+    A valid link target can never legitimately start with "[[" as its
+    own first two characters, so a run of 3+ opening brackets is never
+    genuine nesting -- only ever this mistake. Where the closing side
+    has a matching excess (the common case: someone doubled the whole
+    [[...]] wrapper symmetrically), both sides are stripped and the
+    result is fully clean with no residue. An asymmetric mistake (fewer
+    closing brackets than opens) also comes out fully clean, since
+    there's nothing extra on the closing side to begin with -- the
+    opening collapse alone recovers the real content with no residue.
+    Residue only shows up in a narrower, more ambiguous case: a doubled
+    outer wrapper around content that itself contains several
+    genuinely separate real links, where the excess closing brackets
+    exist but only appear at the very end, not immediately after the
+    first inner link's own close. There, this function safely falls
+    back to collapsing just the opening side rather than guessing at a
+    merge that could misinterpret the real link structure --
+    findBalanced() still recovers all the real inner links correctly,
+    just with a couple of stray trailing "]" characters left over in
+    that specific case.
+
+    Deliberately does not touch the closing side on its own: adjacent
+    closing brackets legitimately occur in real nesting, e.g.
+    [[File:x.jpg|[[real link]]]] where a nested real link is the last
+    thing before the outer link's own close.
+    """
+    result = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == '[':
+            j = i
+            while j < n and text[j] == '[':
+                j += 1
+            open_run = j - i
+            if open_run >= 3:
+                excess = open_run - 2
+                # Find where a normal, correctly-nested single link
+                # starting at position j would naturally close, using
+                # findBalanced() itself rather than a naive first-']]'
+                # scan -- this correctly skips over any genuinely
+                # nested real link in between (e.g. a File: link whose
+                # caption itself contains an actual [[link]]), rather
+                # than mistaking that inner link's own close for the
+                # outer one's.
+                pseudo = '[[' + text[j:]
+                match = next(iter(findBalanced(pseudo, ['[['], [']]'])), None)
+                if match is not None:
+                    _, pseudo_end = match
+                    close_pos = j + (pseudo_end - 2) - 2
+                    k = close_pos + 2
+                    trailing_closes = 0
+                    while k < n and text[k] == ']' and trailing_closes < excess:
+                        trailing_closes += 1
+                        k += 1
+                    if trailing_closes == excess:
+                        result.append('[[')
+                        result.append(text[j:close_pos + 2])
+                        i = close_pos + 2 + excess
+                        continue
+                # Fallback: collapse just the opens; the closing side
+                # is left as-is (may leave a small residue, same as
+                # not attempting the symmetric case at all).
+                result.append('[[')
+                i = j
+                continue
+        result.append(text[i])
+        i += 1
+    return ''.join(result)
+
+
 def replaceInternalLinks(text):
     """
     Replaces external links of the form:
@@ -510,6 +589,8 @@ def replaceInternalLinks(text):
     """
     # call this after removal of external links, so we need not worry about
     # triple closing ]]].
+    text = collapseDoubledLinkBrackets(text)
+
     cur = 0
     res = ''
     for s, e in findBalanced(text, ['[['], [']]']):


### PR DESCRIPTION
This PR includes various fixes for double brackets showing up in output files.  For example, if a template is not properly closed, previously it would prevent all later template processing.  This change scans the document for potential template closes, and if none exist, the double brackets are instead dropped and later templates / links are still treated as normal.

Written with Claude assistance.  Includes a Claude-written unit test.