### PR TITLE
Template blob

### DIFF
--- a/tests/test_block_separator_tags.py
+++ b/tests/test_block_separator_tags.py
@@ -45,7 +45,6 @@ import wikiextractor.extract as ex
 class BlockSeparatorTagsTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_brace_matching.py
+++ b/tests/test_brace_matching.py
@@ -164,7 +164,7 @@ class RecursiveNestingEndToEndTests(unittest.TestCase):
     """
 
     def setUp(self):
-        ex.templates.clear()
+        self.templates = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
@@ -172,7 +172,7 @@ class RecursiveNestingEndToEndTests(unittest.TestCase):
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templates=self.templates)
         return extractor.clean_text(article_text, expand_templates=True)
 
     def test_six_brace_indirection_the_real_documented_example(self):
@@ -183,12 +183,12 @@ class RecursiveNestingEndToEndTests(unittest.TestCase):
         # "bar". MediaWiki namespaces auto-capitalize the first letter
         # of a title, so the template must be defined as "Template:Ppp"
         # to correctly match a call written as {{ppp|...}}.
-        ex.define_template('Template:Ppp', ['{{{{{{p}}}}}}'])
+        ex.define_template('Template:Ppp', ['{{{{{{p}}}}}}'], self.templates)
         result = self.get_result('{{ppp|p=foo|foo=bar}}')
         self.assertEqual(result, ['bar'])
 
     def test_twelve_brace_fourth_level_indirection_the_real_documented_example(self):
-        ex.define_template('Template:Tvvvv', ['{{{{{{{{{{{{p}}}}}}}}}}}}'])
+        ex.define_template('Template:Tvvvv', ['{{{{{{{{{{{{p}}}}}}}}}}}}'], self.templates)
         result = self.get_result('{{tvvvv|p=alpha|alpha=beta|beta=gamma|gamma=delta}}')
         self.assertEqual(result, ['delta'])
 
@@ -223,7 +223,7 @@ class RecursiveNestingWeirdCountsEndToEndTests(unittest.TestCase):
     """
 
     def setUp(self):
-        ex.templates.clear()
+        self.templates = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
@@ -231,14 +231,14 @@ class RecursiveNestingWeirdCountsEndToEndTests(unittest.TestCase):
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templates=self.templates)
         return extractor.clean_text(article_text, expand_templates=True)
 
     def test_seven_braces_stray_literal_brace_survives_around_resolved_value(self):
         # 7 = 2*3 + 1: two nested tplarg levels, wrapped in one leftover,
         # literal stray '{'/'}' on each side (not a valid delimiter of
         # any kind, so it just survives as plain text).
-        ex.define_template('Template:Seven', ['X{{{{{{{p}}}}}}}X'])
+        ex.define_template('Template:Seven', ['X{{{{{{{p}}}}}}}X'], self.templates)
         result = self.get_result('{{seven|p=foo|foo=bar}}')
         self.assertEqual(result, ['X{bar}X'])
 
@@ -246,8 +246,8 @@ class RecursiveNestingWeirdCountsEndToEndTests(unittest.TestCase):
         # 8 = 2*3 + 2: two nested tplarg levels resolve to a value that
         # itself becomes the NAME of a real, outer, dynamically-named
         # 2-brace template call.
-        ex.define_template('Template:Eight', ['{{{{{{{{p}}}}}}}}'])
-        ex.define_template('Template:Bar', ['outer template content'])
+        ex.define_template('Template:Eight', ['{{{{{{{{p}}}}}}}}'], self.templates)
+        ex.define_template('Template:Bar', ['outer template content'], self.templates)
         result = self.get_result('{{eight|p=foo|foo=Bar}}')
         self.assertEqual(result, ['outer template content'])
 
@@ -260,7 +260,7 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
     """
 
     def setUp(self):
-        ex.templates.clear()
+        self.templates = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
@@ -268,12 +268,12 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templates=self.templates)
         return extractor.clean_text(article_text, expand_templates=True)
 
     def test_dynamic_template_name_call_resolves_correctly(self):
-        ex.define_template('Template:Wrapper', ['{{{{{1}}}}}'])
-        ex.define_template('Template:Target', ['the real target content'])
+        ex.define_template('Template:Wrapper', ['{{{{{1}}}}}'], self.templates)
+        ex.define_template('Template:Target', ['the real target content'], self.templates)
         text = 'before {{Wrapper|Target}} after'
         result = self.get_result(text)
         self.assertEqual(result, ['before the real target content after'])
@@ -282,9 +282,8 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
         # Matches the real case this was found on: a conditional
         # wrapper that dynamically calls whatever template name was
         # passed, or falls back to plain text if no parameter was given.
-        ex.define_template('Template:Wrapper',
-                            ['{{#if:{{{1|}}}|{{{{{1}}}}}|no param given}}'])
-        ex.define_template('Template:StubNotice', ['This article is a stub.'])
+        ex.define_template('Template:Wrapper', ['{{#if:{{{1|}}}|{{{{{1}}}}}|no param given}}'], self.templates)
+        ex.define_template('Template:StubNotice', ['This article is a stub.'], self.templates)
 
         with_param = self.get_result('x {{Wrapper|StubNotice}} y')
         self.assertEqual(with_param, ['x This article is a stub. y'])
@@ -296,9 +295,9 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
         # The specific, confirmed failure mode: before the fix, this
         # dynamic call was misinterpreted as a direct call to a
         # template literally named "1".
-        ex.define_template('Template:1', ['WRONG -- this should never be reached'])
-        ex.define_template('Template:Wrapper', ['{{{{{1}}}}}'])
-        ex.define_template('Template:Target', ['correct content'])
+        ex.define_template('Template:1', ['WRONG -- this should never be reached'], self.templates)
+        ex.define_template('Template:Wrapper', ['{{{{{1}}}}}'], self.templates)
+        ex.define_template('Template:Target', ['correct content'], self.templates)
         text = '{{Wrapper|Target}}'
         result = self.get_result(text)
         self.assertEqual(result, ['correct content'])

--- a/tests/test_comment_removal.py
+++ b/tests/test_comment_removal.py
@@ -41,7 +41,6 @@ import wikiextractor.extract as ex
 class CommentRemovalTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_discard_element_slash.py
+++ b/tests/test_discard_element_slash.py
@@ -45,7 +45,6 @@ import wikiextractor.extract as ex
 class SlashInAttributeTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_discard_elements.py
+++ b/tests/test_discard_elements.py
@@ -80,7 +80,6 @@ import wikiextractor.extract as ex
 class DiscardElementsTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_empty_section_dropping.py
+++ b/tests/test_empty_section_dropping.py
@@ -42,7 +42,6 @@ import wikiextractor.extract as ex
 class EmptySectionDroppingTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_frame_cleanup.py
+++ b/tests/test_frame_cleanup.py
@@ -40,7 +40,7 @@ import wikiextractor.extract as ex
 class FrameCleanupOnExceptionTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
+        self.templates = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
@@ -48,7 +48,7 @@ class FrameCleanupOnExceptionTestCase(unittest.TestCase):
 
     def get_extractor(self, article_text):
         return Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                          "Test Article", [article_text])
+                          "Test Article", [article_text], templates=self.templates)
 
 
 class FrameStaysCleanAfterExceptionTests(FrameCleanupOnExceptionTestCase):
@@ -59,7 +59,7 @@ class FrameStaysCleanAfterExceptionTests(FrameCleanupOnExceptionTestCase):
         # expandTemplates() that isn't a #invoke-specific failure
         # (those are already caught locally by callParserFunction's
         # own bare except, before ever reaching this append/pop pair).
-        ex.define_template('Template:Poison', ['poisoned body'])
+        ex.define_template('Template:Poison', ['poisoned body'], self.templates)
 
         extractor = self.get_extractor('Before {{Poison}} after')
 
@@ -93,8 +93,8 @@ class FrameStaysCleanAfterExceptionTests(FrameCleanupOnExceptionTestCase):
         # an exception and continues on the same Extractor instance --
         # not true today, but this is what the fix actually protects
         # against.
-        ex.define_template('Template:Poison', ['poisoned body'])
-        ex.define_template('Template:Fine', ['fine body'])
+        ex.define_template('Template:Poison', ['poisoned body'], self.templates)
+        ex.define_template('Template:Fine', ['fine body'], self.templates)
 
         extractor = self.get_extractor('x')
         original_expand_templates = extractor.expandTemplates

--- a/tests/test_ignored_tags.py
+++ b/tests/test_ignored_tags.py
@@ -42,7 +42,6 @@ import wikiextractor.extract as ex
 class IgnoredTagsTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_load_templates_output_file_whitespace.py
+++ b/tests/test_load_templates_output_file_whitespace.py
@@ -74,7 +74,6 @@ class LoadTemplatesOutputFileWhitespaceTests(unittest.TestCase):
     def setUp(self):
         we.templateNamespace = ''
         ex.Extractor.templatePrefix = ''
-        ex.templates = {}
         ex.redirects.clear()
         self._tmpdir = tempfile.mkdtemp()
         self.addCleanup(self._cleanup_tmpdir)
@@ -140,7 +139,6 @@ class LoadTemplatesOutputFileWhitespaceTests(unittest.TestCase):
         with open(roundtrip_path, 'w', encoding='utf-8') as f:
             f.write(output)
 
-        ex.templates = {}
         we.templateNamespace = ''
         ex.Extractor.templatePrefix = ''
         with we.decode_open(roundtrip_path) as f:
@@ -154,11 +152,13 @@ class LoadTemplatesOutputFileWhitespaceTests(unittest.TestCase):
                     ex.Extractor.templatePrefix = we.templateNamespace + ':'
                 elif tag == '/siteinfo':
                     break
+        roundtrip_templates = {}
         with we.decode_open(roundtrip_path) as f:
-            we.load_templates(f)
+            we.load_templates(f, templates=roundtrip_templates)
 
         wikitext = '{{Wrapper|value}}'
-        extractor = ex.Extractor(1, '1', 'https://x', 'Test', [wikitext])
+        extractor = ex.Extractor(1, '1', 'https://x', 'Test', [wikitext],
+                                  templates=roundtrip_templates)
         result = extractor.clean_text(wikitext, expand_templates=True)
         self.assertEqual(result, ['wrapped[value]'])
 

--- a/tests/test_new_tags.py
+++ b/tests/test_new_tags.py
@@ -58,7 +58,6 @@ import wikiextractor.extract as ex
 class NewTagsTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_noinclude_removal.py
+++ b/tests/test_noinclude_removal.py
@@ -48,7 +48,6 @@ import wikiextractor.extract as ex
 class NoincludeTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_orphaned_discard_close_tags.py
+++ b/tests/test_orphaned_discard_close_tags.py
@@ -48,7 +48,6 @@ import wikiextractor.extract as ex
 class OrphanedDiscardCloseTagTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_quote_aware_tag_matching.py
+++ b/tests/test_quote_aware_tag_matching.py
@@ -52,7 +52,6 @@ import wikiextractor.extract as ex
 class QuoteAwareTagMatchingTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_redirect_keywords.py
+++ b/tests/test_redirect_keywords.py
@@ -58,7 +58,7 @@ import wikiextractor.extract as ex
 class RedirectKeywordsTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
+        self.templates = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
@@ -68,31 +68,31 @@ class EnglishRedirectStillWorksTests(RedirectKeywordsTestCase):
     """Regression coverage for the original, pre-existing behavior."""
 
     def test_uppercase_redirect(self):
-        ex.define_template('Template:Foo', ['#REDIRECT [[Template:Bar]]'])
+        ex.define_template('Template:Foo', ['#REDIRECT [[Template:Bar]]'], self.templates)
         self.assertEqual(ex.redirects.get('Template:Foo'), 'Template:Bar')
-        self.assertNotIn('Template:Foo', ex.templates)
+        self.assertNotIn('Template:Foo', self.templates)
 
     def test_lowercase_redirect_case_insensitive(self):
-        ex.define_template('Template:Foo', ['#redirect [[Template:Bar]]'])
+        ex.define_template('Template:Foo', ['#redirect [[Template:Bar]]'], self.templates)
         self.assertEqual(ex.redirects.get('Template:Foo'), 'Template:Bar')
 
     def test_mixed_case_redirect(self):
-        ex.define_template('Template:Foo', ['#Redirect [[Template:Bar]]'])
+        ex.define_template('Template:Foo', ['#Redirect [[Template:Bar]]'], self.templates)
         self.assertEqual(ex.redirects.get('Template:Foo'), 'Template:Bar')
 
     def test_normal_non_redirect_template_unaffected(self):
-        ex.define_template('Template:Normal', ['Some ordinary template text.'])
+        ex.define_template('Template:Normal', ['Some ordinary template text.'], self.templates)
         self.assertIsNone(ex.redirects.get('Template:Normal'))
-        self.assertIn('Template:Normal', ex.templates)
+        self.assertIn('Template:Normal', self.templates)
 
 
 class SindhiRedirectTests(RedirectKeywordsTestCase):
     """The new behavior this fix adds."""
 
     def test_sindhi_redirect_keyword(self):
-        ex.define_template('سانچو:حوالا', ['#چوريو [[سانچو:حوالو]]'])
+        ex.define_template('سانچو:حوالا', ['#چوريو [[سانچو:حوالو]]'], self.templates)
         self.assertEqual(ex.redirects.get('سانچو:حوالا'), 'سانچو:حوالو')
-        self.assertNotIn('سانچو:حوالا', ex.templates)
+        self.assertNotIn('سانچو:حوالا', self.templates)
 
     def test_real_world_case_content_leak_is_gone(self):
         # The exact real case this fix was found on: once recognized
@@ -103,9 +103,9 @@ class SindhiRedirectTests(RedirectKeywordsTestCase):
             '#چوريو [[سانچو:حوالو]]\n'
             '<div class="reflist" style="list-style-type: decimal;">\n'
             '{{#tag:references}}</div>'
-        ])
+        ], self.templates)
         self.assertEqual(ex.redirects.get('سانچو:حوالا'), 'سانچو:حوالو')
-        self.assertNotIn('سانچو:حوالا', ex.templates)
+        self.assertNotIn('سانچو:حوالا', self.templates)
 
 
 class UrduRedirectTests(RedirectKeywordsTestCase):
@@ -138,23 +138,23 @@ class UrduRedirectTests(RedirectKeywordsTestCase):
     """
 
     def test_urdu_redirect_keyword(self):
