### PR TITLE
Try two different import mechanisms for getting OutputSplitter in cir…

### DIFF
--- a/wikiextractor/cirrus-extract.py
+++ b/wikiextractor/cirrus-extract.py
@@ -42,7 +42,10 @@ import bz2
 import gzip
 import logging
 
-from .WikiExtractor import NextFile, OutputSplitter
+try:
+    from .WikiExtractor import NextFile, OutputSplitter
+except ImportError:
+    from WikiExtractor import NextFile, OutputSplitter
 
 # Program version
 version = '3.0'


### PR DESCRIPTION
…rus-extract.  Related to https://github.com/WikiExtractor/wikiextractor/pull/234 - WikiExtractor might not actually be in the classpath depending on how this is run