### PR TITLE
Fix a potential security issue where 'eval' gets called on... whatever

### DIFF
--- a/tests/test_sharp_expr_security.py
+++ b/tests/test_sharp_expr_security.py
@@ -1,0 +1,145 @@
+"""
+Tests for sharp_expr()'s #expr evaluator in extract.py: confirms it
+cannot execute arbitrary code, only the narrow arithmetic/boolean
+grammar #expr actually supports (see
+https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions).
+
+sharp_expr() previously called Python's own eval() directly on
+wikitext-derived text, with no explicit globals/locals -- which grants
+full access to Python's builtins, including __import__. Confirmed
+directly (see project history) that
+"{{#expr: __import__('os').system('rm -rf ...') }}" would actually run
+a shell command through that path. It's now a small, explicitly
+whitelisted AST walker (_sharp_expr_eval_node()) that only ever
+computes the specific node types #expr's own grammar supports --
+arithmetic, comparison, boolean logic, and the round/trunc/ceil/floor
+special cases -- directly in Python, never via eval()/exec()/compile().
+
+Deliberately, NONE of these tests use an actually destructive payload
+(no filesystem mutation, no subprocess spawning of any kind) -- not
+even as an inert string being fed in for rejection. If a future
+regression somehow reintroduced eval() (or some other code-execution
+path) without anyone noticing until these tests ran, the payloads
+below are chosen so that "the fix is broken" is exactly what a test
+failure here would mean, without a broken fix having any chance of
+causing real harm as a side effect of finding that out. Two safe but
+still fully diagnostic techniques are used instead of a real
+destructive command:
+  - A read-only, side-effect-free call (os.getcwd()) that, if it
+    executed, would return real, observable data -- proving module
+    import and method-call capability without changing anything.
+  - A "canary": a module-level list in THIS test file, which a
+    payload attempts to mutate by reaching back into this module via
+    __import__ -- the same underlying mechanism (__import__ granting
+    access to anything reachable, including this test's own state)
+    a real attack would rely on, but with a completely inert result
+    if it succeeds.
+
+Run with:
+    python -m unittest tests.test_sharp_expr_security -v
+or, from the tests/ directory:
+    python -m unittest test_sharp_expr_security -v
+"""
+
+import sys
+import unittest
+import warnings
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+
+
+# Mutated only if a payload below manages to actually execute code and
+# reach back into this module -- checked but never intentionally set
+# by any test itself.
+CANARY = []
+
+
+class SharpExprSecurityTests(unittest.TestCase):
+
+    ERROR_SPAN = '<span class="error"></span>'
+
+    def test_import_os_getcwd_does_not_execute(self):
+        # Read-only, no side effects at all -- if this executed, the
+        # result would be a real path string, not the error fallback.
+        result = ex.sharp_expr("__import__('os').getcwd()")
+        self.assertEqual(result, self.ERROR_SPAN)
+
+    def test_canary_mutation_payload_does_not_execute(self):
+        # If arbitrary code execution were possible here, this would
+        # reach back into this exact test module and append to CANARY
+        # -- the same "reach anything reachable via __import__"
+        # capability the real os.system(...) attack depends on,
+        # demonstrated with a completely inert result instead.
+        module_name = __name__
+        payload = f"__import__('{module_name}').CANARY.append('EXPLOITED') or 1"
+        result = ex.sharp_expr(payload)
+        self.assertEqual(result, self.ERROR_SPAN)
+        self.assertEqual(CANARY, [], "the canary was mutated -- code execution occurred")
+
+    def test_classic_sandbox_escape_chain_does_not_execute(self):
+        # The well-known "reach __builtins__ via object introspection"
+        # technique, entirely without needing an explicit __import__
+        # call at all.
+        result = ex.sharp_expr("().__class__.__bases__[0].__subclasses__()")
+        self.assertEqual(result, self.ERROR_SPAN)
+
+    def test_direct_attribute_access_does_not_execute(self):
+        result = ex.sharp_expr("().__class__")
+        self.assertEqual(result, self.ERROR_SPAN)
+
+    def test_original_syntaxwarning_trigger_handled_safely(self):
+        # The exact pattern that surfaced this investigation in the
+        # first place: a number directly adjacent to a parenthesized
+        # expression, which Python's own compile() step (not its
+        # parser) flags as likely a mistake. Confirmed directly (see
+        # project history) that ast.parse() alone -- what this
+        # evaluator actually uses -- never reaches that compile step,
+        # so this fix also happens to eliminate the original warning,
+        # not just the security hole; asserted here directly rather
+        # than assumed.
+        #
+        # record=True rather than simplefilter("error") deliberately:
+        # sharp_expr()'s own bare except would swallow a
+        # warning-turned-exception too, for an unrelated reason (it
+        # catches everything), which would make this test pass either
+        # way and prove nothing specific about whether a warning
+        # actually fired. Recording instead lets the two be told apart.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = ex.sharp_expr("2(3+4)")
+        self.assertEqual(result, self.ERROR_SPAN)
+        self.assertEqual(caught, [], "a warning was emitted where none should be")
+
+    def test_string_literal_is_rejected_not_evaluated(self):
+        # #expr's own real grammar has no string type at all -- a
+        # quoted literal should be rejected the same as anything else
+        # outside the numeric/boolean whitelist, not silently accepted.
+        result = ex.sharp_expr("'harmless string'")
+        self.assertEqual(result, self.ERROR_SPAN)
+
+
+class SharpExprLegitimateUseTests(unittest.TestCase):
+    """Positive control: confirms the security fix didn't break the
+    narrow, real functionality #expr is actually meant to provide.
+    """
+
+    def test_basic_arithmetic(self):
+        self.assertEqual(ex.sharp_expr("2 + 2"), "4")
+        self.assertEqual(ex.sharp_expr("2 + 3 * 4"), "14")
+
+    def test_mod_and_div_keywords(self):
+        self.assertEqual(ex.sharp_expr("10 mod 3"), "1")
+        self.assertEqual(ex.sharp_expr("10 div 4"), "2.5")
+
+    def test_equality_and_comparison(self):
+        self.assertEqual(ex.sharp_expr("5 = 5"), "1")
+        self.assertEqual(ex.sharp_expr("3 < 5 and 5 < 10"), "1")
+
+    def test_round(self):
+        self.assertEqual(ex.sharp_expr("3.14159 round 2"), "3.14")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -21,6 +21,8 @@
 import re
 import html
 import json