-        ex.define_template('سانچہ:ص.م/فتح', ['#رجوع_مکرر [[سانچہ:خانہ معلومات/آغاز]]'])
+        ex.define_template('سانچہ:ص.م/فتح', ['#رجوع_مکرر [[سانچہ:خانہ معلومات/آغاز]]'], self.templates)
         self.assertEqual(ex.redirects.get('سانچہ:ص.م/فتح'), 'سانچہ:خانہ معلومات/آغاز')
-        self.assertNotIn('سانچہ:ص.م/فتح', ex.templates)
+        self.assertNotIn('سانچہ:ص.م/فتح', self.templates)
 
     def test_real_world_case_table_leak_is_gone(self):
         # With the redirect keyword recognized AND the target template
         # actually available, the infobox's "{|" opener is reached and
         # the header row it should have wrapped gets correctly dropped
         # -- rather than leaking verbatim as in the real case above.
-        ex.define_template('سانچہ:ص.م/فتح', ['#رجوع_مکرر [[سانچہ:خانہ معلومات/آغاز]]'])
-        ex.define_template('سانچہ:خانہ معلومات/آغاز', ['{| class="infobox"'])
-        ex.define_template('سانچہ:خانہ معلومات/اختتام', ['|}'])
-        ex.define_template('سانچہ:خ۔م/عنوان', ['! scope=col | {{{1}}}'])
+        ex.define_template('سانچہ:ص.م/فتح', ['#رجوع_مکرر [[سانچہ:خانہ معلومات/آغاز]]'], self.templates)
+        ex.define_template('سانچہ:خانہ معلومات/آغاز', ['{| class="infobox"'], self.templates)
+        ex.define_template('سانچہ:خانہ معلومات/اختتام', ['|}'], self.templates)
+        ex.define_template('سانچہ:خ۔م/عنوان', ['! scope=col | {{{1}}}'], self.templates)
 
         wikitext = ('{{ص.م/فتح}}\n{{خ۔م/عنوان|Test}}\n{{خانہ معلومات/اختتام}}\n'
                     'Ordinary article prose follows.')
-        extractor = ex.Extractor('1', '1', 'https://x', 'Test', [wikitext])
+        extractor = ex.Extractor('1', '1', 'https://x', 'Test', [wikitext], templates=self.templates)
         result = extractor.clean_text(wikitext)
         joined = '\n'.join(result)
         self.assertNotIn('scope=col', joined)
@@ -169,28 +169,28 @@ class FalsePositiveBoundaryTests(RedirectKeywordsTestCase):
 
     def test_word_continuation_does_not_match(self):
         # "REDIRECTED" -- no word boundary right after "REDIRECT".
-        ex.define_template('Template:Foo', ['#REDIRECTED to a new place [[Template:Bar]]'])
+        ex.define_template('Template:Foo', ['#REDIRECTED to a new place [[Template:Bar]]'], self.templates)
         self.assertIsNone(ex.redirects.get('Template:Foo'))
-        self.assertIn('Template:Foo', ex.templates)
+        self.assertIn('Template:Foo', self.templates)
 
     def test_keyword_not_at_start_of_first_line_does_not_match(self):
-        ex.define_template('Template:Foo', ['Some text. #REDIRECT mentioned here [[Template:Bar]]'])
+        ex.define_template('Template:Foo', ['Some text. #REDIRECT mentioned here [[Template:Bar]]'], self.templates)
         self.assertIsNone(ex.redirects.get('Template:Foo'))
-        self.assertIn('Template:Foo', ex.templates)
+        self.assertIn('Template:Foo', self.templates)
 
     def test_keyword_with_no_wikilink_does_not_match(self):
-        ex.define_template('Template:Foo', ['#REDIRECT to somewhere, no link here'])
+        ex.define_template('Template:Foo', ['#REDIRECT to somewhere, no link here'], self.templates)
         self.assertIsNone(ex.redirects.get('Template:Foo'))
-        self.assertIn('Template:Foo', ex.templates)
+        self.assertIn('Template:Foo', self.templates)
 
     def test_keyword_appearing_only_in_a_later_line_does_not_match(self):
         # Only the template's first line is ever checked.
         ex.define_template('Template:Foo', [
             'This is the real, first line of content.\n'
             '#REDIRECT [[Template:Bar]]\n'
-        ])
+        ], self.templates)
         self.assertIsNone(ex.redirects.get('Template:Foo'))
-        self.assertIn('Template:Foo', ex.templates)
+        self.assertIn('Template:Foo', self.templates)
 
 
 if __name__ == '__main__':

--- a/tests/test_self_closing_text_tag.py
+++ b/tests/test_self_closing_text_tag.py
@@ -202,8 +202,8 @@ class TemplateContaminationTests(unittest.TestCase):
     """
 
     def setUp(self):
+        self.templates = {}
         import wikiextractor.extract as ex
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
@@ -211,10 +211,9 @@ class TemplateContaminationTests(unittest.TestCase):
     def load(self, xml_text):
         import io
         import wikiextractor.WikiExtractor as we
-        we.load_templates(io.StringIO(xml_text))
+        we.load_templates(io.StringIO(xml_text), templates=self.templates)
 
     def test_template_after_blanked_template_is_not_contaminated(self):
-        import wikiextractor.extract as ex
         xml = '''<mediawiki>
   <page>
     <title>Template:Blanked</title>
@@ -239,9 +238,9 @@ class TemplateContaminationTests(unittest.TestCase):
   </page>
 </mediawiki>'''
         self.load(xml)
-        self.assertNotIn('Template:Blanked', ex.templates)
-        self.assertIn('Template:Infobox person', ex.templates)
-        content = ex.templates['Template:Infobox person']
+        self.assertNotIn('Template:Blanked', self.templates)
+        self.assertIn('Template:Infobox person', self.templates)
+        content = self.templates['Template:Infobox person']
         self.assertNotIn('<contributor>', content)
         self.assertNotIn('SomeEditor', content)
         self.assertEqual(content, 'The real infobox content for {{{name}}}.')
@@ -256,10 +255,10 @@ class TemplateContaminationTests(unittest.TestCase):
         # it got there.
         import wikiextractor.extract as ex
         try:
-            ex.define_template('Template:Blanked', [])
+            ex.define_template('Template:Blanked', [], self.templates)
         except IndexError:
             self.fail("define_template() crashed on a genuinely empty page list")
-        self.assertNotIn('Template:Blanked', ex.templates)
+        self.assertNotIn('Template:Blanked', self.templates)
         self.assertNotIn('Template:Blanked', ex.redirects)
 
 

--- a/tests/test_selfclosing_tags.py
+++ b/tests/test_selfclosing_tags.py
@@ -74,7 +74,6 @@ import wikiextractor.extract as ex
 class VoidElementTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tests/test_sharp_invoke_alias.py
+++ b/tests/test_sharp_invoke_alias.py
@@ -58,7 +58,7 @@ import wikiextractor.extract as ex
 class SharpInvokeAliasTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
+        self.templates = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
@@ -73,7 +73,7 @@ class SharpInvokeAliasTestCase(unittest.TestCase):
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templates=self.templates)
         return extractor.clean_text(article_text, expand_templates=True)
 
 
@@ -89,7 +89,7 @@ class AliasTemplateNameTests(SharpInvokeAliasTestCase):
         # function name "convert") happened to coincide with the
         # template's actual name. Included as a baseline, not as the
         # regression test itself.
-        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'])
+        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'], self.templates)
         result = self.get_result('Value: {{convert|5|km}}')
         self.assertEqual(result, ['Value: 5 km'])
 
@@ -101,14 +101,14 @@ class AliasTemplateNameTests(SharpInvokeAliasTestCase):
         # "Template:Cvt" -- silently failing to empty output every
         # time, regardless of the underlying function being identical
         # and correctly registered.
-        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'])
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates)
         result = self.get_result('Value: {{cvt|5|km}}')
         self.assertEqual(result, ['Value: 5 km'])
 
     def test_original_buffalo_sentence(self):
         # The exact real-world sentence that surfaced this whole
         # investigation.
-        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'])
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates)
         text = ("Buffalo's lowest recorded temperature was {{cvt|−20|°F|0}}, "
                  "which occurred twice: on February 9, 1934, and February 2, 1961.")
         result = self.get_result(text)
@@ -121,9 +121,9 @@ class AliasTemplateNameTests(SharpInvokeAliasTestCase):
         # Not special-cased to "cvt" specifically -- any number of
         # differently-named templates invoking the same function
         # should all work identically.
-        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'])
-        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'])
-        ex.define_template('Template:Convert2', ['{{#invoke:convert|convert}}'])
+        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'], self.templates)
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates)
+        ex.define_template('Template:Convert2', ['{{#invoke:convert|convert}}'], self.templates)
         for name in ('convert', 'cvt', 'convert2'):
             with self.subTest(template=name):
                 result = self.get_result(f'Value: {{{{{name}|5|km}}}}')
@@ -142,8 +142,8 @@ class FrameStackOrderingTests(SharpInvokeAliasTestCase):
         # itself call #invoke -- it calls Cvt, which does. The
         # #invoke call must pick up Cvt's own params (5, km), not
         # Wrapper's (999, mi).
-        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'])
-        ex.define_template('Template:Wrapper', ['See: {{cvt|{{{1}}}|{{{2}}}}}'])
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates)
+        ex.define_template('Template:Wrapper', ['See: {{cvt|{{{1}}}|{{{2}}}}}'], self.templates)
         result = self.get_result('Value: {{wrapper|5|km}}')
         self.assertEqual(result, ['Value: See: 5 km'])
 

--- a/tests/test_streaming_template_blob.py
+++ b/tests/test_streaming_template_blob.py
@@ -1,0 +1,197 @@
+"""
+Tests for template_blob.py's StreamingTemplateBlobBuilder -- built to
+avoid ever holding a full {title: text} dict in memory while also
+holding the compacted blob built from it, which at full EN scale
+(~900K templates) was confirmed, on a real production run, to double
+the mapper's peak RSS just before forking every worker (~1.85GB for
+the dict, ~4.2GB once the blob was also built alongside it) -- and
+much of that first ~1.85GB never came back afterward either, even
+after the dict went out of scope and an explicit gc.collect(), since
+CPython's allocator only returns a fully-empty arena to the OS.
+
+No prior test file covers template_blob.py at all -- this is the
+first, covering both the streaming builder directly and
+load_templates()'s blob_builder= path that uses it in practice.
+
+Run with:
+    python -m unittest tests.test_streaming_template_blob -v
+or, from the tests/ directory:
+    python -m unittest test_streaming_template_blob -v
+"""
+
+import io
+import random
+import string
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.WikiExtractor as we
+import wikiextractor.extract as ex
+from wikiextractor import template_blob as tb
+
+
+class StreamingBuilderMatchesDictBasedTests(unittest.TestCase):
+    """The streaming builder must produce byte-identical blobs to the
+    existing dict-based build_template_blobs(), for the same input --
+    it's a different way of building the same three blobs, not a
+    different format.
+    """
+
+    def test_byte_identical_output_for_random_templates(self):
+        random.seed(5)
+        templates = {}
+        for i in range(2000):
+            templates[f'Template:T{i}'] = ''.join(
+                random.choices(string.ascii_letters + ' ', k=random.randint(10, 300)))
+
+        old_records, old_titles, old_content = tb.build_template_blobs(templates)
+
+        builder = tb.StreamingTemplateBlobBuilder()
+        for title, text in templates.items():
+            builder.add(title, text)
+        new_records, new_titles, new_content = builder.finish()
+
+        self.assertEqual(old_records, new_records)
+        self.assertEqual(old_titles, new_titles)
+        self.assertEqual(old_content, new_content)
+
+    def test_empty_builder_produces_empty_blobs(self):
+        builder = tb.StreamingTemplateBlobBuilder()
+        records, titles, content = builder.finish()
+        self.assertEqual(records, b'')
+        self.assertEqual(titles, b'')
+        self.assertEqual(content, b'')
+
+    def test_content_order_independent_of_add_order_records_still_sorted(self):
+        # Content is appended in whatever order add() is called;
+        # only the (much smaller) records index gets sorted by title.
+        # Adding out of title order must still produce a correctly
+        # sorted, binary-searchable index.
+        builder = tb.StreamingTemplateBlobBuilder()
+        builder.add('Template:Zebra', 'zebra content')
+        builder.add('Template:Apple', 'apple content')
+        builder.add('Template:Mango', 'mango content')
+        records, titles, content = builder.finish()
+
+        with tb.compact_blobs(records, titles, content) as (wrapper, _names):
+            self.assertEqual(wrapper['Template:Zebra'], 'zebra content')
+            self.assertEqual(wrapper['Template:Apple'], 'apple content')
+            self.assertEqual(wrapper['Template:Mango'], 'mango content')
+
+
+class LoadTemplatesBlobBuilderPathTests(unittest.TestCase):
+    """load_templates(..., blob_builder=...) must resolve redirects
+    and noinclude/includeonly exactly like the dict-based path
+    (define_template()) does -- same underlying resolve_template_page()
+    either way, but worth confirming end to end through the real
+    parsing loop, not just at the resolver level.
+    """
+
+    def setUp(self):
+        we.templateNamespace = ''
+        ex.Extractor.templatePrefix = ''
+        ex.redirects.clear()
+
+    def load(self, xml_text):
+        builder = tb.StreamingTemplateBlobBuilder()
+        with io.StringIO(xml_text) as f:
+            for line in f:
+                m = we.tagRE.search(line)
+                if not m:
+                    continue
+                tag = m.group(2)
+                if tag == 'namespace' and 'key="10"' in line:
+                    we.templateNamespace = m.group(3)
+                    ex.Extractor.templatePrefix = we.templateNamespace + ':'
+                elif tag == '/siteinfo':
+                    break
+        with io.StringIO(xml_text) as f:
+            count = we.load_templates(f, blob_builder=builder)
+        return count, builder
+
+    def test_plain_template_streamed_correctly(self):
+        xml = """<mediawiki>
+<siteinfo>
+<namespaces>
+<namespace key="0" case="first-letter" />
+<namespace key="10" case="first-letter">Template</namespace>
+</namespaces>
+</siteinfo>
+<page>
+<title>Template:Greeting</title>
+<ns>10</ns>
+<id>1</id>
+<revision>
+<id>1</id>
+<text>Hello, {{{1}}}!</text>
+</revision>
+</page>
+</mediawiki>
+"""
+        count, builder = self.load(xml)
+        self.assertEqual(count, 1)
+        records, titles, content = builder.finish()
+        with tb.compact_blobs(records, titles, content) as (wrapper, _names):
+            self.assertEqual(wrapper['Template:Greeting'], 'Hello, {{{1}}}!')
+
+    def test_redirect_goes_to_redirects_dict_not_the_blob(self):
+        xml = """<mediawiki>
+<siteinfo>
+<namespaces>
+<namespace key="0" case="first-letter" />
+<namespace key="10" case="first-letter">Template</namespace>
+</namespaces>
+</siteinfo>
+<page>
+<title>Template:Old</title>
+<ns>10</ns>
+<id>1</id>
+<revision>
+<id>1</id>
+<text>#REDIRECT [[Template:New]]</text>
+</revision>
+</page>
+</mediawiki>
+"""
+        count, builder = self.load(xml)
+        self.assertEqual(count, 1)
+        self.assertEqual(ex.redirects.get('Template:Old'), 'Template:New')
+        records, titles, content = builder.finish()
+        self.assertEqual(records, b'')  # nothing streamed into the blob itself
+
+    def test_noinclude_stripped_includeonly_kept_same_as_dict_based_path(self):
+        xml = """<mediawiki>
+<siteinfo>
+<namespaces>
+<namespace key="0" case="first-letter" />
+<namespace key="10" case="first-letter">Template</namespace>
+</namespaces>
+</siteinfo>
+<page>
+<title>Template:WithDocs</title>
+<ns>10</ns>
+<id>1</id>
+<revision>
+<id>1</id>
+<text>
+<includeonly>real content</includeonly>
+<noinclude>
+documentation that must never appear
+</noinclude>
+</text>
+</revision>
+</page>
+</mediawiki>
+"""
+        count, builder = self.load(xml)
+        records, titles, content = builder.finish()
+        with tb.compact_blobs(records, titles, content) as (wrapper, _names):
+            stored = wrapper['Template:WithDocs']
+        self.assertIn('real content', stored)
+        self.assertNotIn('documentation', stored)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_template_boundary_newline_collapse.py
+++ b/tests/test_template_boundary_newline_collapse.py
@@ -74,15 +74,15 @@ import wikiextractor.extract as ex
 class NewlineCollapseTestCase(unittest.TestCase):
 
     def setUp(self):
-        ex.templates.clear()
+        self.templates = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def stored_body(self, page_lines):
-        ex.define_template('Template:X', page_lines)
-        return ex.templates.get('Template:X')
+        ex.define_template('Template:X', page_lines, self.templates)
+        return self.templates.get('Template:X')
 
 
 class NoincludeTrailingNewlineTests(NewlineCollapseTestCase):
@@ -106,13 +106,13 @@ class NoincludeTrailingNewlineTests(NewlineCollapseTestCase):
         ex.define_template('Template:Trim', [
             '<includeonly>{{safesubst:#if:1|{{{1|}}}}}</includeonly>'
             '<noinclude>\n{{documentation}}\n</noinclude>\n'
-        ])
+        ], self.templates)
         ex.define_template('Template:LinkB', [
             'http://example.com?chapter={{Trim| {{{1}}} }}&verse={{Trim| {{{2}}} }}&done'
-        ])
+        ], self.templates)
         wikitext = 'cite: [{{LinkB|2|119}} Some Label]'
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [wikitext])
+                               "Test Article", [wikitext], templates=self.templates)
         result = extractor.clean_text(wikitext, expand_templates=True)
         self.assertEqual(result, ['cite: Some Label'])
 

--- a/tests/test_template_loop_guard.py
+++ b/tests/test_template_loop_guard.py
@@ -48,14 +48,16 @@ import wikiextractor.extract as ex
 
 
 class TemplateLoopGuardTestCase(unittest.TestCase):
-    """Base class that resets wikiextractor's module-level template state
-    before each test. `templates` and `redirects` are
-    plain module globals in extract.py (populated by define_template),
-    so tests must not leak state into one another.
+    """Base class that resets wikiextractor's module-level redirect
+    state before each test, and gives each test its own isolated
+    templates dict. `redirects` is still a plain module global in
+    extract.py (populated by define_template), so tests must not leak
+    state into one another there; `templates` itself is no longer a
+    shared global at all -- each test gets its own via self.templates.
     """
 
     def setUp(self):
