### PR TITLE
Put lru_cache on the template processing steps

### DIFF
--- a/tests/test_block_separator_tags.py
+++ b/tests/test_block_separator_tags.py
@@ -46,7 +46,8 @@ class BlockSeparatorTagsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_block_separator_tags.py
+++ b/tests/test_block_separator_tags.py
@@ -46,7 +46,7 @@ class BlockSeparatorTagsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_brace_matching.py
+++ b/tests/test_brace_matching.py
@@ -165,7 +165,7 @@ class RecursiveNestingEndToEndTests(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
@@ -223,7 +223,7 @@ class RecursiveNestingWeirdCountsEndToEndTests(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
@@ -259,7 +259,7 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_brace_matching.py
+++ b/tests/test_brace_matching.py
@@ -165,7 +165,8 @@ class RecursiveNestingEndToEndTests(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
@@ -223,7 +224,8 @@ class RecursiveNestingWeirdCountsEndToEndTests(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
@@ -259,7 +261,8 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_comment_removal.py
+++ b/tests/test_comment_removal.py
@@ -42,7 +42,7 @@ class CommentRemovalTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_comment_removal.py
+++ b/tests/test_comment_removal.py
@@ -42,7 +42,8 @@ class CommentRemovalTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_discard_element_slash.py
+++ b/tests/test_discard_element_slash.py
@@ -46,7 +46,7 @@ class SlashInAttributeTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_discard_element_slash.py
+++ b/tests/test_discard_element_slash.py
@@ -46,7 +46,8 @@ class SlashInAttributeTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_discard_elements.py
+++ b/tests/test_discard_elements.py
@@ -81,7 +81,7 @@ class DiscardElementsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_discard_elements.py
+++ b/tests/test_discard_elements.py
@@ -81,7 +81,8 @@ class DiscardElementsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_empty_section_dropping.py
+++ b/tests/test_empty_section_dropping.py
@@ -43,7 +43,8 @@ class EmptySectionDroppingTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_empty_section_dropping.py
+++ b/tests/test_empty_section_dropping.py
@@ -43,7 +43,7 @@ class EmptySectionDroppingTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_frame_cleanup.py
+++ b/tests/test_frame_cleanup.py
@@ -41,7 +41,8 @@ class FrameCleanupOnExceptionTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_frame_cleanup.py
+++ b/tests/test_frame_cleanup.py
@@ -41,7 +41,7 @@ class FrameCleanupOnExceptionTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_ignored_tags.py
+++ b/tests/test_ignored_tags.py
@@ -43,7 +43,8 @@ class IgnoredTagsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_ignored_tags.py
+++ b/tests/test_ignored_tags.py
@@ -43,7 +43,7 @@ class IgnoredTagsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_new_tags.py
+++ b/tests/test_new_tags.py
@@ -59,7 +59,7 @@ class NewTagsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
 
     def get_result(self, text):

--- a/tests/test_new_tags.py
+++ b/tests/test_new_tags.py
@@ -59,7 +59,8 @@ class NewTagsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
 
     def get_result(self, text):

--- a/tests/test_noinclude_removal.py
+++ b/tests/test_noinclude_removal.py
@@ -49,7 +49,7 @@ class NoincludeTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_noinclude_removal.py
+++ b/tests/test_noinclude_removal.py
@@ -49,7 +49,8 @@ class NoincludeTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_orphaned_discard_close_tags.py
+++ b/tests/test_orphaned_discard_close_tags.py
@@ -49,7 +49,8 @@ class OrphanedDiscardCloseTagTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_orphaned_discard_close_tags.py
+++ b/tests/test_orphaned_discard_close_tags.py
@@ -49,7 +49,7 @@ class OrphanedDiscardCloseTagTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_quote_aware_tag_matching.py
+++ b/tests/test_quote_aware_tag_matching.py
@@ -53,7 +53,7 @@ class QuoteAwareTagMatchingTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_quote_aware_tag_matching.py
+++ b/tests/test_quote_aware_tag_matching.py
@@ -53,7 +53,8 @@ class QuoteAwareTagMatchingTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_redirect_keywords.py
+++ b/tests/test_redirect_keywords.py
@@ -59,7 +59,8 @@ class RedirectKeywordsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
 
 

--- a/tests/test_redirect_keywords.py
+++ b/tests/test_redirect_keywords.py
@@ -59,7 +59,7 @@ class RedirectKeywordsTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
 
 

--- a/tests/test_self_closing_text_tag.py
+++ b/tests/test_self_closing_text_tag.py
@@ -204,7 +204,8 @@ class TemplateContaminationTests(unittest.TestCase):
     def setUp(self):
         import wikiextractor.extract as ex
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
 
     def load(self, xml_text):

--- a/tests/test_self_closing_text_tag.py
+++ b/tests/test_self_closing_text_tag.py
@@ -204,7 +204,7 @@ class TemplateContaminationTests(unittest.TestCase):
     def setUp(self):
         import wikiextractor.extract as ex
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
 
     def load(self, xml_text):

--- a/tests/test_selfclosing_tags.py
+++ b/tests/test_selfclosing_tags.py
@@ -75,7 +75,7 @@ class VoidElementTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_selfclosing_tags.py
+++ b/tests/test_selfclosing_tags.py
@@ -75,7 +75,8 @@ class VoidElementTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_sharp_invoke_alias.py
+++ b/tests/test_sharp_invoke_alias.py
@@ -59,7 +59,8 @@ class SharpInvokeAliasTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
         # a minimal, deliberately-"no conversion" stand-in matching

--- a/tests/test_sharp_invoke_alias.py
+++ b/tests/test_sharp_invoke_alias.py
@@ -59,7 +59,7 @@ class SharpInvokeAliasTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
         # a minimal, deliberately-"no conversion" stand-in matching

--- a/tests/test_template_boundary_newline_collapse.py
+++ b/tests/test_template_boundary_newline_collapse.py
@@ -75,7 +75,8 @@ class NewlineCollapseTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_template_boundary_newline_collapse.py
+++ b/tests/test_template_boundary_newline_collapse.py
@@ -75,7 +75,7 @@ class NewlineCollapseTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 

--- a/tests/test_template_loop_guard.py
+++ b/tests/test_template_loop_guard.py
@@ -49,14 +49,14 @@ import wikiextractor.extract as ex
 
 class TemplateLoopGuardTestCase(unittest.TestCase):
     """Base class that resets wikiextractor's module-level template state
-    before each test. `templates`, `templateCache`, and `redirects` are
+    before each test. `templates` and `redirects` are
     plain module globals in extract.py (populated by define_template),
     so tests must not leak state into one another.
     """
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         # Normally set by load_templates() when scanning a real dump's
         # first Template-namespace page; tests define templates directly

--- a/tests/test_template_loop_guard.py
+++ b/tests/test_template_loop_guard.py
@@ -56,7 +56,8 @@ class TemplateLoopGuardTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         # Normally set by load_templates() when scanning a real dump's
         # first Template-namespace page; tests define templates directly

--- a/tests/test_text_format.py
+++ b/tests/test_text_format.py
@@ -42,7 +42,8 @@ class TextFormatTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.Template.parse.cache_clear()
+        ex.TemplateArg._parse_template.cache_clear()
+        ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
         # Reset all three output-format flags to their defaults; each

--- a/tests/test_text_format.py
+++ b/tests/test_text_format.py
@@ -42,7 +42,7 @@ class TextFormatTestCase(unittest.TestCase):
 
     def setUp(self):
         ex.templates.clear()
-        ex.templateCache.clear()
+        ex.Template.parse.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
         # Reset all three output-format flags to their defaults; each

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -790,7 +790,6 @@ minFileSize = 200 * 1024
 
 def main():
     global acceptedNamespaces
-    global templateCache
 
     parser = argparse.ArgumentParser(prog=os.path.basename(sys.argv[0]),
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -897,10 +896,6 @@ def main():
 
     if not Extractor.keepLinks:
         ignoreTag('a')
-
-    # sharing cache of parser templates is too slow:
-    # manager = Manager()
-    # templateCache = manager.dict()
 
     if args.article:
         if args.templates:

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -23,6 +23,7 @@ import html
 import json
 import ast
 import operator
+from functools import lru_cache
 from itertools import zip_longest
 from urllib.parse import quote as urlencode
 from html.entities import name2codepoint
@@ -1300,8 +1301,9 @@ class Template(list):
     A Template is a list of TemplateText or TemplateArgs
     """
 
-    @classmethod
-    def parse(cls, body):
+    @staticmethod
+    @lru_cache(maxsize=10000)
+    def parse(body):
         tpl = Template()
         # we must handle nesting, s.a.
         # {{{1|{{PAGENAME}}}
@@ -1745,13 +1747,8 @@ class Extractor():
             title = redirected
 
         # get the template
-        if title in templateCache:
-            template = templateCache[title]
-        elif title in templates:
+        if title in templates:
             template = Template.parse(templates[title])
-            # add it to cache
-            templateCache[title] = template
-            del templates[title]
         else:
             # The page being included could not be identified
             return ''
@@ -2492,9 +2489,6 @@ reIncludeonly = re.compile(r'<includeonly>|</includeonly>', re.DOTALL)
 # These are built before spawning processes, hence they are shared.
 templates = {}
 redirects = {}
-# cache of parser templates
-# FIXME: sharing this with a Manager slows down.
-templateCache = {}
 
 
 def define_template(title, page):

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -1302,7 +1302,6 @@ class Template(list):
     """
 
     @staticmethod
-    @lru_cache(maxsize=10000)
     def parse(body):
         tpl = Template()
         # we must handle nesting, s.a.
@@ -1384,12 +1383,17 @@ class TemplateArg():
         #logger.debug('TemplateArg %s', parameter)
 
         parts = splitParts(parameter)
-        self.name = Template.parse(parts[0])
+        self.name = TemplateArg._parse_template(parts[0])
         if len(parts) > 1:
             # This parameter has a default value
-            self.default = Template.parse(parts[1])
+            self.default = TemplateArg._parse_template(parts[1])
         else:
             self.default = None
+
+    @staticmethod
+    @lru_cache(maxsize=10000)
+    def _parse_template(arg):
+        return Template.parse(arg)
 
     def __str__(self):
         if self.default:
@@ -1656,6 +1660,11 @@ class Extractor():
         logger.debug('   templateParams> %s', '|'.join(templateParams.values()))
         return templateParams
 
+    @staticmethod
+    @lru_cache(maxsize=10000)
+    def _parse_template(template):
+        return Template.parse(template)
+
     def expandTemplate(self, body):
         """Expands template invocation.
         :param body: the parts of a template.
@@ -1748,7 +1757,7 @@ class Extractor():
 
         # get the template
         if title in templates:
-            template = Template.parse(templates[title])
+            template = Extractor._parse_template(templates[title])
         else:
             # The page being included could not be identified
             return ''


### PR DESCRIPTION
In a high process constrained ram environment, putting lru_cache on the template processing code makes it less likely to run out of memory.  For example, a 32 process EN extraction in only 8GB (the setting I get by default on our work cluster) makes it to BG instead of AK before being stuck because a subprocess was terminated for using too much memory.  Also, interestingly, it's actually a little faster to do it this way, probably because the template arg processing is also cached this way.

(Maybe we could make it further with smaller caches, but we should be able to save memory in other ways as well)