### PR TITLE
Fix a bug where pages with `<text/>` as their body, instead of `<text…

### DIFF
--- a/tests/test_self_closing_text_tag.py
+++ b/tests/test_self_closing_text_tag.py
@@ -1,0 +1,266 @@
+"""
+Tests for self-closing <text/> handling in WikiExtractor.py's
+collect_pages() and load_templates().
+
+Real MediaWiki dumps write a revision with zero bytes of content as a
+self-closing tag with no separate closing tag at all:
+    <text bytes="0" sha1="..." />
+rather than the normal <text ...>content</text> pair. Confirmed
+directly against a real Sindhi Wikipedia dump: neither function
+recognized this form at all -- both only ever handled "no matching
+</text> arrives on this line" as the ordinary, still-open case
+(inText = True), with no check for whether the tag that was just
+opened is actually self-closing. Since a self-closing tag's matching
+"</text>" never arrives at all, inText stayed stuck True forever,
+silently merging every SUBSEQUENT line -- including the next page's
+own <ns>/<id>/<revision>/<contributor> metadata and its real body text
+-- into what was supposed to be the empty page's own (nonexistent)
+text.
+
+Concretely, this meant: a page immediately following an empty one got
+the EMPTY page's id, while showing the FOLLOWING page's own title, and
+its extracted text contained the following page's own XML metadata as
+literal, HTML-escaped junk (confirmed as the exact, real-world source
+of a "leaked metadata" pattern that surfaced independently while
+investigating an unrelated redirect-handling change).
+
+Fixed by checking whether the character immediately before the tag's
+closing '>' is '/' -- the same distinguishing signal already used
+elsewhere in this project for the identical self-closing-vs-open
+question (see extract.py's discardElements fix). When it is, the tag
+contributes nothing to the page's text and inText is never set at all,
+rather than being set and left with no way to ever turn back off.
+
+Run with:
+    python -m unittest tests.test_self_closing_text_tag -v
+or, from the tests/ directory:
+    python -m unittest test_self_closing_text_tag -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.WikiExtractor as we
+
+
+class SelfClosingTextTagTestCase(unittest.TestCase):
+
+    def collect(self, xml_text):
+        lines = xml_text.splitlines(keepends=True)
+        return list(we.collect_pages(lines))
+
+
+class EmptyPageDoesNotAbsorbFollowingPageTests(SelfClosingTextTagTestCase):
+
+    def test_page_after_empty_page_keeps_its_own_id_and_title(self):
+        xml = '''<mediawiki>
+  <page>
+    <title>Empty Page</title>
+    <ns>0</ns>
+    <id>1</id>
+    <revision>
+      <id>100</id>
+      <text bytes="0" sha1="abc" />
+    </revision>
+  </page>
+  <page>
+    <title>Real Article</title>
+    <ns>0</ns>
+    <id>2</id>
+    <revision>
+      <id>101</id>
+      <text>Real article content.</text>
+    </revision>
+  </page>
+</mediawiki>'''
+        pages = self.collect(xml)
+        titles = {p[2]: p for p in pages}
+        self.assertIn('Real Article', titles)
+        page_id, revid, title, page = titles['Real Article']
+        self.assertEqual(page_id, '2')
+        self.assertEqual(''.join(page), 'Real article content.')
+
+    def test_following_page_text_contains_no_leaked_metadata(self):
+        xml = '''<mediawiki>
+  <page>
+    <title>Empty Page</title>
+    <ns>0</ns>
+    <id>1</id>
+    <revision>
+      <id>100</id>
+      <text bytes="0" sha1="abc" />
+    </revision>
+  </page>
+  <page>
+    <title>Real Article</title>
+    <ns>0</ns>
+    <id>2</id>
+    <revision>
+      <id>101</id>
+      <contributor>
+        <username>SomeEditor</username>
+      </contributor>
+      <text>Real article content.</text>
+    </revision>
+  </page>
+</mediawiki>'''
+        pages = self.collect(xml)
+        titles = {p[2]: p for p in pages}
+        page_id, revid, title, page = titles['Real Article']
+        text = ''.join(page)
+        self.assertNotIn('<contributor>', text)
+        self.assertNotIn('SomeEditor', text)
+        self.assertEqual(text, 'Real article content.')
+
+    def test_multiple_consecutive_empty_pages(self):
+        xml = '''<mediawiki>
+  <page>
+    <title>Empty One</title>
+    <ns>0</ns>
+    <id>1</id>
+    <revision>
+      <id>100</id>
+      <text bytes="0" sha1="a" />
+    </revision>
+  </page>
+  <page>
+    <title>Empty Two</title>
+    <ns>0</ns>
+    <id>2</id>
+    <revision>
+      <id>101</id>
+      <text bytes="0" sha1="b" />
+    </revision>
+  </page>
+  <page>
+    <title>Real Article After Two Empties</title>
+    <ns>0</ns>
+    <id>3</id>
+    <revision>
+      <id>102</id>
+      <text>Content after two empty pages.</text>
+    </revision>
+  </page>
+</mediawiki>'''
+        pages = self.collect(xml)
+        titles = {p[2]: p for p in pages}
+        page_id, revid, title, page = titles['Real Article After Two Empties']
+        self.assertEqual(page_id, '3')
+        self.assertEqual(''.join(page), 'Content after two empty pages.')
+
+
+class OrdinaryFormsStillWorkTests(SelfClosingTextTagTestCase):
+    """Sanity check: the ordinary, already-working forms (multi-line
+    text, and open+close on the same line) are unaffected.
+    """
+
+    def test_multiline_text(self):
+        xml = '''<mediawiki>
+  <page>
+    <title>Multiline Article</title>
+    <ns>0</ns>
+    <id>1</id>
+    <revision>
+      <id>100</id>
+      <text>Line one.
+Line two.
+Line three.</text>
+    </revision>
+  </page>
+</mediawiki>'''
+        pages = self.collect(xml)
+        self.assertEqual(len(pages), 1)
+        page_id, revid, title, page = pages[0]
+        self.assertEqual(''.join(page), 'Line one.\nLine two.\nLine three.')
+
+    def test_same_line_open_close(self):
+        xml = '''<mediawiki>
+  <page>
+    <title>Single Line Article</title>
+    <ns>0</ns>
+    <id>1</id>
+    <revision>
+      <id>100</id>
+      <text>All content on one line.</text>
+    </revision>
+  </page>
+</mediawiki>'''
+        pages = self.collect(xml)
+        self.assertEqual(len(pages), 1)
+        page_id, revid, title, page = pages[0]
+        self.assertEqual(''.join(page), 'All content on one line.')
+
+
+class TemplateContaminationTests(unittest.TestCase):
+    """load_templates() has an identical copy of the same bug --
+    worse in consequence than the article case, since a template that
+    ends up contaminated this way gets re-expanded into every article
+    that calls it, not just the one page immediately following the
+    empty one in the dump.
+    """
+
+    def setUp(self):
+        import wikiextractor.extract as ex
+        ex.templates.clear()
+        ex.templateCache.clear()
+        ex.redirects.clear()
+
+    def load(self, xml_text):
+        import io
+        import wikiextractor.WikiExtractor as we
+        we.load_templates(io.StringIO(xml_text))
+
+    def test_template_after_blanked_template_is_not_contaminated(self):
+        import wikiextractor.extract as ex
+        xml = '''<mediawiki>
+  <page>
+    <title>Template:Blanked</title>
+    <ns>10</ns>
+    <id>500</id>
+    <revision>
+      <id>900</id>
+      <text bytes="0" sha1="abc" />
+    </revision>
+  </page>
+  <page>
+    <title>Template:Infobox person</title>
+    <ns>10</ns>
+    <id>501</id>
+    <revision>
+      <id>901</id>
+      <contributor>
+        <username>SomeEditor</username>
+      </contributor>
+      <text>The real infobox content for {{{name}}}.</text>
+    </revision>
+  </page>
+</mediawiki>'''
+        self.load(xml)
+        self.assertNotIn('Template:Blanked', ex.templates)
+        self.assertIn('Template:Infobox person', ex.templates)
+        content = ex.templates['Template:Infobox person']
+        self.assertNotIn('<contributor>', content)
+        self.assertNotIn('SomeEditor', content)
+        self.assertEqual(content, 'The real infobox content for {{{name}}}.')
+
+    def test_a_genuinely_empty_template_does_not_crash_define_template(self):
+        # Exposed by the fix above: once collect_pages()/
+        # load_templates() correctly recognize a self-closing <text/>
+        # instead of silently merging in the next page's content,
+        # define_template() can now genuinely be called with an empty
+        # page list -- which it previously never needed to handle,
+        # since the merge bug always made page non-empty by the time
+        # it got there.
+        import wikiextractor.extract as ex
+        try:
+            ex.define_template('Template:Blanked', [])
+        except IndexError:
+            self.fail("define_template() crashed on a genuinely empty page list")
+        self.assertNotIn('Template:Blanked', ex.templates)
+        self.assertNotIn('Template:Blanked', ex.redirects)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -259,6 +259,15 @@ def load_templates(file, output_file=None):
                     Extractor.templatePrefix = title[:colon + 1]
             # FIXME: should reconstruct also moduleNamespace
         elif tag == 'text':
+            tag_end = line.index('>', m.start(2))
+            if line[tag_end - 1] == '/':
+                # See the identical fix and comment in collect_pages()
+                # -- self-closing <text .../> (a revision with no
+                # content) previously left inText stuck True forever,
+                # silently merging every subsequent line, including
+                # the next template's own metadata and body, into
+                # whatever entry was currently being built.
+                continue
             inText = True
             line = line[m.start(3):m.end(3)]
             page.append(line)
@@ -343,6 +352,17 @@ def collect_pages(text):
         elif tag == 'redirect':
             redirect = True
         elif tag == 'text':
+            tag_end = line.index('>', m.start(2))
+            if line[tag_end - 1] == '/':
+                # <text bytes="0" .../> -- a revision with no content
+                # at all. No matching </text> will ever arrive for
+                # this specific tag, since it's self-closing; treating
+                # it as an ordinary, still-open text element (as
+                # before this fix) left inText stuck True forever,
+                # silently merging every subsequent line -- including
+                # the next page's own metadata and content -- into
+                # this (empty) page.
+                continue
             inText = True
             line = line[m.start(3):m.end(3)]
             page.append(line)

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -2433,6 +2433,18 @@ def define_template(title, page):
 
     # title = normalizeTitle(title)
 
+    # An empty page (zero lines) is a genuine, valid case for a
+    # template whose current revision has no content at all (a
+    # self-closing <text bytes="0" .../> in the source) -- not a
+    # redirect, and not any real content either. Confirmed this is
+    # reachable now that collect_pages()/load_templates() correctly
+    # recognize that self-closing form instead of silently merging the
+    # next page's content into this one (which previously masked this
+    # case entirely, since page was never actually empty by the time
+    # it reached here).
+    if not page:
+        return
+
     # check for redirects
     m = re.match(r'#REDIRECT.*?\[\[([^\]]*)]]', page[0], re.IGNORECASE)
     if m:


### PR DESCRIPTION
Fix a bug where pages with `<text/>` as their body, instead of `<text…>body</text>`, were treated as if they had body up until the next page's close `</text>` tag.  Not ideal (these were actually just empty pages)

Also fix blank documents in extract.py

This removes artifacts which were escaped blocks describing the page, such as this block produced in the SKR wikipedia:

```
>  &lt;ns&gt;0&lt;/ns&gt;
>  &lt;revision&gt;
>  &lt;parentid&gt;20627&lt;/parentid&gt;
>  &lt;timestamp&gt;2021-02-16T14:07:37Z&lt;/timestamp&gt;
>  &lt;contributor&gt;
>  &lt;username&gt;Engr.ismailbhutta&lt;/username&gt;
>  &lt;/contributor&gt;
>  &lt;origin&gt;20628&lt;/origin&gt;
>  &lt;model&gt;wikitext&lt;/model&gt;
>  &lt;format&gt;text/x-wiki&lt;/format&gt;
```