-        ex.templates.clear()
+        self.templates = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()
@@ -73,7 +75,7 @@ class TemplateLoopGuardTestCase(unittest.TestCase):
     def make_extractor(self, article_text, article_id=1, title="Test Article"):
         return Extractor(article_id, str(article_id),
                           f"https://test.wikipedia.org/wiki?curid={article_id}",
-                          title, [article_text])
+                          title, [article_text], templates=self.templates)
 
 
 class LegitimateSelfRecursionTests(TemplateLoopGuardTestCase):
@@ -89,7 +91,8 @@ class LegitimateSelfRecursionTests(TemplateLoopGuardTestCase):
         # DIFFERENT parameters than its caller -- genuine progress.
         ex.define_template(
             "Template:P2",
-            ["{{{1}}}{{#if:{{{2|}}}|, {{P2|{{{2|}}}|{{{3|}}}|{{{4|}}}|{{{5|}}}}}|}}"]
+            ["{{{1}}}{{#if:{{{2|}}}|, {{P2|{{{2|}}}|{{{3|}}}|{{{4|}}}|{{{5|}}}}}|}}"],
+            self.templates
         )
         article_text = "Population list: {{P2|CityA|CityB|CityC|CityD}}"
         extractor = self.make_extractor(article_text)
@@ -108,7 +111,8 @@ class LegitimateSelfRecursionTests(TemplateLoopGuardTestCase):
         ex.define_template(
             "Template:P2",
             ["{{{1}}}{{#if:{{{2|}}}|, {{P2|{{{2|}}}|{{{3|}}}|{{{4|}}}|{{{5|}}}"
-             "|{{{6|}}}|{{{7|}}}|{{{8|}}}}}|}}"]
+             "|{{{6|}}}|{{{7|}}}|{{{8|}}}}}|}}"],
+            self.templates
         )
         article_text = ("{{P2|A|B|C|D|E|F|G|H}}")
         extractor = self.make_extractor(article_text)
@@ -148,7 +152,7 @@ Usage examples:
 {{Redirect-multi|3|A|B|C|use=x}}
 {{Redirect-multi|3|A|B|C|use=y}}
 {{Redirect-multi|3|A|B|C|use=z}}
-"""])
+"""], self.templates)
         article_text = "Some article text.\n\n{{Redirect-multi|2|X|Y}}\n\nMore text."
         extractor = self.make_extractor(article_text)
 
@@ -172,7 +176,7 @@ Usage examples:
     def test_direct_immediate_self_reference_is_caught(self):
         # The simplest possible case: a template whose body invokes
         # itself with the exact same parameters, unconditionally.
-        ex.define_template("Template:Self", ["before {{Self|x}} after"])
+        ex.define_template("Template:Self", ["before {{Self|x}} after"], self.templates)
         article_text = "{{Self|x}}"
         extractor = self.make_extractor(article_text)
 
@@ -197,7 +201,7 @@ class WarningLogDeduplicationTests(TemplateLoopGuardTestCase):
 {{Redirect-multi|3|A|B|C|use=x}}
 {{Redirect-multi|3|A|B|C|use=y}}
 {{Redirect-multi|3|A|B|C|use=z}}
-"""])
+"""], self.templates)
         article_text = "{{Redirect-multi|2|X|Y}}"
         extractor = self.make_extractor(article_text)
 
@@ -229,7 +233,7 @@ class ErrorSummaryReportingTests(TemplateLoopGuardTestCase):
     """
 
     def test_loop_errs_included_in_summary_when_present(self):
-        ex.define_template("Template:Self", ["{{Self|x}}"])
+        ex.define_template("Template:Self", ["{{Self|x}}"], self.templates)
         article_text = "{{Self|x}}"
         extractor = self.make_extractor(article_text)
 
@@ -251,7 +255,7 @@ class ErrorSummaryReportingTests(TemplateLoopGuardTestCase):
                       "per-article error summary should report the loop count")
 
     def test_no_spurious_errors_reported_for_clean_article(self):
-        ex.define_template("Template:Plain", ["just plain text"])
+        ex.define_template("Template:Plain", ["just plain text"], self.templates)
         article_text = "{{Plain}}"
         extractor = self.make_extractor(article_text)
 

--- a/tests/test_text_format.py
+++ b/tests/test_text_format.py
@@ -41,7 +41,6 @@ class TextFormatTestCase(unittest.TestCase):
     """
 
     def setUp(self):
-        ex.templates.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         ex.redirects.clear()

--- a/tools/classify_missing_pages.py
+++ b/tools/classify_missing_pages.py
@@ -188,7 +188,7 @@ def collect_doc_ids(path, verbose_label):
     return ids
 
 
-def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None):
+def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None, templates=None):
     """
     Stream through the original XML dump looking for <page> blocks whose
     page id is in target_ids. Returns {id: info_dict} where info_dict has
@@ -240,7 +240,7 @@ def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None):
                 if '</page>' in line:
                     in_page = False
                     if page_id in remaining:
-                        results[page_id] = _parse_page_block(''.join(page_lines), ex_module)
+                        results[page_id] = _parse_page_block(''.join(page_lines), ex_module, templates)
                         remaining.discard(page_id)
                         pbar.set_postfix(found=f"{len(results)}/{total_targets}")
                     page_lines = []
@@ -250,7 +250,7 @@ def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None):
     return results, remaining
 
 
-def _parse_page_block(block, ex_module=None):
+def _parse_page_block(block, ex_module=None, templates=None):
     title_m = TITLE_RE.search(block)
     title = title_m.group(1) if title_m else ''
     has_redirect = bool(REDIRECT_TAG_RE.search(block))
@@ -290,7 +290,7 @@ def _parse_page_block(block, ex_module=None):
         try:
             extractor = ex_module.Extractor(
                 page_id, page_id, f"https://example.org/wiki?curid={page_id}",
-                title, [stripped])
+                title, [stripped], templates=templates)
             # Run on the full page text, redirect line included, to
             # exactly mirror what the real extraction pipeline does in
             # Extractor.extract() -- not just the trailing portion in
@@ -361,14 +361,16 @@ def main():
     args = ap.parse_args()
 
     ex_module = None
+    templates = None
     if not args.no_extraction_check:
         try:
             import wikiextractor.extract as ex_module
             if args.templates:
                 import wikiextractor.WikiExtractor as we
                 print(f"Loading templates from {args.templates}...", file=sys.stderr)
+                templates = {}
                 with we.decode_open(args.templates) as f:
-                    count = we.load_templates(f)
+                    count = we.load_templates(f, templates=templates)
                 print(f"Loaded {count} templates.", file=sys.stderr)
         except ImportError as e:
             print(f"warning: --no-extraction-check was not given, but wikiextractor isn't "
@@ -391,7 +393,7 @@ def main():
 
     dump_info, not_found = scan_dump_for_ids(args.dump, missing,
                                               early_exit=not args.no_early_exit,
-                                              ex_module=ex_module)
+                                              ex_module=ex_module, templates=templates)
 
     rows = []
     counts = {}

--- a/tools/confirm_redirect_keyword_causation.py
+++ b/tools/confirm_redirect_keyword_causation.py
@@ -208,31 +208,32 @@ class RecordingDict(dict):
         return super().get(key, default)
 
 
-def find_redirect_templates_invoked(ex, page_id, wikitext, non_english_redirect_titles):
+def find_redirect_templates_invoked(ex, page_id, wikitext, non_english_redirect_titles, templates):
     """
     Runs the real clean_text() on wikitext, instrumented to record
     every template title looked up, then returns the subset of those
     that are known (from --templates) to be redirects using one of
     the newly-recognized, non-English keywords -- genuine, per-article
     confirmation, not a file-wide pattern match.
