### PR TITLE
Use utf-8 as the default encoding when writing, to avoid encoding err…

### DIFF
--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -208,9 +208,9 @@ class OutputSplitter():
     def open(self, filename):
         self.size = 0
         if self.compress:
-            return bz2.open(filename + '.bz2', 'wt')
+            return bz2.open(filename + '.bz2', 'wt', encoding='utf-8')
         else:
-            return open(filename, 'w')
+            return open(filename, 'w', encoding='utf-8')
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Use utf-8 as the default encoding when writing, to avoid encoding errors on platforms such as Windows
