### PR TITLE
Ref tags with slash

### DIFF
--- a/tests/test_quote_aware_tag_matching.py
+++ b/tests/test_quote_aware_tag_matching.py
@@ -1,0 +1,139 @@
+"""
+Tests for quote-aware tag matching in extract.py (lineBreak_tag_patterns,
+selfClosing_tag_patterns, and discardElements' opening pattern).
+
+A literal '>' inside a quoted attribute value is legal HTML -- e.g.
+<br style="a > b" /> -- and doesn't end the tag; confirmed directly
+against a real HTML tokenizer, which correctly tracks quote state.
+The plain [^>]* character class these patterns previously used has no
+concept of quote state at all: it simply stops at the first '>' it
+sees, wherever that is. That truncated the match at the inner '>',
+leaving the tag's own real ending stranded as literal, escaped text
+afterward.
+
+Fixed with the standard "quoted-string-or-single-character" alternation
+((?:"[^"]*"|'[^']*'|[^>])*), which treats a full quoted string as one
+atomic unit rather than character-by-character. That alone isn't
+sufficient, though -- discovered directly, not assumed: combined with
+discardElements' (?<!/) self-closing exclusion, the two interact
+badly. When the "correct" (quote-respecting) parse fails the (?<!/)
+check -- i.e. the tag genuinely IS self-closing, e.g.
+<ref style="a > b" /> -- plain backtracking falls back to
+re-interpreting the quote characters as individual [^>] matches
+instead of giving up, finding a DIFFERENT, wrong match that ends at
+the quoted value's own inner '>'. Fixed with the (?=(...))\\1
+lookahead+backreference trick, which emulates atomic/possessive
+matching portably (works on Python versions before 3.11's native
+atomic groups too): once a quoted string is matched, the engine can
+never backtrack into re-interpreting its own quote characters.
+
+Also confirmed and tested here (see NormalCasesUnaffectedTests /
+GenuineSelfClosingStillHandledTests): this doesn't change behavior for
+any of the ordinary cases already covered by earlier fixes -- bare
+tags, a literal slash inside an attribute value (unrelated to quoting,
+a separate earlier fix), and genuine self-closing tags without quoted
+attributes at all.
+
+Run with:
+    python -m unittest tests.test_quote_aware_tag_matching -v
+or, from the tests/ directory:
+    python -m unittest test_quote_aware_tag_matching -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+from wikiextractor.extract import Extractor
+import wikiextractor.extract as ex
+
+
+class QuoteAwareTagMatchingTestCase(unittest.TestCase):
+
+    def setUp(self):
+        ex.templates.clear()
+        ex.templateCache.clear()
+        ex.redirects.clear()
+        ex.Extractor.templatePrefix = "Template:"
+
+    def get_result(self, article_text):
+        extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
+                               "Test Article", [article_text])
+        return extractor.clean_text(article_text, expand_templates=True)
+
+
+class LineBreakTagQuoteAwarenessTests(QuoteAwareTagMatchingTestCase):
+    """lineBreak_tag_patterns (br/hr) -- the exact case reported."""
+
+    def test_quoted_greater_than_with_self_closing_slash(self):
+        text = 'word<br style="a > b" />word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["word word"])
+
+    def test_quoted_greater_than_without_self_closing_slash(self):
+        text = 'word<br style="a > b">word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["word word"])
+
+    def test_ordinary_forms_still_work(self):
+        for text, label in [
+            ('word<br>word', 'bare'),
+            ('word<br/>word', 'self-closing, no space'),
+            ('word<br />word', 'self-closing, with space'),
+        ]:
+            with self.subTest(label=label):
+                result = self.get_result(text)
+                self.assertEqual(result, ["word word"])
+
+
+class DiscardElementsQuoteAwarenessTests(QuoteAwareTagMatchingTestCase):
+    """discardElements' opening pattern (ref, div, etc.) -- the harder
+    case, since the self-closing exclusion (?<!/) has to coexist with
+    quote-awareness correctly.
+    """
+
+    def test_quoted_greater_than_with_self_closing_slash_correctly_not_matched_as_open(self):
+        # Genuinely self-closing -- must NOT be treated as a
+        # discardElements-style content-wrapping open at all.
+        text = 'word<ref style="a > b" />word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+    def test_quoted_greater_than_paired_non_self_closing(self):
+        text = 'word<ref style="a > b">content</ref>word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+
+class NormalCasesUnaffectedTests(QuoteAwareTagMatchingTestCase):
+    """Sanity check: ordinary cases, and the earlier slash-in-attribute
+    fix, still behave exactly as before this change.
+    """
+
+    def test_bare_tag(self):
+        text = 'word<ref>content</ref>word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+    def test_slash_in_attribute_value_unrelated_to_quoting(self):
+        text = 'word<ref name="geo/18aug2018-1">content</ref>word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+
+class GenuineSelfClosingStillHandledTests(QuoteAwareTagMatchingTestCase):
+
+    def test_self_closing_no_quoted_attributes(self):
+        text = 'word<ref name="x" />word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+    def test_nobr_self_closing_with_quoted_greater_than(self):
+        text = 'word<nobr style="a > b" />word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/text_discard_element_slash.py
+++ b/tests/text_discard_element_slash.py
@@ -1,0 +1,115 @@
+"""
+Tests for discardElements' opening-tag pattern fix in extract.py.
+
+discardElements (table, tr, td, th, div, ref, and others) drops a tag
+AND its content together, via dropNested() matching (open, close)
+pairs. Its opening-tag pattern previously excluded '/' entirely from
+the attribute-matching character class ([^>/]*) -- intended to avoid
+matching a genuine self-closing tag (e.g. <ref name="x" />, which
+reuses an earlier-defined reference and is handled separately by
+selfClosing_tag_patterns, not discardElements) as if it were a
+content-wrapping open.
+
+But that blanket exclusion also broke matching for any opening tag
+whose ATTRIBUTE VALUE happens to contain a literal '/' -- e.g. a real
+<ref name="geo/18aug2018-1"> found in an actual Saraiki Wikipedia
+article, where the reference name itself includes a slash. The
+opening tag's own pattern then failed to match at all, surviving as
+literal, escaped text -- while its closing </ref> (left unpaired by
+the failed opening match) got correctly stripped by the
+orphaned-close-tag handling elsewhere, producing the confusing
+"opening tag remains, closing tag vanished" result this fix addresses.
+
+Fixed via a negative lookbehind, (?<!/), rather than excluding '/'
+from the character class outright: matches any characters up to '>'
+freely (including '/' anywhere within an attribute value), only
+excluding the specific case where '/' sits immediately before the
+final '>' -- which is what actually indicates a genuine self-closing
+tag, not the mere presence of a slash anywhere in the attributes.
+
+Run with:
+    python -m unittest tests.test_discard_element_slash_in_attribute -v
+or, from the tests/ directory:
+    python -m unittest test_discard_element_slash_in_attribute -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+from wikiextractor.extract import Extractor
+import wikiextractor.extract as ex
+
+
+class SlashInAttributeTestCase(unittest.TestCase):
+
+    def setUp(self):
+        ex.templates.clear()
+        ex.templateCache.clear()
+        ex.redirects.clear()
+        ex.Extractor.templatePrefix = "Template:"
+
+    def get_result(self, article_text):
+        extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
+                               "Test Article", [article_text])
+        return extractor.clean_text(article_text, expand_templates=True)
+
+
+class SlashInAttributeValueTests(SlashInAttributeTestCase):
+
+    def test_slash_within_attribute_value_still_discards_tag_and_content(self):
+        text = 'word<ref name="geo/18aug2018-1">content</ref>word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+    def test_real_world_saraiki_case(self):
+        # The exact real case this fix was found on.
+        text = ('عثمان بزدار&lt;ref name="geo/18aug2018-1"&gt; news '
+                '|title=PTI nominee|date=18 اگست 2018&lt;/ref&gt; مقامی میڈیا')
+        result = self.get_result(text)
+        self.assertEqual(result, ["عثمان بزدار مقامی میڈیا"])
+
+    def test_multiple_slashes_in_attribute_value(self):
+        text = 'word<ref name="a/b/c/d">content</ref>word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+
+class NormalCasesUnaffectedTests(SlashInAttributeTestCase):
+    """Sanity check: ordinary cases (no slash at all, or a bare tag)
+    still behave exactly as before.
+    """
+
+    def test_bare_tag_no_attributes(self):
+        text = 'word<ref>content</ref>word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+    def test_attribute_with_no_slash(self):
+        text = 'word<ref name="geo18aug2018">content</ref>word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+
+class GenuineSelfClosingTagStillHandledTests(SlashInAttributeTestCase):
+    """The case the original '/'-exclusion was actually trying to
+    protect: a genuine self-closing tag (reusing an earlier-defined
+    reference) must not be treated as a discardElements-style
+    content-wrapping open -- it's handled separately, by
+    selfClosing_tag_patterns.
+    """
+
+    def test_self_closing_ref_with_space_before_slash(self):
+        text = 'word<ref name="x" />word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+    def test_self_closing_ref_no_space_before_slash(self):
+        text = 'word<ref name="x"/>word'
+        result = self.get_result(text)
+        self.assertEqual(result, ["wordword"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -223,7 +223,22 @@ def clean(extractor, text, expand_templates=False, html_safe=True):
     # Drop discarded elements
     for tag in discardElements:
         close_pattern = r'<\s*/\s*%s\s*>' % tag
-        text = dropNested(text, r'<\s*%s\b[^>/]*>' % tag, close_pattern)
+        # [^>]*(?<!/) rather than [^>/]*: attribute values can
+        # legitimately contain a literal '/' (e.g. a ref name like
+        # "geo/18aug2018-1"), which the old, blanket '/'-excluding
+        # character class broke on -- the opening tag simply failed
+        # to match at all, surviving as literal text, while its
+        # closing tag (left unpaired) got correctly stripped by the
+        # orphaned-close-tag handling below, producing a mismatched
+        # "closing tag vanished, opening tag remains" result. Only a
+        # '/' immediately before the final '>' should be excluded here
+        # -- that's a genuine self-closing tag (e.g. <ref name="x" />,
+        # already handled separately by selfClosing_tag_patterns
+        # above), not a wrapping open that discardElements should
+        # pair up.
+        # An example of this occurred in doc 1795 (and many others)
+        # in the Saraiki wiki dump of 2026-07-01
+        text = dropNested(text, r'<\s*%s\b[^>]*(?<!/)>' % tag, close_pattern)
         # dropNested only ever removes a close tag as part of a
         # matched (open, close) pair -- an unpaired one
         # (its own opening tag consumed or malformed elsewhere, e.g. by

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -236,9 +236,17 @@ def clean(extractor, text, expand_templates=False, html_safe=True):
         # already handled separately by selfClosing_tag_patterns
         # above), not a wrapping open that discardElements should
         # pair up.
-        # An example of this occurred in doc 1795 (and many others)
-        # in the Saraiki wiki dump of 2026-07-01
-        text = dropNested(text, r'<\s*%s\b[^>]*(?<!/)>' % tag, close_pattern)
+        # (?=(...))\1 emulates an atomic/possessive match for the
+        # quoted alternatives (see lineBreak_tag_patterns above for
+        # the full reasoning) -- needed here specifically because
+        # without it, the (?<!/) exclusion below can force a
+        # backtrack that falls back to treating quote characters as
+        # plain [^>] matches, finding a WRONG match that ends at a
+        # quoted value's own inner '>' instead of failing to match
+        # (correctly) on a genuine self-closing tag like
+        # <ref style="a > b" />.
+        text = dropNested(text, r'''<\s*%s\b(?:(?=("[^"]*"|'[^']*'|[^>]))\1)*(?<!/)>''' % tag,
+                           close_pattern)
         # dropNested only ever removes a close tag as part of a
         # matched (open, close) pair -- an unpaired one
         # (its own opening tag consumed or malformed elsewhere, e.g. by
@@ -1193,8 +1201,14 @@ selfClosing_tag_patterns = [
     # MediaWiki usage (it loads CSS for a template's rendering, never
     # wraps real content), so the strict pattern doesn't lose anything
     # for it either.
-    re.compile(r'<\s*%s\b[^>]*/?\s*>' % tag if tag == 'nobr'
-               else r'<\s*%s\b[^>]*/\s*>' % tag,
+    # (?=(...))\1 emulates an atomic/possessive match for the quoted
+    # alternatives (see lineBreak_tag_patterns below for the full
+    # reasoning) -- without it, a literal '>' inside a quoted
+    # attribute value (e.g. <ref style="a > b" />) would prevent this
+    # from matching at all, since [^>]* alone stops at that inner '>'
+    # and can never find the real, required trailing '/' after it.
+    re.compile(r'''<\s*%s\b(?:(?=("[^"]*"|'[^']*'|[^>]))\1)*/?\s*>''' % tag if tag == 'nobr'
+               else r'''<\s*%s\b(?:(?=("[^"]*"|'[^']*'|[^>]))\1)*/\s*>''' % tag,
                re.DOTALL | re.IGNORECASE)
     for tag in selfClosingTags
 ]
@@ -1205,7 +1219,19 @@ selfClosing_tag_patterns = [
 # or even a bare <br> -- is just as valid a "line break" instance as
 # <br/>), but substituted with a space instead of bulk-deleted.
 lineBreak_tag_patterns = [
-    re.compile(r'<\s*%s\b[^>]*/?\s*>' % tag, re.DOTALL | re.IGNORECASE)
+    # (?=(...))\1 emulates an atomic/possessive match for the quoted
+    # alternatives, portably (works pre-3.11 too, unlike native atomic
+    # groups): once a quoted string is matched, the engine can never
+    # backtrack into re-interpreting its own quote characters as
+    # individual [^>] matches -- confirmed directly this matters, not
+    # just theoretical: without it, a literal '>' inside a quoted
+    # attribute value (e.g. <br style="a > b" />, legal HTML -- a
+    # literal '>' inside a quoted value doesn't end the tag, confirmed
+    # against a real HTML tokenizer) truncates the match early, at
+    # that inner '>', leaving the tag's own real ending stranded as
+    # literal text afterward.
+    re.compile(r'''<\s*%s\b(?:(?=("[^"]*"|'[^']*'|[^>]))\1)*>''' % tag,
+               re.DOTALL | re.IGNORECASE)
     for tag in lineBreakTags
 ]
 


### PR DESCRIPTION
If a ref tag has a slash in quoted attributes - or even a `>` apparent closing tag - this should not actually terminate the processing of the tag.  For example, there are legitimate tags which look like

`<ref name="brecorder/12feb2012">`

throughout various datasets, this example coming from SKR.  These tags should be processed the same as any other ref tag.

With the help of Claude, this change extends the tag matching regex to allow for `/` or `>` in quoted attributes.