+
+    templates: the real {title: text} dict, as populated by
+    load_templates() in main() -- wrapped fresh here each call rather
+    than mutating any shared global (there is no longer a module-level
+    `templates` in extract.py to save/swap/restore around this call at
+    all; the caller's own dict is untouched by the wrapping itself).
     """
     looked_up = set()
-    original_templates = ex.templates
-    original_cache = ex.templateCache
     original_redirects = ex.redirects
     try:
-        ex.templates = RecordingDict(ex.templates, looked_up.add)
-        ex.templateCache = RecordingDict(ex.templateCache, looked_up.add)
+        wrapped_templates = RecordingDict(templates, looked_up.add)
         ex.redirects = RecordingDict(ex.redirects, looked_up.add)
         extractor = ex.Extractor(page_id, page_id, f"https://example.org/wiki?curid={page_id}",
-                                  f"Page{page_id}", [wikitext])
+                                  f"Page{page_id}", [wikitext], templates=wrapped_templates)
         try:
             extractor.clean_text(wikitext, expand_templates=True)
         except Exception:
             pass  # a page that can't finish expanding still reveals what it looked up first
     finally:
-        ex.templates = original_templates
-        ex.templateCache = original_cache
         ex.redirects = original_redirects
     return looked_up & non_english_redirect_titles
 
@@ -347,9 +348,10 @@ def main():
           file=sys.stderr)
 
     print("Loading templates into the real extract.py machinery...", file=sys.stderr)
+    templates = {}
     with open(args.templates, encoding='utf-8', errors='replace') as f:
         import wikiextractor.WikiExtractor as we
-        we.load_templates(f)
+        we.load_templates(f, templates=templates)
 
     source_texts = get_source_wikitext_by_id(args.dump, changed_ids)
     missing_from_source = [doc_id for doc_id in changed_ids if doc_id not in source_texts]
@@ -378,7 +380,7 @@ def main():
 
         if doc_id in source_texts:
             invoked = find_redirect_templates_invoked(
-                ex, doc_id, source_texts[doc_id], non_english_redirect_titles)
+                ex, doc_id, source_texts[doc_id], non_english_redirect_titles, templates)
         else:
             invoked = None
 

--- a/tools/extract_templates_by_id.py
+++ b/tools/extract_templates_by_id.py
@@ -164,8 +164,16 @@ def discover_and_extract(wikiextractor_extract_module, page_texts, templates_pat
     ex.Extractor.templatePrefix = determine_template_prefix(templates_path)
 
     looked_up = set()
-    ex.templates = RecordingDict(on_lookup=looked_up.add)
-    ex.templateCache = RecordingDict(on_lookup=looked_up.add)
+    # Local, not a module attribute: extract.py no longer has a
+    # module-level `templates` global at all for assigning to
+    # ex.templates to mean anything -- both define_template() and
+    # Extractor() take their templates dict as an explicit argument
+    # now, so that's how this RecordingDict actually gets used, same
+    # as any other templates source. templateCache is gone entirely
+    # (Extractor._parse_template() is its own lru_cache-decorated
+    # function now, not a dict expandTemplate() ever checks
+    # membership against), so there's nothing to instrument there.
+    templates = RecordingDict(on_lookup=looked_up.add)
     ex.redirects.clear()
 
     loaded_pages = {}  # title -> original <page> text, for writing to --output
@@ -175,7 +183,7 @@ def discover_and_extract(wikiextractor_extract_module, page_texts, templates_pat
         for page_id, wikitext in page_texts.items():
             extractor = ex.Extractor(page_id, str(page_id),
                                       f"https://example.org/wiki?curid={page_id}",
-                                      f"Page{page_id}", [wikitext])
+                                      f"Page{page_id}", [wikitext], templates=templates)
             try:
                 extractor.clean_text(wikitext, expand_templates=True)
             except Exception:
@@ -184,8 +192,7 @@ def discover_and_extract(wikiextractor_extract_module, page_texts, templates_pat
                 # before failing -- looked_up is unaffected by the exception
                 pass
 
-        still_unsatisfied = {t for t in looked_up
-                              if t not in ex.templates and t not in ex.templateCache}
+        still_unsatisfied = {t for t in looked_up if t not in templates}
         if not still_unsatisfied:
             break
 
@@ -201,14 +208,12 @@ def discover_and_extract(wikiextractor_extract_module, page_texts, templates_pat
             loaded_pages[title] = page_text
             text_match = re.search(r'<text[^>]*>(.*?)</text>', page_text, re.DOTALL)
             page_lines = [text_match.group(1)] if text_match else ['']
-            ex.define_template(title, page_lines)
+            ex.define_template(title, page_lines, templates)
     else:
         print(f"WARNING: stopped after {max_passes} passes -- possible deep "
               f"nesting or a circular reference", file=sys.stderr)
 
-    never_found = {t for t in looked_up
-                    if t not in ex.templates and t not in ex.templateCache
-                    and t not in loaded_pages}
+    never_found = {t for t in looked_up if t not in templates and t not in loaded_pages}
     return loaded_pages, never_found
 
 

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -59,6 +59,7 @@ collecting template definitions.
 
 import argparse
 import bz2
+import contextlib
 import logging
 import os.path
 import re  # TODO use regex when it will be standard
@@ -562,126 +563,127 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
         # just the names, to hand to workers, and the cleanup
         # callback, to release the shared memory once everyone's done.
         compact_start = default_timer()
-        _wrapper, template_blob_names, template_blob_cleanup = template_blob.compact(raw_templates)
+        template_blob_ctx = template_blob.compact(raw_templates)
         logging.info("Compacted templates into shared memory in %.1fs",
                      default_timer() - compact_start)
     else:
-        template_blob_names = None
-        template_blob_cleanup = None
+        # nullcontext, not None -- keeps the with-statement below
+        # uniform regardless of whether templates are in play at all,
+        # rather than needing a separate branch for --no-templates.
+        template_blob_ctx = contextlib.nullcontext((None, None))
+    with template_blob_ctx as (_wrapper, template_blob_names):
+        # process pages
+        logging.info("Starting page extraction from %s.", input_file)
+        extract_start = default_timer()
 
-    # process pages
-    logging.info("Starting page extraction from %s.", input_file)
-    extract_start = default_timer()
+        # Parallel Map/Reduce:
+        # - pages to be processed are dispatched to workers
+        # - a reduce process collects the results, sort them and print them.
 
-    # Parallel Map/Reduce:
-    # - pages to be processed are dispatched to workers
-    # - a reduce process collects the results, sort them and print them.
+        # fixes MacOS error: TypeError: cannot pickle '_io.TextIOWrapper' object
+        Process = get_context("fork").Process
 
-    # fixes MacOS error: TypeError: cannot pickle '_io.TextIOWrapper' object
-    Process = get_context("fork").Process
+        maxsize = 10 * process_count
+        # output queue
+        output_queue = Queue(maxsize=maxsize)
 
-    maxsize = 10 * process_count
-    # output queue
-    output_queue = Queue(maxsize=maxsize)
+        # Shared counter reduce_process updates every time it successfully
+        # writes an ordinal out, so the mapper below can tell how far
+        # ahead of the actually-written output it's gotten -- without this,
+        # nothing stops the mapper from queueing (and workers from
+        # completing) unboundedly many pages while reduce_process is stuck
+        # waiting on one specific ordinal, e.g. a genuinely stuck or
+        # extremely slow page: every other worker just keeps racing ahead,
+        # and every one of their completed results piles up in
+        # reduce_process's own ordering_buffer, which has no size limit at
+        # all. This bounds how far ahead the pipeline is allowed to get,
+        # at the mapper (job-dispatch) side specifically -- NOT inside
+        # reduce_process itself, since reduce_process must keep draining
+        # output_queue unconditionally to have any chance of ever finding
+        # the specific ordinal it's waiting for (a plain multiprocessing
+        # Queue only supports FIFO reads, with no way to selectively wait
+        # for one specific item while ignoring others ahead of it in the
+        # queue -- pausing reduce_process's own consumption was tried and
+        # reverted after it produced a genuine deadlock in testing).
+        next_ordinal_shared = Value('l', 0)
 
-    # Shared counter reduce_process updates every time it successfully
-    # writes an ordinal out, so the mapper below can tell how far
-    # ahead of the actually-written output it's gotten -- without this,
-    # nothing stops the mapper from queueing (and workers from
-    # completing) unboundedly many pages while reduce_process is stuck
-    # waiting on one specific ordinal, e.g. a genuinely stuck or
-    # extremely slow page: every other worker just keeps racing ahead,
-    # and every one of their completed results piles up in
-    # reduce_process's own ordering_buffer, which has no size limit at
-    # all. This bounds how far ahead the pipeline is allowed to get,
-    # at the mapper (job-dispatch) side specifically -- NOT inside
-    # reduce_process itself, since reduce_process must keep draining
-    # output_queue unconditionally to have any chance of ever finding
-    # the specific ordinal it's waiting for (a plain multiprocessing
-    # Queue only supports FIFO reads, with no way to selectively wait
-    # for one specific item while ignoring others ahead of it in the
-    # queue -- pausing reduce_process's own consumption was tried and
-    # reverted after it produced a genuine deadlock in testing).
-    next_ordinal_shared = Value('l', 0)
+        # Notified by reduce_process every time next_ordinal_shared
+        # advances, so the mapper's throttle below can genuinely wake up
+        # on that specific event, rather than polling the value on some
+        # fixed interval regardless of whether anything happened.
+        progress_condition = Condition()
 
-    # Notified by reduce_process every time next_ordinal_shared
-    # advances, so the mapper's throttle below can genuinely wake up
-    # on that specific event, rather than polling the value on some
-    # fixed interval regardless of whether anything happened.
-    progress_condition = Condition()
+        # Reduce job that sorts and prints output
+        reduce = Process(target=reduce_process,
+                          args=(output_queue, out_file, file_size, file_compress, next_ordinal_shared, progress_condition, debug_map_reduce))
+        reduce.start()
 
-    # Reduce job that sorts and prints output
-    reduce = Process(target=reduce_process,
-                      args=(output_queue, out_file, file_size, file_compress, next_ordinal_shared, progress_condition, debug_map_reduce))
-    reduce.start()
+        # initialize jobs queue
+        jobs_queue = Queue(maxsize=maxsize)
 
-    # initialize jobs queue
-    jobs_queue = Queue(maxsize=maxsize)
+        # start worker processes
+        logging.info("Using %d extract processes.", process_count)
+        workers = []
+        for _ in range(max(1, process_count)):
+            extractor = Process(target=extract_process,
+                                args=(jobs_queue, output_queue, html_safe, debug_map_reduce,
+                                      template_blob_names))
+            extractor.daemon = True  # only live while parent process lives
+            extractor.start()
+            workers.append(extractor)
 
-    # start worker processes
-    logging.info("Using %d extract processes.", process_count)
-    workers = []
-    for _ in range(max(1, process_count)):
-        extractor = Process(target=extract_process,
-                            args=(jobs_queue, output_queue, html_safe, debug_map_reduce,
-                                  template_blob_names))
-        extractor.daemon = True  # only live while parent process lives
-        extractor.start()
-        workers.append(extractor)
+        watchdog_stop = threading.Event()
+        watchdog_thread = None
+        if mapreduce_logger.isEnabledFor(logging.DEBUG):
+            watchdog_thread = threading.Thread(
+                target=watchdog, args=(jobs_queue, output_queue, reduce, workers, watchdog_stop),
+                daemon=True)
+            watchdog_thread.start()
 
-    watchdog_stop = threading.Event()
-    watchdog_thread = None
-    if mapreduce_logger.isEnabledFor(logging.DEBUG):
-        watchdog_thread = threading.Thread(
-            target=watchdog, args=(jobs_queue, output_queue, reduce, workers, watchdog_stop),
-            daemon=True)
-        watchdog_thread.start()
+        # Mapper process
 
-    # Mapper process
+        # we collect individual lines, since str.join() is significantly faster
+        # than concatenation
 
-    # we collect individual lines, since str.join() is significantly faster
-    # than concatenation
+        ordinal = 0  # page count
+        # How far ahead of the last actually-written ordinal the mapper is
+        # willing to get before pausing -- matches the same maxsize
+        # convention already used for the queues themselves, so this stays
+        # proportional to process_count.
+        for id, revid, title, page in collect_pages(input):
+            while ordinal - next_ordinal_shared.value > maxsize:
+                # progress_condition is notified by reduce_process every
+                # time next_ordinal_shared actually advances (see there),
+                with progress_condition:
+                    progress_condition.wait(timeout=1.0)
+            job = (id, revid, urlbase, title, page, ordinal)
+            jobs_queue.put(job)  # goes to any available extract_process
+            mapreduce_logger.debug("JOB_QUEUED ordinal=%d id=%s title=%r", ordinal, id, title)
+            ordinal += 1
 
-    ordinal = 0  # page count
-    # How far ahead of the last actually-written ordinal the mapper is
-    # willing to get before pausing -- matches the same maxsize
-    # convention already used for the queues themselves, so this stays
-    # proportional to process_count.
-    for id, revid, title, page in collect_pages(input):
-        while ordinal - next_ordinal_shared.value > maxsize:
-            # progress_condition is notified by reduce_process every
-            # time next_ordinal_shared actually advances (see there),
-            with progress_condition:
-                progress_condition.wait(timeout=1.0)
-        job = (id, revid, urlbase, title, page, ordinal)
-        jobs_queue.put(job)  # goes to any available extract_process
-        mapreduce_logger.debug("JOB_QUEUED ordinal=%d id=%s title=%r", ordinal, id, title)
-        ordinal += 1
+        input.close()
 
-    input.close()
+        # signal termination
+        for _ in workers:
+            jobs_queue.put(None)
+        # wait for workers to terminate
+        for w in workers:
+            w.join()
 
-    # signal termination
-    for _ in workers:
-        jobs_queue.put(None)
-    # wait for workers to terminate
-    for w in workers:
-        w.join()
+        # signal end of work to reduce process
+        output_queue.put(None)
+        # wait for it to finish
+        reduce.join()
 
-    # signal end of work to reduce process
-    output_queue.put(None)
-    # wait for it to finish
-    reduce.join()
+        watchdog_stop.set()
+        if watchdog_thread is not None:
+            watchdog_thread.join(timeout=5)
 
-    watchdog_stop.set()
-    if watchdog_thread is not None:
-        watchdog_thread.join(timeout=5)
-
-    # Every worker and the reducer have now exited (w.join()/reduce.join()
-    # above already waited for that) -- safe to release the shared
-    # memory for good. template_blob_cleanup is None when extraction
-    # ran with --no-templates, since nothing was ever compacted.
-    if template_blob_cleanup is not None:
-        template_blob_cleanup()
+        # Every worker and the reducer have now exited (w.join()/reduce.join()
+        # above already waited for that) -- safe for the with-block above
+        # to release the shared memory for good on exit (close() + unlink()
+        # via CompactedTemplatesOwner.__exit__, or a no-op if this ran with
+        # --no-templates via nullcontext).
 
     extract_duration = default_timer() - extract_start
     extract_rate = ordinal / extract_duration
@@ -713,39 +715,46 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
     :param template_blob_names: names of the shared-memory segments
         built by template_blob.compact() in process_dump(), or None
         if extraction is running with --no-templates. Attached here,
-        once, at worker startup, and the resulting view passed
-        explicitly into every Extractor(...) constructed below --
-        not assigned to the extract module's own `templates` global,
-        which used to be how a worker's template source got set up.
-        Passing it as a constructor argument means extract.py's own
-        behavior is visible in extract.py itself (Extractor takes a
-        templates argument) rather than being silently swappable only
-        from here; it's also what's actually required once this
-        worker starts being launched via spawn instead of fork, which
+        once, at worker startup, inside a with-block so this worker's
+        own view is closed automatically when the loop below exits
+        (never unlinked, though -- that's the creator's job alone via
+        CompactedTemplatesOwner, since a worker unlinking the shared
+        segment would destroy it out from under any sibling worker
+        still using it). The resulting view is passed explicitly into
+        every Extractor(...) constructed below -- not assigned to the
+        extract module's own `templates` global, which used to be how
+        a worker's template source got set up. Passing it as a
+        constructor argument means extract.py's own behavior is
+        visible in extract.py itself (Extractor takes a templates
+        argument) rather than being silently swappable only from
+        here; it's also what's actually required once this worker
+        starts being launched via spawn instead of fork, which
         inherits nothing implicitly at all -- doing it this way now
         means extract_process()'s own body doesn't need to change
         shape later for that transition.
     """
     configure_mapreduce_logging(debug_map_reduce)
-    worker_templates = template_blob.attach(template_blob_names) if template_blob_names is not None else None
-    while True:
-        job = jobs_queue.get()  # job is (id, revid, urlbase, title, page, ordinal)
-        if job:
-            page_id, _, _, title, _, ordinal = job
-            start = time.time()
-            mapreduce_logger.debug("PAGE_START pid=%d ordinal=%d id=%s title=%r",
-                                   os.getpid(), ordinal, page_id, title)
-            out = StringIO()  # memory buffer
-            Extractor(*job[:-1], templates=worker_templates).extract(out, html_safe)  # (id, urlbase, title, page)
-            finish = time.time()
-            mapreduce_logger.debug(
-                "PAGE_TIMING pid=%d ordinal=%d id=%s title=%r elapsed=%.2fs",
-                os.getpid(), ordinal, page_id, title, finish - start)
-            text = out.getvalue()
-            output_queue.put((job[-1], text))  # (ordinal, extracted_text)
-            out.close()
-        else:
-            break
+    worker_ctx = (template_blob.attach(template_blob_names) if template_blob_names is not None
+                  else contextlib.nullcontext(None))
+    with worker_ctx as worker_templates:
+        while True:
+            job = jobs_queue.get()  # job is (id, revid, urlbase, title, page, ordinal)
+            if job:
+                page_id, _, _, title, _, ordinal = job
+                start = time.time()
+                mapreduce_logger.debug("PAGE_START pid=%d ordinal=%d id=%s title=%r",
+                                       os.getpid(), ordinal, page_id, title)
+                out = StringIO()  # memory buffer
+                Extractor(*job[:-1], templates=worker_templates).extract(out, html_safe)  # (id, urlbase, title, page)
+                finish = time.time()
+                mapreduce_logger.debug(
+                    "PAGE_TIMING pid=%d ordinal=%d id=%s title=%r elapsed=%.2fs",
+                    os.getpid(), ordinal, page_id, title, finish - start)
+                text = out.getvalue()
+                output_queue.put((job[-1], text))  # (ordinal, extracted_text)
+                out.close()
+            else:
+                break
 
 
 def reduce_process(output_queue, out_file, file_size, file_compress, next_ordinal_shared, progress_condition, debug_map_reduce=False):
@@ -968,30 +977,26 @@ def main():
         ignoreTag('a')
 
     if args.article:
-        template_blob_cleanup = None
-        article_templates = None
-        if args.templates:
-            if os.path.exists(args.templates):
-                with decode_open(args.templates) as file:
-                    raw_templates = {}
-                    load_templates(file, templates=raw_templates)
-                # Same compaction as process_dump() -- deliberately
-                # not a separate plain-dict path for --article just
-                # because there's no forking here to protect against:
-                # --article exists partly to validate real behavior,
-                # and exercising a different templates lookup
-                # mechanism here than what real multiprocess runs use
-                # would defeat that.
-                article_templates, _names, template_blob_cleanup = template_blob.compact(raw_templates)
+        if args.templates and os.path.exists(args.templates):
+            with decode_open(args.templates) as file:
+                raw_templates = {}
+                load_templates(file, templates=raw_templates)
+            # Same compaction as process_dump() -- deliberately not a
+            # separate plain-dict path for --article just because
+            # there's no forking here to protect against: --article
+            # exists partly to validate real behavior, and exercising
+            # a different templates lookup mechanism here than what
+            # real multiprocess runs use would defeat that.
+            article_templates_ctx = template_blob.compact(raw_templates)
+        else:
+            article_templates_ctx = contextlib.nullcontext((None, None))
 
-        urlbase = ''
-        with decode_open(input_file) as input:
-            for id, revid, title, page in collect_pages(input):
-                Extractor(id, revid, urlbase, title, page,
-                          templates=article_templates).extract(sys.stdout)
-
-        if template_blob_cleanup is not None:
-            template_blob_cleanup()
+        with article_templates_ctx as (article_templates, _names):
+            urlbase = ''
+            with decode_open(input_file) as input:
+                for id, revid, title, page in collect_pages(input):
+                    Extractor(id, revid, urlbase, title, page,
+                              templates=article_templates).extract(sys.stdout)
         return
 
     output_path = args.output

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -70,7 +70,8 @@ from io import StringIO
 from multiprocessing import Queue, get_context, cpu_count, Value, Condition
 from timeit import default_timer
 
-from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces
+from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces, \
+    resolve_template_page, redirects
 from . import template_blob
 
 # ===========================================================================
@@ -220,7 +221,7 @@ tagRE = re.compile(r'(.*?)<(/?\w+)[^>]*>(?:([^<]*)(<.*?>)?)?')
 #                    1     2               3      4
 
 
-def load_templates(file, output_file=None, encoding='utf-8', templates=None):
+def load_templates(file, output_file=None, encoding='utf-8', templates=None, blob_builder=None):
     """
     Load templates from :param file:.
     :param output_file: file where to save templates and modules.
@@ -233,12 +234,18 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None):
         own dict here explicitly and keep using that same reference
         -- this function mutates it in place, same as
         define_template() itself always has, just one level up.
+        Ignored when blob_builder is given.
+    :param blob_builder: a template_blob.StreamingTemplateBlobBuilder
+        to stream parsed templates directly into instead of
+        populating `templates` -- for a real, full-scale dump, this
+        avoids ever holding a full {title: text} dict in memory at
+        all (see StreamingTemplateBlobBuilder's own docstring).
     :return: number of templates loaded.
     """
     global templateNamespace
     global moduleNamespace, modulePrefix
     modulePrefix = moduleNamespace + ':'
-    if templates is None:
+    if blob_builder is None and templates is None:
         templates = {}
     articles = 0
     template_count = 0
@@ -290,7 +297,16 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None):
             page.append(line)
         elif tag == '/page':
             if title.startswith(Extractor.templatePrefix):