+import ast
+import operator
 from itertools import zip_longest
 from urllib.parse import quote as urlencode
 from html.entities import name2codepoint
@@ -2070,43 +2072,136 @@ def normalizeNamespace(ns):
 # https://github.com/Wikia/app/blob/dev/extensions/ParserFunctions/ParserFunctions_body.php
 
 
-class Infix():
+# #expr's operators, mapped to their Python equivalents -- this is the
+# complete, explicit whitelist; nothing outside it is ever evaluated.
+_SHARP_EXPR_BINOPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+_SHARP_EXPR_UNARYOPS = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+    ast.Not: lambda x: 0 if x else 1,
+}
+_SHARP_EXPR_COMPARISONS = {
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+}
 
-    """Infix operators.
-    The calling sequence for the infix is:
-      x |op| y
+
+def _sharp_expr_eval_node(node):
+    """Recursively evaluates one node of a parsed #expr expression,
+    computing the result directly in Python rather than ever calling
+    eval()/exec()/compile() on the (untrusted, wikitext-derived)
+    expression text. Every node type reachable here is on an explicit
+    whitelist; anything else -- a function call, a name lookup, an
+    attribute access, a string, anything at all outside plain
+    numeric/boolean arithmetic -- raises ValueError and is treated as
+    a malformed expression, the same outcome #expr's real syntax
+    would produce for it anyway (it doesn't support any of those
+    either: see https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions,
+    #expr operates on numbers and booleans only, never strings, and
+    has no facility for function calls or name references at all).
+
+    This replaces a previous implementation that called Python's own
+    eval() directly on the (barely pre-processed) expression string.
+    Confirmed directly, not just theoretically: with no explicit
+    globals/locals passed, that eval() call had full access to
+    Python's builtins, including __import__ -- e.g.
+    "{{#expr: __import__('os').system('rm -rf ...') }}" would
+    actually execute a shell command.
+
+    Realistic exposure, precisely: MediaWiki's own #expr wouldn't
+    execute this either (it would just render an inline "Expression
+    error" and save the edit anyway -- the save itself isn't blocked
+    by anything). Automated anti-vandalism tooling on the largest
+    wikis (e.g. ClueBot NG) is trained on what typical vandalism looks
+    like -- profanity, blanking, spam -- and, by its own published
+    numbers, catches only a minority of even that at its current
+    false-positive-conservative setting; a syntactically-plausible,
+    non-obviously-damaging template call is a poor match for what it's
+    trained to flag. Smaller wikis very likely have no such bot
+    running at all, and far fewer active editors, so real exposure
+    time before a human notices could be substantial.
     """
+    if isinstance(node, ast.Expression):
+        return _sharp_expr_eval_node(node.body)
 
-    def __init__(self, function):
-        self.function = function
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, (int, float)) and not isinstance(node.value, bool):
+            return node.value
+        raise ValueError("only numeric constants are permitted in #expr")
 
-    def __ror__(self, other):
-        return Infix(lambda x, self=self, other=other: self.function(other, x))
+    if isinstance(node, ast.BinOp):
+        # "X round Y" gets pre-processed (see sharp_expr() below) into
+        # "X |ROUND| Y", which -- since | left-associates in Python --
+        # parses as (X | ROUND) | Y. Recognized specifically as this
+        # exact shape, rather than treating BitOr as a general-purpose
+        # operator (it isn't one in #expr's own grammar at all).
+        if (isinstance(node.op, ast.BitOr)
+                and isinstance(node.left, ast.BinOp)
+                and isinstance(node.left.op, ast.BitOr)
+                and isinstance(node.left.right, ast.Name)
+                and node.left.right.id == 'ROUND'):
+            value = _sharp_expr_eval_node(node.left.left)
+            digits = _sharp_expr_eval_node(node.right)
+            return round(value, int(digits))
+        op_func = _SHARP_EXPR_BINOPS.get(type(node.op))
+        if op_func is None:
+            raise ValueError(f"operator not permitted in #expr: {type(node.op).__name__}")
+        return op_func(_sharp_expr_eval_node(node.left), _sharp_expr_eval_node(node.right))
 
-    def __or__(self, other):
-        return self.function(other)
+    if isinstance(node, ast.UnaryOp):
+        op_func = _SHARP_EXPR_UNARYOPS.get(type(node.op))
+        if op_func is None:
+            raise ValueError(f"unary operator not permitted in #expr: {type(node.op).__name__}")
+        return op_func(_sharp_expr_eval_node(node.operand))
 
-    def __rlshift__(self, other):
-        return Infix(lambda x, self=self, other=other: self.function(other, x))
+    if isinstance(node, ast.Compare):
+        if len(node.ops) != 1:
+            raise ValueError("chained comparisons not supported in #expr")
+        op_func = _SHARP_EXPR_COMPARISONS.get(type(node.ops[0]))
+        if op_func is None:
+            raise ValueError(f"comparison not permitted in #expr: {type(node.ops[0]).__name__}")
+        result = op_func(_sharp_expr_eval_node(node.left),
+                         _sharp_expr_eval_node(node.comparators[0]))
+        return 1 if result else 0
 
-    def __rshift__(self, other):
-        return self.function(other)
+    if isinstance(node, ast.BoolOp):
+        if isinstance(node.op, ast.And):
+            result = 1
+            for value_node in node.values:
+                result = _sharp_expr_eval_node(value_node)
+                if not result:
+                    return 0
+            return result
+        else:  # ast.Or
+            for value_node in node.values:
+                result = _sharp_expr_eval_node(value_node)
+                if result:
+                    return result
+            return 0
 
-    def __call__(self, value1, value2):
-        return self.function(value1, value2)
-
-
-ROUND = Infix(lambda x, y: round(x, y))
+    raise ValueError(f"disallowed #expr element: {type(node).__name__}")
 
 
 def sharp_expr(expr):
     try:
         expr = re.sub('=', '==', expr)
         expr = re.sub('mod', '%', expr)
-        expr = re.sub('\bdiv\b', '/', expr)
-        expr = re.sub('\bround\b', '|ROUND|', expr)
-        return str(eval(expr))
-    except:
+        expr = re.sub(r'\bdiv\b', '/', expr)
+        expr = re.sub(r'\bround\b', '|ROUND|', expr)
+        tree = ast.parse(expr, mode='eval')
+        return str(_sharp_expr_eval_node(tree))
+    except Exception:
         return '<span class="error"></span>'
 
 


### PR DESCRIPTION
Fix a potential security issue where 'eval' gets called on... whatever.  Could be a problem if a wiki page has a malicious system command on it, for example.  Fix is by replacing all the operations with an ast instead.  Written with assistance from Claude

Add a test of the security fix / expr replacement