### PR TITLE
Fix an issue where cvt instead of convert is being lost

### DIFF
--- a/tests/test_frame_cleanup.py
+++ b/tests/test_frame_cleanup.py
@@ -1,0 +1,123 @@
+"""
+Tests for the try/finally guard around self.frame's append/pop pair in
+expandTemplate() (extract.py).
+
+self.frame is a stack tracking the currently-enclosing template
+invocation(s) -- pushed right before expanding a template's body,
+popped right after (see sharp_invoke()'s own use of frame[-1], and
+test_sharp_invoke_alias.py). Previously, that pop() was a plain,
+unguarded statement following the expansion call: if anything raised
+during template.subst() or self.expandTemplates(), the pop() was
+skipped, leaving a stale, un-popped entry on the stack rather than
+restoring it to what it was before that invocation was attempted.
+
+Given the current architecture (a brand-new Extractor instance per
+page, never reused -- confirmed directly at both call sites in
+WikiExtractor.py), an uncaught exception here aborts that page's
+extract() call entirely, so this gap doesn't currently produce wrong
+output in practice. But it's exactly the kind of invariant ("frame
+always accurately reflects the current call stack") that's easy to
+silently violate if the surrounding architecture ever changes --
+instance reuse across pages, or an added catch-and-continue somewhere
+in the middle of this chain -- so the try/finally protects the
+invariant itself, not just today's specific call graph.
+
+Run with:
+    python -m unittest tests.test_frame_cleanup_on_exception -v
+or, from the tests/ directory:
+    python -m unittest test_frame_cleanup_on_exception -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+from wikiextractor.extract import Extractor
+import wikiextractor.extract as ex
+
+
+class FrameCleanupOnExceptionTestCase(unittest.TestCase):
+
+    def setUp(self):
+        ex.templates.clear()
+        ex.templateCache.clear()
+        ex.redirects.clear()
+        ex.Extractor.templatePrefix = "Template:"
+
+    def get_extractor(self, article_text):
+        return Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
+                          "Test Article", [article_text])
+
+
+class FrameStaysCleanAfterExceptionTests(FrameCleanupOnExceptionTestCase):
+
+    def test_frame_is_empty_after_a_failing_template_expansion(self):
+        # A poison template whose expansion is made to raise partway
+        # through, simulating some genuine bug in subst()/
+        # expandTemplates() that isn't a #invoke-specific failure
+        # (those are already caught locally by callParserFunction's
+        # own bare except, before ever reaching this append/pop pair).
+        ex.define_template('Template:Poison', ['poisoned body'])
+
+        extractor = self.get_extractor('Before {{Poison}} after')
+
+        original_expand_templates = extractor.expandTemplates
+
+        def poisoned_expand_templates(wikitext):
+            if 'poisoned body' in wikitext:
+                raise RuntimeError("simulated failure during expansion")
+            return original_expand_templates(wikitext)
+
+        extractor.expandTemplates = poisoned_expand_templates
+
+        self.assertEqual(extractor.frame, [])
+        with self.assertRaises(RuntimeError):
+            extractor.clean_text('Before {{Poison}} after', expand_templates=True)
+
+        # The key assertion: frame was pushed once, for the Poison
+        # invocation, then the raise happened -- with the fix, it must
+        # still have been correctly popped back to empty, not left
+        # with that invocation's entry stranded on the stack.
+        self.assertEqual(extractor.frame, [],
+                          "frame was left dirty after an exception during expansion")
+
+    def test_frame_stays_correct_for_a_sibling_invocation_after_a_prior_failure(self):
+        # Belt-and-suspenders version of the above: after a failed
+        # expansion (caught at the test level, simulating some
+        # hypothetical future caller that catches and continues),
+        # a LATER, unrelated template invocation on the same
+        # extractor must not see any leftover state from the failed
+        # one. This only matters if some future change catches such
+        # an exception and continues on the same Extractor instance --
+        # not true today, but this is what the fix actually protects
+        # against.
+        ex.define_template('Template:Poison', ['poisoned body'])
+        ex.define_template('Template:Fine', ['fine body'])
+
+        extractor = self.get_extractor('x')
+        original_expand_templates = extractor.expandTemplates
+
+        def poisoned_expand_templates(wikitext):
+            if 'poisoned body' in wikitext:
+                raise RuntimeError("simulated failure during expansion")
+            return original_expand_templates(wikitext)
+
+        extractor.expandTemplates = poisoned_expand_templates
+
+        try:
+            extractor.expandTemplate('Poison')
+        except RuntimeError:
+            pass
+
+        self.assertEqual(extractor.frame, [])
+
+        # a subsequent, unrelated invocation should behave normally,
+        # with no leftover frame entry from the earlier failure
+        result = extractor.expandTemplate('Fine')
+        self.assertEqual(result, 'fine body')
+        self.assertEqual(extractor.frame, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_sharp_invoke_alias.py
+++ b/tests/test_sharp_invoke_alias.py
@@ -1,0 +1,151 @@
+"""
+Tests for sharp_invoke()'s #invoke frame-lookup fix in extract.py.
+
+Two separate, stacked bugs previously made {{#invoke: module | function }}
+calls fail:
+
+  1. sharp_invoke() referenced a global `modules` dict that was only
+     ever defined in WikiExtractor.py, a different module -- Python
+     resolves global lookups against the DEFINING module's own
+     namespace, not the caller's, so this always raised NameError,
+     silently swallowed by callParserFunction()'s bare except. Fixed
+     by moving `modules` into extract.py, where sharp_invoke() itself
+     lives.
+
+  2. Once that NameError was gone, sharp_invoke() still failed for
+     the ordinary case of an alias-style template: it guessed the
+     calling template's title FROM THE INVOKED FUNCTION'S OWN NAME
+     (e.g. "convert" -> "Template:Convert"), then searched the frame
+     stack for an entry matching that guess. This only ever worked by
+     coincidence, when a template's own name happened to match the
+     function it invokes. It silently failed the moment a
+     differently-named template invoked the same function -- e.g.
+     {{cvt|...}}, a template literally named "Cvt", invoking the
+     identical "convert" function that {{convert|...}} also invokes
+     under its own, different name. This is confirmed to be the
+     ordinary case, not an edge case: real Wikipedia's actual
+     Template:Convert is invoked under several different short-name
+     aliases this way.
+
+     Fixed by using frame[-1] directly -- frame is a genuine stack
+     (appended right before expanding a template's body, popped right
+     after; see expandTemplate()), so frame[-1] is always exactly the
+     template invocation that directly encloses whatever #invoke call
+     is currently running, regardless of what that template happens
+     to be named. No name-matching involved at all.
+
+This file demonstrates fix #2 specifically -- the alias-name case --
+since that's the one a naive "does #invoke work at all" check would
+miss entirely (a same-named template invocation, like
+{{convert|...}} invoking "convert", passes even against the old,
+broken lookup logic; only a differently-named one exposes it).
+
+Run with:
+    python -m unittest tests.test_sharp_invoke_alias -v
+or, from the tests/ directory:
+    python -m unittest test_sharp_invoke_alias -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+from wikiextractor.extract import Extractor
+import wikiextractor.extract as ex
+
+
+class SharpInvokeAliasTestCase(unittest.TestCase):
+
+    def setUp(self):
+        ex.templates.clear()
+        ex.templateCache.clear()
+        ex.redirects.clear()
+        ex.Extractor.templatePrefix = "Template:"
+        # a minimal, deliberately-"no conversion" stand-in matching
+        # the one actually shipped in extract.py's own `modules` dict
+        # -- kept separate here so this test doesn't depend on that
+        # dict's own exact contents remaining unchanged elsewhere.
+        ex.modules['convert'] = {
+            'convert': lambda x, u, *rest: x + ' ' + u,
+        }
+
+    def get_result(self, article_text):
+        extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
+                               "Test Article", [article_text])
+        return extractor.clean_text(article_text, expand_templates=True)
+
+
+class AliasTemplateNameTests(SharpInvokeAliasTestCase):
+    """The core regression: a template invoking #invoke under a name
+    OTHER than the function it calls.
+    """
+
+    def test_same_named_template_works(self):
+        # Template:Convert invoking "convert" -- names match. This
+        # passed even under the old, broken lookup logic, since the
+        # guessed title ("Template:Convert", derived from the
+        # function name "convert") happened to coincide with the
+        # template's actual name. Included as a baseline, not as the
+        # regression test itself.
+        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'])
+        result = self.get_result('Value: {{convert|5|km}}')
+        self.assertEqual(result, ['Value: 5 km'])
+
+    def test_differently_named_alias_template_works(self):
+        # Template:Cvt invoking the SAME "convert" function under a
+        # different name -- this is the actual bug. The old lookup
+        # guessed "Template:Convert" (from the function name) and
+        # never found a match against the frame stack's real entry,
+        # "Template:Cvt" -- silently failing to empty output every
+        # time, regardless of the underlying function being identical
+        # and correctly registered.
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'])
+        result = self.get_result('Value: {{cvt|5|km}}')
+        self.assertEqual(result, ['Value: 5 km'])
+
+    def test_original_buffalo_sentence(self):
+        # The exact real-world sentence that surfaced this whole
+        # investigation.
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'])
+        text = ("Buffalo's lowest recorded temperature was {{cvt|−20|°F|0}}, "
+                 "which occurred twice: on February 9, 1934, and February 2, 1961.")
+        result = self.get_result(text)
+        self.assertEqual(
+            result,
+            ["Buffalo's lowest recorded temperature was −20 °F, which occurred "
+             "twice: on February 9, 1934, and February 2, 1961."])
+
+    def test_multiple_differently_named_aliases_of_the_same_function(self):
+        # Not special-cased to "cvt" specifically -- any number of
+        # differently-named templates invoking the same function
+        # should all work identically.
+        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'])
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'])
+        ex.define_template('Template:Convert2', ['{{#invoke:convert|convert}}'])
+        for name in ('convert', 'cvt', 'convert2'):
+            with self.subTest(template=name):
+                result = self.get_result(f'Value: {{{{{name}|5|km}}}}')
+                self.assertEqual(result, ['Value: 5 km'])
+
+
+class FrameStackOrderingTests(SharpInvokeAliasTestCase):
+    """Confirms the fix genuinely uses stack position (innermost,
+    currently-expanding invocation), not just "any name at all" --
+    distinguishing between two different templates' own parameters
+    when one invokes #invoke and the other doesn't.
+    """
+
+    def test_uses_the_directly_enclosing_invocation_not_an_outer_one(self):
+        # Outer template has its own, different params and does NOT
+        # itself call #invoke -- it calls Cvt, which does. The
+        # #invoke call must pick up Cvt's own params (5, km), not
+        # Wrapper's (999, mi).
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'])
+        ex.define_template('Template:Wrapper', ['See: {{cvt|{{{1}}}|{{{2}}}}}'])
+        result = self.get_result('Value: {{wrapper|5|km}}')
+        self.assertEqual(result, ['Value: See: 5 km'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -129,17 +129,6 @@ templateNamespace = ''
 moduleNamespace = ''
 
 # ----------------------------------------------------------------------
-# Modules
-
-# Only minimal support
-# FIXME: import Lua modules.
-
-modules = {
-    'convert': {
-        'convert': lambda x, u, *rest: x + ' ' + u,  # no conversion
-    }
-}
-# ----------------------------------------------------------------------
 # Expand using WikiMedia API
 # import json
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -1761,10 +1761,12 @@ class Extractor():
         # parameter value, e.g. {{OTRS|celebrative|date=April 2015}} in article
         # 21637542 in enwiki.
         self.frame.append((title, params))
-        instantiated = template.subst(params, self)
-        # logger.debug('instantiated %d %s', len(self.frame), instantiated)
-        value = self.expandTemplates(instantiated)
-        self.frame.pop()
+        try:
+            instantiated = template.subst(params, self)
+            # logger.debug('instantiated %d %s', len(self.frame), instantiated)
+            value = self.expandTemplates(instantiated)
+        finally:
+            self.frame.pop()
         # logger.debug('   INVOCATION> %s %d %s', title, len(self.frame), value)
         return value
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -1160,11 +1160,10 @@ lineBreak_tag_patterns = [
 # self-closing tags) these have two distinct halves, each appearing at
 # a different position and needing its own independent substitution.
 # Same shapes as ignoreTag()'s own left/right patterns, for
-# consistency: opening requires the tag name immediately after '<'
-# (matching real HTML tokenizer behavior -- confirmed directly against
-# Python's html.parser -- a bare '< p>' is not treated as a tag at all
-# by real parsers, so this shouldn't either); closing tolerates
-# whitespace on either side of the name.
+# consistency: opening requires the tag name immediately after '<',
+# matching real HTML tokenizer behavior (a bare '< p>' is not treated
+# as a tag at all by real parsers, so this shouldn't either); closing
+# tolerates whitespace on either side of the name.
 block_separator_tag_patterns = [
     pattern
     for tag in blockSeparatorTags
@@ -2098,7 +2097,8 @@ _SHARP_EXPR_COMPARISONS = {
 
 
 def _sharp_expr_eval_node(node):
-    """Recursively evaluates one node of a parsed #expr expression,
+    """
+    Recursively evaluates one node of a parsed #expr expression,
     computing the result directly in Python rather than ever calling
     eval()/exec()/compile() on the (untrusted, wikitext-derived)
     expression text. Every node type reachable here is on an explicit
@@ -2111,26 +2111,18 @@ def _sharp_expr_eval_node(node):
     #expr operates on numbers and booleans only, never strings, and
     has no facility for function calls or name references at all).
 
-    This replaces a previous implementation that called Python's own
-    eval() directly on the (barely pre-processed) expression string.
-    Confirmed directly, not just theoretically: with no explicit
-    globals/locals passed, that eval() call had full access to
-    Python's builtins, including __import__ -- e.g.
-    "{{#expr: __import__('os').system('rm -rf ...') }}" would
-    actually execute a shell command.
+    This must never be changed to route the expression text through
+    eval()/exec()/compile() in any form: #expr's input comes from
+    wikitext on openly-editable wikis, and any such path grants full
+    access to Python's builtins (including __import__) unless
+    explicit globals/locals are passed and carefully restricted --
+    easy to get wrong, so the whitelist-only approach here is
+    deliberate, not incidental.
 
-    Realistic exposure, precisely: MediaWiki's own #expr wouldn't
-    execute this either (it would just render an inline "Expression
-    error" and save the edit anyway -- the save itself isn't blocked
-    by anything). Automated anti-vandalism tooling on the largest
-    wikis (e.g. ClueBot NG) is trained on what typical vandalism looks
-    like -- profanity, blanking, spam -- and, by its own published
-    numbers, catches only a minority of even that at its current
-    false-positive-conservative setting; a syntactically-plausible,
-    non-obviously-damaging template call is a poor match for what it's
-    trained to flag. Smaller wikis very likely have no such bot
-    running at all, and far fewer active editors, so real exposure
-    time before a human notices could be substantial.
+    Previously, an eval() call had full access to
+    Python's builtins, including __import__ -- e.g.
+    "{{#expr: __import__('os').system('rm -rf ...') }}"
+    would actually execute a shell command.
     """
     if isinstance(node, ast.Expression):
         return _sharp_expr_eval_node(node.body)
@@ -2294,6 +2286,10 @@ def sharp_switch(primary, *params):
 # Only minimal support for Lua modules invoked via #invoke.
 # FIXME: import real Lua modules (would require a Lua interpreter,
 # which this project doesn't have).
+#
+# Must stay defined in this module, not a caller's -- sharp_invoke()
+# below reads this as a global, and Python resolves that against the
+# function's own defining module, not wherever it's called from.
 modules = {
     'convert': {
         'convert': lambda x, u, *rest: x + ' ' + u,  # no conversion
@@ -2311,21 +2307,12 @@ def sharp_invoke(module, function, frame):
             # right before expanding a template's body, popped right
             # after), so frame[-1] is exactly the template invocation
             # that directly encloses this #invoke call, matching real
-            # Scribunto's frame:getParent() semantics.
-            #
-            # Previously this guessed the calling template's title
-            # from the invoked function's own name instead (e.g.
-            # "convert" -> "Template:Convert"), which only worked when
-            # a template's name happened to match the function it
-            # invokes. That breaks for the ordinary case of an
-            # alias-style template with a different name invoking the
-            # same function -- e.g. {{cvt|...}}, a template literally
-            # named "Cvt", invoking the same "convert" function that
-            # "Template:Convert" also invokes under its own, different
-            # name. Confirmed directly: the old lookup silently failed
-            # for {{cvt|...}} specifically while working for
-            # {{convert|...}}, even though both invoke the identical
-            # function.
+            # Scribunto's frame:getParent() semantics. Don't match by
+            # guessing the calling template's title from the function
+            # name instead -- that only works when they happen to
+            # coincide (e.g. Template:Convert invoking "convert"), and
+            # silently breaks for any differently-named alias template
+            # invoking the same function (e.g. {{cvt|...}}).
             if frame:
                 params = frame[-1][1]
                 # extract positional args

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -2291,19 +2291,43 @@ def sharp_switch(primary, *params):
 
 
 # Extension Scribuntu
+# Only minimal support for Lua modules invoked via #invoke.
+# FIXME: import real Lua modules (would require a Lua interpreter,
+# which this project doesn't have).
+modules = {
+    'convert': {
+        'convert': lambda x, u, *rest: x + ' ' + u,  # no conversion
+    }
+}
+
+
 def sharp_invoke(module, function, frame):
     functions = modules.get(module)
     if functions:
         funct = functions.get(function)
         if funct:
-            # find parameters in frame whose title is the one of the original
-            # template invocation
-            templateTitle = fullyQualifiedTemplateTitle(function)
-            if not templateTitle:
-                logger.warning("Template with empty title")
-            pair = next((x for x in frame if x[0] == templateTitle), None)
-            if pair:
-                params = pair[1]
+            # Use the innermost (most recently entered) frame entry --
+            # frame is a proper stack (see expandTemplate: appended
+            # right before expanding a template's body, popped right
+            # after), so frame[-1] is exactly the template invocation
+            # that directly encloses this #invoke call, matching real
+            # Scribunto's frame:getParent() semantics.
+            #
+            # Previously this guessed the calling template's title
+            # from the invoked function's own name instead (e.g.
+            # "convert" -> "Template:Convert"), which only worked when
+            # a template's name happened to match the function it
+            # invokes. That breaks for the ordinary case of an
+            # alias-style template with a different name invoking the
+            # same function -- e.g. {{cvt|...}}, a template literally
+            # named "Cvt", invoking the same "convert" function that
+            # "Template:Convert" also invokes under its own, different
+            # name. Confirmed directly: the old lookup silently failed
+            # for {{cvt|...}} specifically while working for
+            # {{convert|...}}, even though both invoke the identical
+            # function.
+            if frame:
+                params = frame[-1][1]
                 # extract positional args
                 params = [params.get(str(i + 1)) for i in range(len(params))]
                 return funct(*params)


### PR DESCRIPTION
In particular, this affected Buffalo:

```
Buffalo's lowest recorded temperature was ,
```

vs

```
Buffalo's lowest recorded temperature was -20F
```

but presumably there are a lot of other pages which this affected