-                define_template(title, page, templates)
+                if blob_builder is not None:
+                    result = resolve_template_page(title, page)
+                    if result is not None:
+                        kind, value = result
+                        if kind == 'redirect':
+                            redirects[title] = value
+                        else:
+                            blob_builder.add(title, value)
+                else:
+                    define_template(title, page, templates)
                 template_count += 1
             # save templates and modules to file
             if output_file and (title.startswith(Extractor.templatePrefix) or
@@ -471,6 +487,65 @@ def watchdog(jobs_queue, output_queue, reduce_proc, workers, stop_event, interva
             "%.1f" % sum(worker_mems) if worker_mems else "unknown")
 
 
+def load_and_compact_templates(template_file, input_file, input):
+    """Loads templates (from template_file if given, else input_file
+    itself) and compacts them into a shared-memory-backed view.
+
+    Returns (template_blob_ctx, input) -- input is returned because,
+    when template_file isn't given, this scans and then re-opens
+    input_file itself, and the caller needs that updated handle.
+
+    Streams parsed templates directly into a
+    template_blob.StreamingTemplateBlobBuilder rather than building a
+    full {title: text} dict first and compacting it as a separate
+    pass -- at full EN scale (~900K templates), having both
+    representations resident at once meant this function's own peak
+    RSS was roughly double the size of the templates themselves,
+    confirmed directly on a real, memory-constrained production run
+    (mapper RSS: ~1.85GB after loading a plain dict, ~4.2GB once the
+    blob was also built alongside it -- and that ~1.85GB never fully
+    came back afterward either, even after the dict went out of scope
+    and an explicit gc.collect(): CPython's own allocator only returns
+    a fully-empty arena to the OS, and a dict with hundreds of
+    thousands of individually-allocated strings, built while other,
+    unrelated parsing allocations were happening at the same time,
+    left enough live stragglers scattered across arenas that most of
+    it stayed mapped). Streaming avoids the dict existing at all, so
+    there's nothing separate left to free or that can fail to be
+    freed -- the content blob's bytes are the only large allocation
+    made, once, directly.
+    """
+    builder = template_blob.StreamingTemplateBlobBuilder()
+    template_load_start = default_timer()
+    if template_file and os.path.exists(template_file):
+        logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", template_file)
+        file = decode_open(template_file)
+        template_count = load_templates(file, blob_builder=builder)
+        file.close()
+    else:
+        if input_file == '-':
+            # can't scan then reset stdin; must error w/ suggestion to specify template_file
+            raise ValueError("to use templates with stdin dump, must supply explicit template-file")
+        logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", input_file)
+        template_count = load_templates(input, template_file, blob_builder=builder)
+        input.close()
+        input = decode_open(input_file)
+    logging.info("Loaded %d templates in %.1fs", template_count, default_timer() - template_load_start)
+
+    # See template_blob.py's own module docstring for why compaction
+    # itself is necessary (fork()'s copy-on-write doesn't protect a
+    # dict of Python objects the way it looks like it should).
+    # template_blob_ctx gets threaded through explicitly to
+    # extract_process() below (and to the single-article path in
+    # main()), which construct their own CompactedTemplates and pass
+    # it directly into each Extractor(..., templates=...).
+    compact_start = default_timer()
+    template_blob_ctx = template_blob.compact_blobs(*builder.finish())
+    logging.info("Compacted templates into shared memory in %.1fs",
+                 default_timer() - compact_start)
+    return template_blob_ctx, input
+
+
 def process_dump(input_file, template_file, out_file, file_size, file_compress,
                  process_count, html_safe, expand_templates=True, debug_map_reduce=False):
     """
@@ -518,54 +593,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
             break
 
     if expand_templates:
-        # preprocess
-        template_load_start = default_timer()
-        raw_templates = {}
-        if template_file and os.path.exists(template_file):
-            logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", template_file)
-            file = decode_open(template_file)
-            template_count = load_templates(file, templates=raw_templates)
-            file.close()
-        else:
-            if input_file == '-':
-                # can't scan then reset stdin; must error w/ suggestion to specify template_file
-                raise ValueError("to use templates with stdin dump, must supply explicit template-file")
-            logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", input_file)
-            template_count = load_templates(input, template_file, templates=raw_templates)
-            input.close()
-            input = decode_open(input_file)
-        template_load_elapsed = default_timer() - template_load_start
-        logging.info("Loaded %d templates in %.1fs", template_count, template_load_elapsed)
-
-        # Compact raw_templates (a plain dict, ~900K individual str
-        # objects at full EN scale) into a shared-memory-backed,
-        # read-only view before forking workers. Necessary because
-        # fork()'s copy-on-write sharing doesn't actually protect a
-        # dict of Python objects the way it looks like it should --
-        # every *read* (even `title in templates`) bumps the touched
-        # object's own refcount, which is a write at the memory level,
-        # so a worker doing nothing but ordinary template lookups
-        # still ends up silently, irreversibly privatizing large
-        # fractions of the dict's pages over its lifetime. See
-        # template_blob.py's own module docstring for the full
-        # reasoning and the production measurements that confirmed it.
-        #
-        # template_blob_names gets threaded through explicitly to
-        # extract_process() below (and to the single-article path in
-        # main()), which construct their own CompactedTemplates and
-        # pass it directly into each Extractor(..., templates=...) --
-        # not picked up implicitly by workers via any shared global --
-        # there is no module-level `templates` in extract.py at all
-        # anymore for that to mean; every reader (Extractor) and
-        # writer (define_template()) takes it as an explicit argument.
-        # This process (the mapper) never constructs an Extractor
-        # itself, so it has no need to hold onto the compacted view --
-        # just the names, to hand to workers, and the cleanup
-        # callback, to release the shared memory once everyone's done.
-        compact_start = default_timer()
-        template_blob_ctx = template_blob.compact(raw_templates)
-        logging.info("Compacted templates into shared memory in %.1fs",
-                     default_timer() - compact_start)
+        template_blob_ctx, input = load_and_compact_templates(template_file, input_file, input)
     else:
         # nullcontext, not None -- keeps the with-statement below
         # uniform regardless of whether templates are in play at all,
@@ -977,17 +1005,23 @@ def main():
         ignoreTag('a')
 
     if args.article:
+        def compact_article_templates(templates_path):
+            """Streams directly into a blob builder, same as
+            load_and_compact_templates() -- matches real behavior more
+            closely, and --article exists partly to validate that."""
+            builder = template_blob.StreamingTemplateBlobBuilder()
+            with decode_open(templates_path) as file:
+                load_templates(file, blob_builder=builder)
+            return template_blob.compact_blobs(*builder.finish())
+
         if args.templates and os.path.exists(args.templates):
-            with decode_open(args.templates) as file:
-                raw_templates = {}
-                load_templates(file, templates=raw_templates)
             # Same compaction as process_dump() -- deliberately not a
             # separate plain-dict path for --article just because
             # there's no forking here to protect against: --article
             # exists partly to validate real behavior, and exercising
             # a different templates lookup mechanism here than what
             # real multiprocess runs use would defeat that.
-            article_templates_ctx = template_blob.compact(raw_templates)
+            article_templates_ctx = compact_article_templates(args.templates)
         else:
             article_templates_ctx = contextlib.nullcontext((None, None))
 

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -70,7 +70,6 @@ from multiprocessing import Queue, get_context, cpu_count, Value, Condition
 from timeit import default_timer
 
 from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces
-from . import extract as ex
 from . import template_blob
 
 # ===========================================================================
@@ -220,17 +219,28 @@ tagRE = re.compile(r'(.*?)<(/?\w+)[^>]*>(?:([^<]*)(<.*?>)?)?')
 #                    1     2               3      4
 
 
-def load_templates(file, output_file=None, encoding='utf-8'):
+def load_templates(file, output_file=None, encoding='utf-8', templates=None):
     """
     Load templates from :param file:.
     :param output_file: file where to save templates and modules.
+    :param templates: the {title: text} dict to populate -- defaults
+        to a fresh, empty dict when not given (matching Extractor's
+        own default), NOT any shared global; there is no longer a
+        module-level `templates` for this function to reach into.
+        A caller that wants access to the populated dict afterward
+        (process_dump(), the --article path, tests) must pass its
+        own dict here explicitly and keep using that same reference
+        -- this function mutates it in place, same as
+        define_template() itself always has, just one level up.
     :return: number of templates loaded.
     """
     global templateNamespace
     global moduleNamespace, modulePrefix
     modulePrefix = moduleNamespace + ':'
+    if templates is None:
+        templates = {}
     articles = 0
-    templates = 0
+    template_count = 0
     page = []
     inText = False
     if output_file:
@@ -279,8 +289,8 @@ def load_templates(file, output_file=None, encoding='utf-8'):
             page.append(line)
         elif tag == '/page':
             if title.startswith(Extractor.templatePrefix):
-                define_template(title, page)
-                templates += 1
+                define_template(title, page, templates)
+                template_count += 1
             # save templates and modules to file
             if output_file and (title.startswith(Extractor.templatePrefix) or
                                 title.startswith(modulePrefix)):
@@ -298,8 +308,8 @@ def load_templates(file, output_file=None, encoding='utf-8'):
                 logging.info("Preprocessed %d pages", articles)
     if output_file:
         output.close()
-        logging.info("Saved %d templates to '%s'", templates, output_file)
-    return templates
+        logging.info("Saved %d templates to '%s'", template_count, output_file)
+    return template_count
 
 
 def decode_open(filename, mode='rt', encoding='utf-8'):
@@ -509,23 +519,24 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     if expand_templates:
         # preprocess
         template_load_start = default_timer()
+        raw_templates = {}
         if template_file and os.path.exists(template_file):
             logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", template_file)
             file = decode_open(template_file)
-            templates = load_templates(file)
+            template_count = load_templates(file, templates=raw_templates)
             file.close()
         else:
             if input_file == '-':
                 # can't scan then reset stdin; must error w/ suggestion to specify template_file
                 raise ValueError("to use templates with stdin dump, must supply explicit template-file")
             logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", input_file)
-            templates = load_templates(input, template_file)
+            template_count = load_templates(input, template_file, templates=raw_templates)
             input.close()
             input = decode_open(input_file)
         template_load_elapsed = default_timer() - template_load_start
-        logging.info("Loaded %d templates in %.1fs", templates, template_load_elapsed)
+        logging.info("Loaded %d templates in %.1fs", template_count, template_load_elapsed)
 
-        # Compact ex.templates (a plain dict, ~900K individual str
+        # Compact raw_templates (a plain dict, ~900K individual str
         # objects at full EN scale) into a shared-memory-backed,
         # read-only view before forking workers. Necessary because
         # fork()'s copy-on-write sharing doesn't actually protect a
@@ -542,16 +553,16 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
         # extract_process() below (and to the single-article path in
         # main()), which construct their own CompactedTemplates and
         # pass it directly into each Extractor(..., templates=...) --
-        # not picked up implicitly from a reassigned ex.templates
-        # global, which used to be the only way a worker's template
-        # source got set up, with nothing in extract.py itself
-        # reflecting that its behavior could be changed from outside
-        # it. This process (the mapper) never constructs an Extractor
+        # not picked up implicitly by workers via any shared global --
+        # there is no module-level `templates` in extract.py at all
+        # anymore for that to mean; every reader (Extractor) and
+        # writer (define_template()) takes it as an explicit argument.
+        # This process (the mapper) never constructs an Extractor
         # itself, so it has no need to hold onto the compacted view --
         # just the names, to hand to workers, and the cleanup
         # callback, to release the shared memory once everyone's done.
         compact_start = default_timer()
-        _wrapper, template_blob_names, template_blob_cleanup = template_blob.compact(ex.templates)
+        _wrapper, template_blob_names, template_blob_cleanup = template_blob.compact(raw_templates)
         logging.info("Compacted templates into shared memory in %.1fs",
                      default_timer() - compact_start)
     else:
@@ -962,7 +973,8 @@ def main():
         if args.templates:
             if os.path.exists(args.templates):
                 with decode_open(args.templates) as file:
-                    load_templates(file)
+                    raw_templates = {}
+                    load_templates(file, templates=raw_templates)
                 # Same compaction as process_dump() -- deliberately
                 # not a separate plain-dict path for --article just
                 # because there's no forking here to protect against:
@@ -970,7 +982,7 @@ def main():
                 # and exercising a different templates lookup
                 # mechanism here than what real multiprocess runs use
                 # would defeat that.
-                article_templates, _names, template_blob_cleanup = template_blob.compact(ex.templates)
+                article_templates, _names, template_blob_cleanup = template_blob.compact(raw_templates)
 
         urlbase = ''
         with decode_open(input_file) as input:

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -70,6 +70,8 @@ from multiprocessing import Queue, get_context, cpu_count, Value, Condition
 from timeit import default_timer
 
 from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces
+from . import extract as ex
+from . import template_blob
 
 # ===========================================================================
 
@@ -523,6 +525,39 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
         template_load_elapsed = default_timer() - template_load_start
         logging.info("Loaded %d templates in %.1fs", templates, template_load_elapsed)
 
+        # Compact ex.templates (a plain dict, ~900K individual str
+        # objects at full EN scale) into a shared-memory-backed,
+        # read-only view before forking workers. Necessary because
+        # fork()'s copy-on-write sharing doesn't actually protect a
+        # dict of Python objects the way it looks like it should --
+        # every *read* (even `title in templates`) bumps the touched
+        # object's own refcount, which is a write at the memory level,
+        # so a worker doing nothing but ordinary template lookups
+        # still ends up silently, irreversibly privatizing large
+        # fractions of the dict's pages over its lifetime. See
+        # template_blob.py's own module docstring for the full
+        # reasoning and the production measurements that confirmed it.
+        #
+        # template_blob_names gets threaded through explicitly to
+        # extract_process() below (and to the single-article path in
+        # main()), which construct their own CompactedTemplates and
+        # pass it directly into each Extractor(..., templates=...) --
+        # not picked up implicitly from a reassigned ex.templates
+        # global, which used to be the only way a worker's template
+        # source got set up, with nothing in extract.py itself
+        # reflecting that its behavior could be changed from outside
+        # it. This process (the mapper) never constructs an Extractor
+        # itself, so it has no need to hold onto the compacted view --
+        # just the names, to hand to workers, and the cleanup
+        # callback, to release the shared memory once everyone's done.
+        compact_start = default_timer()
+        _wrapper, template_blob_names, template_blob_cleanup = template_blob.compact(ex.templates)
+        logging.info("Compacted templates into shared memory in %.1fs",
+                     default_timer() - compact_start)
+    else:
+        template_blob_names = None
+        template_blob_cleanup = None
+
     # process pages
     logging.info("Starting page extraction from %s.", input_file)
     extract_start = default_timer()
@@ -577,7 +612,8 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     workers = []
     for _ in range(max(1, process_count)):
         extractor = Process(target=extract_process,
-                            args=(jobs_queue, output_queue, html_safe, debug_map_reduce))
+                            args=(jobs_queue, output_queue, html_safe, debug_map_reduce,
+                                  template_blob_names))
         extractor.daemon = True  # only live while parent process lives
         extractor.start()
         workers.append(extractor)
@@ -629,6 +665,13 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     if watchdog_thread is not None:
         watchdog_thread.join(timeout=5)
 
+    # Every worker and the reducer have now exited (w.join()/reduce.join()
+    # above already waited for that) -- safe to release the shared
+    # memory for good. template_blob_cleanup is None when extraction
+    # ran with --no-templates, since nothing was ever compacted.
+    if template_blob_cleanup is not None:
+        template_blob_cleanup()
+
     extract_duration = default_timer() - extract_start
     extract_rate = ordinal / extract_duration
     logging.info("Finished %d-process extraction of %d articles in %.1fs (%.1f art/s)",
@@ -639,7 +682,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
 # Multiprocess support
 
 
-def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False):
+def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False, template_blob_names=None):
     """Pull tuples of raw page content, do CPU/regex-heavy fixup, push finished text
     :param jobs_queue: where to get jobs.
     :param output_queue: where to queue extracted text for output.
@@ -656,8 +699,24 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False)
         PAGE_START line -- that's exactly the page it's stuck on, with
         no need to infer it from surrounding pages or wait to see
         whether it was "just slow".
+    :param template_blob_names: names of the shared-memory segments
+        built by template_blob.compact() in process_dump(), or None
+        if extraction is running with --no-templates. Attached here,
+        once, at worker startup, and the resulting view passed
+        explicitly into every Extractor(...) constructed below --
+        not assigned to the extract module's own `templates` global,
+        which used to be how a worker's template source got set up.
+        Passing it as a constructor argument means extract.py's own
+        behavior is visible in extract.py itself (Extractor takes a
+        templates argument) rather than being silently swappable only
+        from here; it's also what's actually required once this
+        worker starts being launched via spawn instead of fork, which
+        inherits nothing implicitly at all -- doing it this way now
+        means extract_process()'s own body doesn't need to change
+        shape later for that transition.
     """
     configure_mapreduce_logging(debug_map_reduce)
+    worker_templates = template_blob.attach(template_blob_names) if template_blob_names is not None else None
     while True:
         job = jobs_queue.get()  # job is (id, revid, urlbase, title, page, ordinal)
         if job:
@@ -666,7 +725,7 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False)
             mapreduce_logger.debug("PAGE_START pid=%d ordinal=%d id=%s title=%r",
                                    os.getpid(), ordinal, page_id, title)
             out = StringIO()  # memory buffer
-            Extractor(*job[:-1]).extract(out, html_safe)  # (id, urlbase, title, page)
+            Extractor(*job[:-1], templates=worker_templates).extract(out, html_safe)  # (id, urlbase, title, page)
             finish = time.time()
             mapreduce_logger.debug(
                 "PAGE_TIMING pid=%d ordinal=%d id=%s title=%r elapsed=%.2fs",
@@ -898,15 +957,29 @@ def main():
         ignoreTag('a')
 
     if args.article:
+        template_blob_cleanup = None
+        article_templates = None
         if args.templates:
             if os.path.exists(args.templates):
                 with decode_open(args.templates) as file:
                     load_templates(file)
+                # Same compaction as process_dump() -- deliberately
+                # not a separate plain-dict path for --article just
+                # because there's no forking here to protect against:
+                # --article exists partly to validate real behavior,
+                # and exercising a different templates lookup
+                # mechanism here than what real multiprocess runs use
+                # would defeat that.
+                article_templates, _names, template_blob_cleanup = template_blob.compact(ex.templates)
 
         urlbase = ''
         with decode_open(input_file) as input:
             for id, revid, title, page in collect_pages(input):
-                Extractor(id, revid, urlbase, title, page).extract(sys.stdout)
+                Extractor(id, revid, urlbase, title, page,
+                          templates=article_templates).extract(sys.stdout)
+
+        if template_blob_cleanup is not None:
+            template_blob_cleanup()
         return
 
     output_path = args.output

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -1456,15 +1456,30 @@ class Extractor():
     # Obtained from TemplateNamespace
     templatePrefix = ''
 
-    def __init__(self, id, revid, urlbase, title, page):
+    def __init__(self, id, revid, urlbase, title, page, templates=None):
         """
         :param page: a list of lines.
+        :param templates: the {title: text} template lookup this
+            extraction should use -- a plain dict (the module-level
+            `templates` global, as populated by define_template()) or
+            anything else supporting `in`/`[]`, e.g. a
+            template_blob.CompactedTemplates view. Defaults to the
+            module-level `templates` global when not given, so every
+            existing caller that never passed this explicitly keeps
+            working unchanged -- but a caller that DOES have its own
+            templates view (extract_process(), the --article path)
+            should pass it here rather than reassigning the module
+            global out from under this module, which used to be the
+            only way to swap in a different templates source and
+            left extract.py itself with no visible sign that its own
+            behavior could be changed from outside it.
         """
         self.id = id
         self.revid = revid
         self.url = get_url(urlbase, id)
         self.title = title
         self.page = page
+        self.templates = templates if templates is not None else globals()['templates']
         self.magicWords = MagicWords()
         self.frame = []
         self.recursion_exceeded_1_errs = 0  # template recursion within expandTemplates()
@@ -1756,8 +1771,8 @@ class Extractor():
             title = redirected
 
         # get the template
-        if title in templates:
-            template = Extractor._parse_template(templates[title])
+        if title in self.templates:
+            template = Extractor._parse_template(self.templates[title])
         else:
             # The page being included could not be identified
             return ''

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -1460,26 +1460,25 @@ class Extractor():
         """
         :param page: a list of lines.
         :param templates: the {title: text} template lookup this
-            extraction should use -- a plain dict (the module-level
-            `templates` global, as populated by define_template()) or
-            anything else supporting `in`/`[]`, e.g. a
-            template_blob.CompactedTemplates view. Defaults to the
-            module-level `templates` global when not given, so every
-            existing caller that never passed this explicitly keeps
-            working unchanged -- but a caller that DOES have its own
-            templates view (extract_process(), the --article path)
-            should pass it here rather than reassigning the module
-            global out from under this module, which used to be the
-            only way to swap in a different templates source and
-            left extract.py itself with no visible sign that its own
-            behavior could be changed from outside it.
+            extraction should use -- a plain dict, populated via
+            define_template(), or anything else supporting `in`/`[]`,
+            e.g. a template_blob.CompactedTemplates view. Defaults to
+            a fresh, empty dict when not given -- not to any shared
+            global -- so a caller that doesn't care about templates
+            (most unit tests) simply gets none, isolated from
+            whatever any other caller or test elsewhere in the same
+            process has loaded; there is no longer a module-level
+            `templates` for this to silently depend on. A caller that
+            DOES need real templates (extract_process(), the
+            --article path) passes its own dict or CompactedTemplates
+            view here explicitly.
         """
         self.id = id
         self.revid = revid
         self.url = get_url(urlbase, id)
         self.title = title
         self.page = page
-        self.templates = templates if templates is not None else globals()['templates']
+        self.templates = templates if templates is not None else {}
         self.magicWords = MagicWords()
         self.frame = []
         self.recursion_exceeded_1_errs = 0  # template recursion within expandTemplates()
@@ -2510,17 +2509,26 @@ def callParserFunction(functionName, args, frame):
 reNoinclude = re.compile(r'<noinclude>(?:.*?)</noinclude>\n?', re.DOTALL)
 reIncludeonly = re.compile(r'<includeonly>|</includeonly>', re.DOTALL)
 
-# These are built before spawning processes, hence they are shared.
-templates = {}
+# redirects is still module-level, shared, mutable state -- deferred
+# deliberately, alongside templatePrefix/knownNamespaces/modules, as
+# its own separate piece of work (see define_template()'s own
+# docstring). templates itself no longer lives here: every reader
+# (Extractor) and writer (define_template()) now takes it as an
+# explicit argument instead.
 redirects = {}
 
 
-def define_template(title, page):
+def define_template(title, page, templates):
     """
-    Adds a template defined in the :param page:.
+    Adds a template defined in the :param page: to :param templates:.
+    :param templates: the {title: text} dict to populate -- required,
+        not defaulted, since this function's entire job is writing
+        into it; a silent "if not given, use a throwaway empty dict"
+        default would make a forgotten argument fail silently (the
+        template is "defined" into a dict nobody keeps) rather than
+        loudly, which is worse than just requiring it.
     @see https://en.wikipedia.org/wiki/Help:Template#Noinclude.2C_includeonly.2C_and_onlyinclude
     """
-    global templates
     global redirects
 
     # title = normalizeTitle(title)

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -2518,54 +2518,36 @@ reIncludeonly = re.compile(r'<includeonly>|</includeonly>', re.DOTALL)
 redirects = {}
 
 
-def define_template(title, page, templates):
+def resolve_template_page(title, page):
     """
-    Adds a template defined in the :param page: to :param templates:.
-    :param templates: the {title: text} dict to populate -- required,
-        not defaulted, since this function's entire job is writing
-        into it; a silent "if not given, use a throwaway empty dict"
-        default would make a forgotten argument fail silently (the
-        template is "defined" into a dict nobody keeps) rather than
-        loudly, which is worse than just requiring it.
-    @see https://en.wikipedia.org/wiki/Help:Template#Noinclude.2C_includeonly.2C_and_onlyinclude
+    Given a template page's raw text lines, determines whether it's a
+    redirect or a genuine template definition, and if the latter,
+    computes its final, stored text (comments stripped,
+    noinclude/includeonly/onlyinclude resolved per
+    https://en.wikipedia.org/wiki/Help:Template#Noinclude.2C_includeonly.2C_and_onlyinclude).
+
+    Returns one of:
+      - None: nothing to store (an empty page, or a template whose
+        body is empty once noinclude/includeonly processing is done).
+      - ('redirect', target_title)
+      - ('template', final_text)
+
+    Used by both define_template() (writes into a plain {title: text}
+    dict) and template_blob's streaming builder (appends straight into
+    a shared-memory blob without ever building that dict at all) --
+    kept as the one place this resolution logic lives so both stay in
+    sync automatically.
     """
-    global redirects
-
-    # title = normalizeTitle(title)
-
-    # An empty page (zero lines) is a genuine, valid case for a
-    # template whose current revision has no content at all (a
-    # self-closing <text bytes="0" .../> in the source) -- not a
-    # redirect, and not any real content either. Reachable now that
-    # collect_pages()/load_templates() correctly recognize that
-    # self-closing form instead of silently merging the next page's
-    # content into this one.
     if not page:
-        return
+        return None
 
-    # check for redirects
     m = redirectRE.match(page[0])
     if m:
-        redirects[title] = m.group(1)  # normalizeTitle(m.group(1))
-        return
+        return ('redirect', m.group(1))
 
     text = unescape(''.join(page))
-
-    # We're storing template text for future inclusion, therefore,
-    # remove all <noinclude> text and keep all <includeonly> text
-    # (but eliminate <includeonly> tags per se).
-    # However, if <onlyinclude> ... </onlyinclude> parts are present,
-    # then only keep them and discard the rest of the template body.
-    # This is because using <onlyinclude> on a text fragment is
-    # equivalent to enclosing it in <includeonly> tags **AND**
-    # enclosing all the rest of the template body in <noinclude> tags.
-
-    # remove comments
     text = comment.sub('', text)
-
-    # eliminate <noinclude> fragments
     text = reNoinclude.sub('', text)
-    # eliminate unterminated <noinclude> elements
     text = re.sub(r'<noinclude\s*>.*$', '', text, flags=re.DOTALL)
     text = re.sub(r'<noinclude/>\n?', '', text)
 
@@ -2577,7 +2559,30 @@ def define_template(title, page, templates):
     else:
         text = reIncludeonly.sub('', text)
 
-    if text:
-        if title in templates and templates[title] != text:
-            logger.warning('Redefining: %s', title)
-        templates[title] = text
+    if not text:
+        return None
+    return ('template', text)
+
+
+def define_template(title, page, templates):
+    """
+    Adds a template defined in the :param page: to :param templates:.
+    :param templates: the {title: text} dict to populate -- required,
+        not defaulted, since this function's entire job is writing
+        into it; a silent "if not given, use a throwaway empty dict"
+        default would make a forgotten argument fail silently (the
+        template is "defined" into a dict nobody keeps) rather than
+        loudly, which is worse than just requiring it.
+    """
+    global redirects
+    result = resolve_template_page(title, page)
+    if result is None:
+        return
+    kind, value = result
+    if kind == 'redirect':
+        redirects[title] = value
+        return
+    text = value
+    if title in templates and templates[title] != text:
+        logger.warning('Redefining: %s', title)
+    templates[title] = text

--- a/wikiextractor/template_blob.py
+++ b/wikiextractor/template_blob.py
@@ -258,15 +258,12 @@ class CompactedTemplatesOwner:
         return False
 
 
-def compact(templates_dict):
-    """Build shared-memory segments from templates_dict and return a
-    CompactedTemplatesOwner -- a context manager that, on exit, closes
-    and unlinks the three underlying shared_memory segments for good.
-    See CompactedTemplatesOwner's own docstring for the intended usage
-    shape and why this is a different type from what attach() returns.
+def compact_blobs(records_bytes, titles_bytes, content_bytes):
+    """Wraps already-built (records, titles, content) blobs -- from
+    build_template_blobs() or StreamingTemplateBlobBuilder.finish() --
+    into shared memory and returns a CompactedTemplatesOwner. See
+    compact()'s own docstring for the intended usage shape.
     """
-    records_bytes, titles_bytes, content_bytes = build_template_blobs(templates_dict)
-
     records_shm = shared_memory.SharedMemory(create=True, size=max(1, len(records_bytes)))
     records_shm.buf[:len(records_bytes)] = records_bytes
     titles_shm = shared_memory.SharedMemory(create=True, size=max(1, len(titles_bytes)))
@@ -283,6 +280,85 @@ def compact(templates_dict):
     names = (records_shm.name, titles_shm.name, content_shm.name, len(records_bytes))
 
     return CompactedTemplatesOwner(wrapper, names)
+
+
+def compact(templates_dict):
+    """Build shared-memory segments from templates_dict and return a
+    CompactedTemplatesOwner -- a context manager that, on exit, closes
+    and unlinks the three underlying shared_memory segments for good.
+    See CompactedTemplatesOwner's own docstring for the intended usage
+    shape and why this is a different type from what attach() returns.
+
+    templates_dict must already exist as a full {title: text} dict --
+    for loading a real, full-scale dump, prefer
+    StreamingTemplateBlobBuilder instead, which builds the same blobs
+    without ever holding that dict in memory at all. This function
+    stays for callers (tests, smaller tools) that already have such a
+    dict on hand for other reasons.
+    """
+    return compact_blobs(*build_template_blobs(templates_dict))
+
+
+class StreamingTemplateBlobBuilder:
+    """Builds the same three blobs as build_template_blobs(), one
+    (title, text) pair at a time, without ever holding a full
+    {title: text} dict in memory -- only the (title, content_offset,
+    content_length) metadata, far smaller than the template bodies
+    themselves, survives between add() calls. content_blob doesn't
+    need to be title-sorted -- only records (the binary-searchable
+    index) does, since each record just points at wherever its own
+    content happens to live -- so content is appended in whatever
+    order add() is called, and only the metadata gets sorted, once,
+    at finish().
+
+    Exists because build_template_blobs() requires a complete dict
+    up front: at full EN scale, loading that dict, then building an
+    equally large set of blobs from it while the dict is still alive,
+    means both representations of ~900K templates are resident at
+    once -- confirmed directly on a real, memory-constrained
+    production run, where this doubled peak was measured contributing
+    directly to an earlier out-of-memory kill. Streaming avoids the
+    dict existing at all, not just freeing it quickly afterward.
+
+    Usage:
+        builder = StreamingTemplateBlobBuilder()
+        builder.add('Template:Foo', 'some text')
+        ...
+        owner = compact_blobs(*builder.finish())
+    """
+
+    def __init__(self):
+        self._content_parts = []
+        self._content_offset = 0
+        self._metadata = []  # (title, content_offset, content_length)
+
+    def add(self, title, text):
+        encoded = text.encode('utf-8')
+        length = len(encoded)
+        self._metadata.append((title, self._content_offset, length))
+        self._content_parts.append(encoded)
+        self._content_offset += length
+
+    def finish(self):
+        """Returns (records_bytes, titles_bytes, content_bytes), the
+        same shape build_template_blobs() returns -- pass straight
+        into compact_blobs()."""
+        content_blob = b''.join(self._content_parts)
+        self._content_parts = None  # let the (now-redundant) parts list go
+
+        title_parts = []
+        title_offset = 0
+        records = []
+        for title, c_off, c_len in sorted(self._metadata, key=lambda t: t[0]):
+            encoded_title = title.encode('utf-8')
+            records.append(struct.pack(RECORD_FORMAT, title_offset, len(encoded_title), c_off, c_len))
+            title_parts.append(encoded_title)
+            title_offset += len(encoded_title)
+        self._metadata = None
+        titles_blob = b''.join(title_parts)
+        records_blob = b''.join(records)
+
+        return records_blob, titles_blob, content_blob
 
 
 def attach(names):

--- a/wikiextractor/template_blob.py
+++ b/wikiextractor/template_blob.py
@@ -1,0 +1,272 @@
+"""
+template_blob.py
+
+A read-only, dict-like view over {title: template_text}, backed by
+three flat byte buffers (a sorted, binary-searchable title index;
+concatenated title bytes; concatenated content bytes) instead of one
+Python dict holding ~900K individual str objects.
+
+Why this exists: fork()'s copy-on-write sharing does not actually
+protect a plain dict full of strings the way it looks like it should.
+Every *read* of a Python object -- even `title in templates`, which
+looks read-only -- increments that object's own refcount, which lives
+in the same memory page as the object itself. That increment is a
+write at the memory level, and writing to any part of a page is
+exactly what triggers copy-on-write. So a worker process doing nothing
+but ordinary template lookups still ends up silently, irreversibly
+privatizing large fractions of the dict's pages over its lifetime, one
+touched title at a time -- defeating COW despite the worker never
+intentionally mutating anything.
+
+Confirmed directly on a real, memory-constrained production run (8GB/
+job, 31 workers, ~897K templates): via /proc/<pid>/smaps_rollup, a
+worker doing real template lookups showed Private_Dirty 5-8x higher
+than the reducer/mapper (which mostly relay already-processed text,
+touching far fewer distinct templates) -- tracking exactly with how
+much each process type actually reads from `templates`, not with
+anything either of them explicitly writes.
+
+Raw shared-memory bytes sidestep this entirely: there are no per-title
+Python objects sitting in the buffer waiting to be referenced and
+refcounted. A lookup touches a handful of small slices during binary
+search, decodes the ONE matched (title, content) pair into a fresh
+str, and that transient object is garbage collected shortly after use
+-- nothing about a lookup privatizes any shared page. Verified earlier
+(see prescan/lru_cache work) that this holds at real scale: worker RSS
+stayed flat around 18-24MB regardless of corpus size, using this exact
+three-blob design.
+
+Layout:
+  content_blob: concatenated raw template text, UTF-8
+  titles_blob:  concatenated title text, UTF-8, same order as records
+  records:      fixed-width array, SORTED by title (binary search),
+                one record per template:
+                  >QQQQ = title_offset, title_length, content_offset, content_length
+                (all big-endian unsigned 64-bit, 32 bytes/record)
+
+Used identically from both the multiprocess path (process_dump) and
+the single-article (--article) path -- deliberately not a separate
+plain-dict branch for the latter, since exercising a different lookup
+mechanism there would defeat --article's use as a way to validate real
+behavior, not just a fast path for one-off runs.
+"""
+
+import struct
+from functools import lru_cache
+from multiprocessing import shared_memory
+
+RECORD_FORMAT = '>QQQQ'
+RECORD_SIZE = struct.calcsize(RECORD_FORMAT)
+
+
+def build_template_blobs(templates_dict):
+    """templates_dict: {title: text}, e.g. extract.templates as
+    populated by load_templates()/define_template() before compaction.
+    Returns (records_bytes, titles_bytes, content_bytes)."""
+    content_parts = []
+    content_offset = 0
+    content_offsets = {}
+    for title, text in templates_dict.items():
+        encoded = text.encode('utf-8')
+        content_offsets[title] = (content_offset, len(encoded))
+        content_parts.append(encoded)
+        content_offset += len(encoded)
+    content_blob = b''.join(content_parts)
+
+    title_parts = []
+    title_offset = 0
+    records = []
+    for title in sorted(templates_dict.keys()):  # sorted -> binary search works
+        encoded_title = title.encode('utf-8')
+        c_off, c_len = content_offsets[title]
+        records.append(struct.pack(RECORD_FORMAT, title_offset, len(encoded_title), c_off, c_len))
+        title_parts.append(encoded_title)
+        title_offset += len(encoded_title)
+    titles_blob = b''.join(title_parts)
+    records_blob = b''.join(records)
+
+    return records_blob, titles_blob, content_blob
+
+
+class CompactedTemplates:
+    """Read-only, dict-like view over the three blobs above. Supports
+    exactly what extract.py's own template-lookup code uses:
+    `title in templates` and `templates[title]` (plus `.get()`, for
+    compatibility with the other tools built against extract.templates
+    over the course of this project -- prescan_template_usage.py,
+    extract_templates_by_id.py -- which do use it).
+
+    Deliberately no __setitem__: nothing should be writing to
+    `templates` after compaction (all real writes happen earlier, via
+    define_template() during loading, against the plain dict this
+    class replaces) -- a write attempted after compaction should fail
+    loudly (a plain TypeError, from Python's own "object does not
+    support item assignment"), not silently do the wrong thing.
+
+    Keeps a small, bounded, title-keyed cache of already-decoded
+    content strings. Without it, every lookup of `templates[title]` --
+    even the 1000th lookup of the same, already-parse-cached template
+    -- would still pay for a fresh bytes->str decode (and a fresh hash
+    computation over that new string, for whatever lru_cache the
+    result is about to be checked against) before Extractor's own
+    _parse_template() cache ever gets a chance to short-circuit
+    anything. At real EN scale, several templates are referenced by a
+    large fraction of the entire multi-million-article corpus (String,
+    Citation/CS1, etc.) -- redundantly decoding those on every single
+    use, forever, is a real and avoidable cost. This cache absorbs
+    that: a hit here returns the SAME decoded string object each time,
+    so a downstream lru_cache benefits from CPython's own hash-caching
+    on that object too, not just from skipping re-parsing.
+    """
+
+    def __init__(self, records_buf, titles_buf, content_buf, records_len=None, decode_cache_size=10000):
+        self._records = records_buf
+        self._titles = titles_buf
+        self._content = content_buf
+        # records_len lets the caller say "only the first N bytes of
+        # records_buf are real data" -- needed because
+        # SharedMemory's actual allocation can be larger than
+        # requested (page-size rounding), so len(records_buf) alone
+        # isn't reliably the true record count. Titles/content don't
+        # need this: every offset stored in a record already points
+        # within the real data range, so slicing with those offsets
+        # is safe even if the buffer has unused trailing space.
+        self._n = (records_len if records_len is not None else len(records_buf)) // RECORD_SIZE
+        self._owned_shms = []  # populated by attach()/compact(), for cleanup
+
+        # Instance-bound cache (not a bare @lru_cache on a method,
+        # which would share state across every CompactedTemplates
+        # instance ever constructed -- each worker's own instance
+        # needs its own, independent cache).
+        self._decode = lru_cache(maxsize=decode_cache_size)(self._decode_uncached)
+
+    def _find(self, title):
+        """Binary search over records, by title. Returns (content_off,
+        content_len) or None."""
+        query = title.encode('utf-8')
+        lo, hi = 0, self._n - 1
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            rec = self._records[mid * RECORD_SIZE:(mid + 1) * RECORD_SIZE]
+            t_off, t_len, c_off, c_len = struct.unpack(RECORD_FORMAT, rec)
+            mid_title = bytes(self._titles[t_off:t_off + t_len])
+            if mid_title == query:
+                return c_off, c_len
+            elif mid_title < query:
+                lo = mid + 1
+            else:
+                hi = mid - 1
+        return None
+
+    def _decode_uncached(self, title):
+        found = self._find(title)
+        if found is None:
+            return None
+        c_off, c_len = found
+        return bytes(self._content[c_off:c_off + c_len]).decode('utf-8')
+
+    def __contains__(self, title):
+        return self._decode(title) is not None
+
+    def __getitem__(self, title):
+        text = self._decode(title)
+        if text is None:
+            raise KeyError(title)
+        return text
+
+    def get(self, title, default=None):
+        text = self._decode(title)
+        return default if text is None else text
+
+    def __len__(self):
+        return self._n
+
+    def close(self):
+        """Detach from shared memory (this process only) -- call once
+        this wrapper is no longer needed. Safe to call on an instance
+        that doesn't own any shared_memory handles (e.g. one built
+        in-process for a test); a no-op in that case.
+
+        Releases this instance's own memoryview references first --
+        SharedMemory.close() refuses to run ("cannot close exported
+        pointers exist") while any memoryview derived from .buf is
+        still alive, and self._records/_titles/_content (plus
+        whatever the decode cache is holding) are exactly that.
+        """
+        self._decode.cache_clear()
+        for attr in ('_records', '_titles', '_content'):
+            buf = getattr(self, attr)
+            if isinstance(buf, memoryview):
+                buf.release()
+        for shm in self._owned_shms:
+            shm.close()
+
+    def unlink(self):
+        """Release the underlying shared memory for good -- call ONCE,
+        from whichever process created it (the mapper / single-article
+        path), only after every consumer (workers, or this same
+        in-process extraction loop) is done reading it."""
+        for shm in self._owned_shms:
+            shm.unlink()
+
+
+def compact(templates_dict):
+    """Build shared-memory segments from templates_dict and return a
+    (CompactedTemplates, cleanup) pair. cleanup() must be called
+    exactly once, after every consumer (workers, or the caller itself
+    in the single-article case) is done -- it closes and unlinks the
+    three underlying shared_memory segments.
+
+    The returned CompactedTemplates also owns and closes its own
+    handles to these segments (via .close()); cleanup() additionally
+    unlinks them (releasing the memory for real) -- kept separate
+    since only the creator should ever unlink, while every consumer,
+    including the creator itself, should close.
+    """
+    records_bytes, titles_bytes, content_bytes = build_template_blobs(templates_dict)
+
+    records_shm = shared_memory.SharedMemory(create=True, size=max(1, len(records_bytes)))
+    records_shm.buf[:len(records_bytes)] = records_bytes
+    titles_shm = shared_memory.SharedMemory(create=True, size=max(1, len(titles_bytes)))
+    titles_shm.buf[:len(titles_bytes)] = titles_bytes
+    content_shm = shared_memory.SharedMemory(create=True, size=max(1, len(content_bytes)))
+    content_shm.buf[:len(content_bytes)] = content_bytes
+
+    wrapper = CompactedTemplates(
+        records_shm.buf, titles_shm.buf, content_shm.buf,
+        records_len=len(records_bytes),
+    )
+    wrapper._owned_shms = [records_shm, titles_shm, content_shm]
+
+    names = (records_shm.name, titles_shm.name, content_shm.name, len(records_bytes))
+
+    def cleanup():
+        wrapper.close()
+        for shm in (records_shm, titles_shm, content_shm):
+            shm.unlink()
+
+    return wrapper, names, cleanup
+
+
+def attach(names):
+    """Worker-side: attach to the three already-built shared-memory
+    segments by name (as returned by compact()) and return a
+    CompactedTemplates view over them. Cheap -- three small mmap
+    attach calls, no data copied.
+
+    names: (records_name, titles_name, content_name, records_len) --
+    records_len (the real byte length of the records blob, as
+    written) is carried through explicitly rather than trusting
+    len(records_shm.buf) to equal it -- true on the platforms this has
+    been tested on, but not a documented guarantee of the
+    SharedMemory API, and not worth depending on silently.
+    """
+    records_name, titles_name, content_name, records_len = names
+    records_shm = shared_memory.SharedMemory(name=records_name)
+    titles_shm = shared_memory.SharedMemory(name=titles_name)
+    content_shm = shared_memory.SharedMemory(name=content_name)
+
+    wrapper = CompactedTemplates(records_shm.buf, titles_shm.buf, content_shm.buf,
+                                  records_len=records_len)
+    wrapper._owned_shms = [records_shm, titles_shm, content_shm]
+    return wrapper

--- a/wikiextractor/template_blob.py
+++ b/wikiextractor/template_blob.py
@@ -209,19 +209,61 @@ class CompactedTemplates:
         for shm in self._owned_shms:
             shm.unlink()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        # Deliberately close() only, never unlink(): this class is
+        # used identically by both the creator (compact()) and every
+        # consumer that merely attach()ed to an existing segment by
+        # name -- a consumer unlinking would destroy shared memory
+        # out from under any sibling worker still reading it. Full
+        # lifetime ownership (close + unlink) is CompactedTemplatesOwner's
+        # job specifically, returned by compact() for exactly this
+        # reason -- see there.
+        self.close()
+        return False
+
+
+class CompactedTemplatesOwner:
+    """Context manager for the process that actually called compact()
+    -- as opposed to CompactedTemplates itself, which every consumer
+    (the owner included) uses identically for read access and for
+    releasing just its own view. On exit, this one additionally
+    unlinks the underlying shared memory for good, which must only
+    ever happen once, from the creator, after every consumer (workers,
+    or this same process if used in-line) is done -- never from a
+    worker that only attach()ed.
+
+    Usage:
+        with template_blob.compact(raw_templates) as (wrapper, names):
+            # spawn workers, pass them `names` to attach() with, wait
+            # for them to finish (or do in-process reads via `wrapper`
+            # directly, e.g. the single-article path)
+        # close() + unlink() on all three segments happens here,
+        # automatically, even if the block above raised.
+    """
+
+    def __init__(self, wrapper, names):
+        self.wrapper = wrapper
+        self.names = names
+
+    def __enter__(self):
+        return self.wrapper, self.names
+
+    def __exit__(self, *exc_info):
+        self.wrapper.close()
+        for shm in self.wrapper._owned_shms:
+            shm.unlink()
+        return False
+
 
 def compact(templates_dict):
     """Build shared-memory segments from templates_dict and return a
-    (CompactedTemplates, cleanup) pair. cleanup() must be called
-    exactly once, after every consumer (workers, or the caller itself
-    in the single-article case) is done -- it closes and unlinks the
-    three underlying shared_memory segments.
-
-    The returned CompactedTemplates also owns and closes its own
-    handles to these segments (via .close()); cleanup() additionally
-    unlinks them (releasing the memory for real) -- kept separate
-    since only the creator should ever unlink, while every consumer,
-    including the creator itself, should close.
+    CompactedTemplatesOwner -- a context manager that, on exit, closes
+    and unlinks the three underlying shared_memory segments for good.
+    See CompactedTemplatesOwner's own docstring for the intended usage
+    shape and why this is a different type from what attach() returns.
     """
     records_bytes, titles_bytes, content_bytes = build_template_blobs(templates_dict)
 
@@ -240,12 +282,7 @@ def compact(templates_dict):
 
     names = (records_shm.name, titles_shm.name, content_shm.name, len(records_bytes))
 
-    def cleanup():
-        wrapper.close()
-        for shm in (records_shm, titles_shm, content_shm):
-            shm.unlink()
-
-    return wrapper, names, cleanup
+    return CompactedTemplatesOwner(wrapper, names)
 
 
 def attach(names):
@@ -253,6 +290,13 @@ def attach(names):
     segments by name (as returned by compact()) and return a
     CompactedTemplates view over them. Cheap -- three small mmap
     attach calls, no data copied.
+
+    The returned object is itself a context manager (via
+    CompactedTemplates.__enter__/__exit__) -- `with attach(names) as
+    worker_templates:` closes this process's own view automatically
+    on exit, without ever unlinking the underlying segments (that
+    remains the creator's responsibility alone, via
+    CompactedTemplatesOwner -- see compact()).
 
     names: (records_name, titles_name, content_name, records_len) --
     records_len (the real byte length of the records blob, as


### PR DESCRIPTION
A refactoring (by Claude) to turn the template dictionary into a single blob which is owned by the master process (eg, the mapper)

There are a few reasons for this.

One is that in the high process low ram regime - for example, our cluster using 32 CPUs but only 8GB on EN - processing gets much further with this in place.  The key reason for this is that fork's COW (copy on write) behavior gradually pulls in more and more pages into the children, causing them to bloat, so the entire process tree eventually OOMs.  As the hash tables are referenced, reference counting makes those pages "dirty" and therefore copied into the fork.  This does not happen with the blob because it is a single reference (well, three) shared among each child.

The other main reason is that when we try to port WikiExtractor to Windows, one of the main obstacles is that it is extremely slow and memory intensive to transfer the entire templates dict using `spawn`.  `fork`, of course, would share that memory space but does not exist on Windows.  Using a `SharedMemory` blob is substantially easier to transfer, as it only requires transferring the name of the blob.

Overall layout:

- there is a sorted array of key position, key length, value position, value length
- there is a continuous array of output keys, where the start and end is determined by the position & length from the first array
- there is also a continuous array of values with the same structure

The method for finding something in this map is to binary search in the positions array for a given key, checking in the key array at each step if it's the right one.  If a key can't be found, it isn't in the map.  If it is found, then that gives you the start and end of the template text in the values array.

Once the template is found, of course, processing goes the same as before.

The template blob is constructed in a streaming manner, as best as possible, as this avoids wasting memory in the parent process, such as by loading the template hash in the parent process and then converting.  Experiments showed that if the mapper process first allocates 1.5G for the template hash, then 1.5G for the blobs, the 1.5G for the hash *is not freed* back to the system, even if it goes out of scope.  In practice this mattered a great deal: switching to streaming, which avoids the hash table ever existing as a separate, simultaneous allocation in the first place, was the difference between the EN run OOMing early and running to completion.

Left unchanged so far is the `redirects` map, which needs the same treatment but is substantially smaller.