### PR TITLE
Remove remaining global state from Extractor so we can set up switching to `spawn` for Windows

### DIFF
--- a/tests/test_article_extraction_content.py
+++ b/tests/test_article_extraction_content.py
@@ -143,7 +143,7 @@ class ArticleExtractionContentTestCase(unittest.TestCase):
 
     def setUp(self):
         we.templateNamespace = ''
-        ex.Extractor.templatePrefix = ''
+        self.templatePrefix = ''
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         with io.StringIO(_ARTICLE_XML) as f:
@@ -154,7 +154,7 @@ class ArticleExtractionContentTestCase(unittest.TestCase):
                 tag = m.group(2)
                 if tag == 'namespace' and 'key="10"' in line:
                     we.templateNamespace = m.group(3)
-                    ex.Extractor.templatePrefix = we.templateNamespace + ':'
+                    self.templatePrefix = we.templateNamespace + ':'
                 elif tag == '/siteinfo':
                     break
 
@@ -163,14 +163,16 @@ class ArticleExtractionContentTestCase(unittest.TestCase):
         redirects = {}
         if with_templates:
             with io.StringIO(_ARTICLE_XML) as f:
-                we.load_templates(f, templates=templates, redirects=redirects)
+                we.load_templates(f, templates=templates, redirects=redirects,
+                                   template_prefix=self.templatePrefix)
 
         with io.StringIO(_ARTICLE_XML) as f:
             pages = list(we.collect_pages(f))
         [(page_id, revid, title, page)] = [p for p in pages if p[2] == 'Geography']
 
         extractor = Extractor(page_id, revid, 'https://test.wikipedia.org/wiki?curid=1',
-                               title, page, templates=templates, redirects=redirects)
+                               title, page, templates=templates, redirects=redirects,
+                               templatePrefix=self.templatePrefix)
         return extractor.clean_text(''.join(page), expand_templates=True)
 
 

--- a/tests/test_article_extraction_content.py
+++ b/tests/test_article_extraction_content.py
@@ -144,7 +144,6 @@ class ArticleExtractionContentTestCase(unittest.TestCase):
     def setUp(self):
         we.templateNamespace = ''
         ex.Extractor.templatePrefix = ''
-        ex.redirects.clear()
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
         with io.StringIO(_ARTICLE_XML) as f:
@@ -161,16 +160,17 @@ class ArticleExtractionContentTestCase(unittest.TestCase):
 
     def extract_article(self, with_templates):
         templates = {}
+        redirects = {}
         if with_templates:
             with io.StringIO(_ARTICLE_XML) as f:
-                we.load_templates(f, templates=templates)
+                we.load_templates(f, templates=templates, redirects=redirects)
 
         with io.StringIO(_ARTICLE_XML) as f:
             pages = list(we.collect_pages(f))
         [(page_id, revid, title, page)] = [p for p in pages if p[2] == 'Geography']
 
         extractor = Extractor(page_id, revid, 'https://test.wikipedia.org/wiki?curid=1',
-                               title, page, templates=templates)
+                               title, page, templates=templates, redirects=redirects)
         return extractor.clean_text(''.join(page), expand_templates=True)
 
 

--- a/tests/test_article_mode.py
+++ b/tests/test_article_mode.py
@@ -40,7 +40,6 @@ import unittest
 sys.path.insert(0, '..')  # allow running directly from tests/ without installing
 
 import wikiextractor.WikiExtractor as we
-import wikiextractor.extract as ex
 
 # A minimal, realistic single-article dump, deliberately including
 # non-ASCII (Arabic-script) content alongside a template call, so a
@@ -100,20 +99,10 @@ class ArticleModeTestCase(unittest.TestCase):
 
         self._orig_argv = sys.argv
         self._orig_stdout = sys.stdout
-        # we.main() calls ignoreTag('a') unconditionally by default
-        # (Extractor.keepLinks defaults to False), permanently adding
-        # to extract.py's module-level ignored_tag_patterns with no
-        # matching cleanup of its own -- reasonable for a real,
-        # one-shot CLI invocation, but this file calls we.main()
-        # repeatedly, in-process, across many tests. Save/restore here
-        # so that leak doesn't outlive this test class and silently
-        # change unrelated tests' behavior elsewhere in the suite.
-        self._orig_ignored_tag_patterns = list(ex.ignored_tag_patterns)
 
     def tearDown(self):
         sys.argv = self._orig_argv
         sys.stdout = self._orig_stdout
-        ex.ignored_tag_patterns = self._orig_ignored_tag_patterns
         for path in (self.input_plain, self.templates_plain,
                      self.input_bz2, self.templates_bz2):
             if os.path.exists(path):

--- a/tests/test_block_separator_tags.py
+++ b/tests/test_block_separator_tags.py
@@ -47,7 +47,6 @@ class BlockSeparatorTagsTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_block_separator_tags.py
+++ b/tests/test_block_separator_tags.py
@@ -47,11 +47,11 @@ class BlockSeparatorTagsTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_brace_matching.py
+++ b/tests/test_brace_matching.py
@@ -165,14 +165,14 @@ class RecursiveNestingEndToEndTests(unittest.TestCase):
 
     def setUp(self):
         self.templates = {}
+        self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text], templates=self.templates)
+                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
         return extractor.clean_text(article_text, expand_templates=True)
 
     def test_six_brace_indirection_the_real_documented_example(self):
@@ -183,12 +183,12 @@ class RecursiveNestingEndToEndTests(unittest.TestCase):
         # "bar". MediaWiki namespaces auto-capitalize the first letter
         # of a title, so the template must be defined as "Template:Ppp"
         # to correctly match a call written as {{ppp|...}}.
-        ex.define_template('Template:Ppp', ['{{{{{{p}}}}}}'], self.templates)
+        ex.define_template('Template:Ppp', ['{{{{{{p}}}}}}'], self.templates, self.redirects)
         result = self.get_result('{{ppp|p=foo|foo=bar}}')
         self.assertEqual(result, ['bar'])
 
     def test_twelve_brace_fourth_level_indirection_the_real_documented_example(self):
-        ex.define_template('Template:Tvvvv', ['{{{{{{{{{{{{p}}}}}}}}}}}}'], self.templates)
+        ex.define_template('Template:Tvvvv', ['{{{{{{{{{{{{p}}}}}}}}}}}}'], self.templates, self.redirects)
         result = self.get_result('{{tvvvv|p=alpha|alpha=beta|beta=gamma|gamma=delta}}')
         self.assertEqual(result, ['delta'])
 
@@ -224,21 +224,21 @@ class RecursiveNestingWeirdCountsEndToEndTests(unittest.TestCase):
 
     def setUp(self):
         self.templates = {}
+        self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text], templates=self.templates)
+                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
         return extractor.clean_text(article_text, expand_templates=True)
 
     def test_seven_braces_stray_literal_brace_survives_around_resolved_value(self):
         # 7 = 2*3 + 1: two nested tplarg levels, wrapped in one leftover,
         # literal stray '{'/'}' on each side (not a valid delimiter of
         # any kind, so it just survives as plain text).
-        ex.define_template('Template:Seven', ['X{{{{{{{p}}}}}}}X'], self.templates)
+        ex.define_template('Template:Seven', ['X{{{{{{{p}}}}}}}X'], self.templates, self.redirects)
         result = self.get_result('{{seven|p=foo|foo=bar}}')
         self.assertEqual(result, ['X{bar}X'])
 
@@ -246,8 +246,8 @@ class RecursiveNestingWeirdCountsEndToEndTests(unittest.TestCase):
         # 8 = 2*3 + 2: two nested tplarg levels resolve to a value that
         # itself becomes the NAME of a real, outer, dynamically-named
         # 2-brace template call.
-        ex.define_template('Template:Eight', ['{{{{{{{{p}}}}}}}}'], self.templates)
-        ex.define_template('Template:Bar', ['outer template content'], self.templates)
+        ex.define_template('Template:Eight', ['{{{{{{{{p}}}}}}}}'], self.templates, self.redirects)
+        ex.define_template('Template:Bar', ['outer template content'], self.templates, self.redirects)
         result = self.get_result('{{eight|p=foo|foo=Bar}}')
         self.assertEqual(result, ['outer template content'])
 
@@ -261,19 +261,19 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
 
     def setUp(self):
         self.templates = {}
+        self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text], templates=self.templates)
+                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
         return extractor.clean_text(article_text, expand_templates=True)
 
     def test_dynamic_template_name_call_resolves_correctly(self):
-        ex.define_template('Template:Wrapper', ['{{{{{1}}}}}'], self.templates)
-        ex.define_template('Template:Target', ['the real target content'], self.templates)
+        ex.define_template('Template:Wrapper', ['{{{{{1}}}}}'], self.templates, self.redirects)
+        ex.define_template('Template:Target', ['the real target content'], self.templates, self.redirects)
         text = 'before {{Wrapper|Target}} after'
         result = self.get_result(text)
         self.assertEqual(result, ['before the real target content after'])
@@ -282,8 +282,8 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
         # Matches the real case this was found on: a conditional
         # wrapper that dynamically calls whatever template name was
         # passed, or falls back to plain text if no parameter was given.
-        ex.define_template('Template:Wrapper', ['{{#if:{{{1|}}}|{{{{{1}}}}}|no param given}}'], self.templates)
-        ex.define_template('Template:StubNotice', ['This article is a stub.'], self.templates)
+        ex.define_template('Template:Wrapper', ['{{#if:{{{1|}}}|{{{{{1}}}}}|no param given}}'], self.templates, self.redirects)
+        ex.define_template('Template:StubNotice', ['This article is a stub.'], self.templates, self.redirects)
 
         with_param = self.get_result('x {{Wrapper|StubNotice}} y')
         self.assertEqual(with_param, ['x This article is a stub. y'])
@@ -295,9 +295,9 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
         # The specific, confirmed failure mode: before the fix, this
         # dynamic call was misinterpreted as a direct call to a
         # template literally named "1".
-        ex.define_template('Template:1', ['WRONG -- this should never be reached'], self.templates)
-        ex.define_template('Template:Wrapper', ['{{{{{1}}}}}'], self.templates)
-        ex.define_template('Template:Target', ['correct content'], self.templates)
+        ex.define_template('Template:1', ['WRONG -- this should never be reached'], self.templates, self.redirects)
+        ex.define_template('Template:Wrapper', ['{{{{{1}}}}}'], self.templates, self.redirects)
+        ex.define_template('Template:Target', ['correct content'], self.templates, self.redirects)
         text = '{{Wrapper|Target}}'
         result = self.get_result(text)
         self.assertEqual(result, ['correct content'])

--- a/tests/test_brace_matching.py
+++ b/tests/test_brace_matching.py
@@ -168,11 +168,11 @@ class RecursiveNestingEndToEndTests(unittest.TestCase):
         self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
+                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects, templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
     def test_six_brace_indirection_the_real_documented_example(self):
@@ -227,11 +227,11 @@ class RecursiveNestingWeirdCountsEndToEndTests(unittest.TestCase):
         self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
+                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects, templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
     def test_seven_braces_stray_literal_brace_survives_around_resolved_value(self):
@@ -264,11 +264,11 @@ class DynamicTemplateNameEndToEndTests(unittest.TestCase):
         self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
+                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects, templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
     def test_dynamic_template_name_call_resolves_correctly(self):

--- a/tests/test_clean_markup.py
+++ b/tests/test_clean_markup.py
@@ -20,16 +20,6 @@ from wikiextractor.clean import clean_markup
 
 class CleanMarkupTests(unittest.TestCase):
 
-    def setUp(self):
-        ex.Extractor.templatePrefix = 'Template:'
-        # Reset to the real default set before every test, restore
-        # after -- don't depend on what state some other test file
-        # (e.g. test_article_mode.py) left in this shared list.
-        self._orig_ignored_tag_patterns = list(ex.ignored_tag_patterns)
-
-    def tearDown(self):
-        ex.ignored_tag_patterns = self._orig_ignored_tag_patterns
-
     def test_basic_prose_and_bold_markup(self):
         result = list(clean_markup("'''Geography''' is a broad field of study."))
         self.assertEqual(result, ['Geography is a broad field of study.'])

--- a/tests/test_clean_markup.py
+++ b/tests/test_clean_markup.py
@@ -22,7 +22,6 @@ class CleanMarkupTests(unittest.TestCase):
 
     def setUp(self):
         ex.Extractor.templatePrefix = 'Template:'
-        ex.redirects.clear()
         # Reset to the real default set before every test, restore
         # after -- don't depend on what state some other test file
         # (e.g. test_article_mode.py) left in this shared list.
@@ -76,7 +75,7 @@ class CleanMarkupTests(unittest.TestCase):
         # expand_templates=False -- a template call should survive
         # unexpanded (or vanish if it's the only content on its own
         # line, per test_article_extraction_content.py).
-        ex.define_template('Template:Greeting', ['Hello, {{{1}}}!'], {})
+        ex.define_template('Template:Greeting', ['Hello, {{{1}}}!'], {}, {})
         markup = "Intro text. {{Greeting|World}} Trailing text."
         result = list(clean_markup(markup))
         joined = ' '.join(result)

--- a/tests/test_collect_pages_redirect.py
+++ b/tests/test_collect_pages_redirect.py
@@ -1,6 +1,11 @@
 """
 Tests for collect_pages()'s page-filtering condition, which had a
-Python operator-precedence bug: 'and' binds tighter than 'or', so
+Python operator-precedence bug. The condition at the time (since
+superseded by the #254 fix -- see test_colon_in_title.py -- which
+replaced the acceptedNamespaces-based check below with a direct read
+of the page's own <ns> element; quoted here only as historical context
+for the precedence bug itself, not a description of the current code):
+'and' binds tighter than 'or', so
 
     if (colon < 0 or (title[:colon] in acceptedNamespaces) and id != last_id and
             not redirect and not title.startswith(templateNamespace)):
@@ -29,7 +34,11 @@ Fixed by parenthesizing the two logical halves explicitly:
             not redirect and not title.startswith(templateNamespace)):
 
 so the namespace check and the redirect/duplicate/template checks are
-both always evaluated, exactly as originally intended.
+both always evaluated, exactly as originally intended. (The
+acceptedNamespaces half was itself removed entirely by the later #254
+fix -- collect_pages() now reads <ns> directly instead -- but the
+redirect/duplicate/template-exclusion logic these tests actually cover
+is unchanged by that.)
 
 Run with:
     python -m unittest tests.test_collect_pages_redirect -v
@@ -49,20 +58,17 @@ import wikiextractor.WikiExtractor as we
 class CollectPagesRedirectFilterTests(unittest.TestCase):
 
     def setUp(self):
-        # collect_pages() relies on these module-level globals, normally
-        # populated from the dump's own <siteinfo> section -- set them
+        # collect_pages() relies on this module-level global, normally
+        # populated from the dump's own <siteinfo> section -- set it
         # explicitly here, matching what a real dump would provide,
         # rather than relying on whatever a prior test left behind.
         self._orig_namespace = we.templateNamespace
-        self._orig_accepted = we.acceptedNamespaces
         we.templateNamespace = 'Template'
-        we.acceptedNamespaces = set(['w'])
         self.tmpdir = os.path.dirname(os.path.abspath(__file__))
         self._paths = []
 
     def tearDown(self):
         we.templateNamespace = self._orig_namespace
-        we.acceptedNamespaces = self._orig_accepted
         for path in self._paths:
             if os.path.exists(path):
                 os.remove(path)
@@ -113,7 +119,6 @@ class CollectPagesRedirectFilterTests(unittest.TestCase):
         # excluded -- the fix must not just be "fixing" the no-colon
         # case by accident while leaving the with-colon case broken
         # some other way.
-        we.acceptedNamespaces = set(['w', 'wiktionary'])
         xml = '''<mediawiki>
   <siteinfo><sitename>Test</sitename></siteinfo>
   <page>

--- a/tests/test_colon_in_title.py
+++ b/tests/test_colon_in_title.py
@@ -60,19 +60,16 @@ class ColonInTitleTests(unittest.TestCase):
 
     def setUp(self):
         # Same reasoning as test_collect_pages_redirect.py: collect_pages()
-        # relies on these module-level globals, normally populated from the
-        # dump's own <siteinfo> section -- set them explicitly so the test
+        # relies on this module-level global, normally populated from the
+        # dump's own <siteinfo> section -- set it explicitly so the test
         # doesn't depend on whatever a prior test left behind.
         self._orig_namespace = we.templateNamespace
-        self._orig_accepted = we.acceptedNamespaces
         we.templateNamespace = 'Template'
-        we.acceptedNamespaces = set(['w'])
         self.tmpdir = os.path.dirname(os.path.abspath(__file__))
         self._paths = []
 
     def tearDown(self):
         we.templateNamespace = self._orig_namespace
-        we.acceptedNamespaces = self._orig_accepted
         for path in self._paths:
             if os.path.exists(path):
                 os.remove(path)
@@ -194,13 +191,11 @@ class ColonInTitleTests(unittest.TestCase):
         self.assertNotIn('Talk:Some Article', titles)
 
     def test_ns_flag_still_controls_link_stripping_only(self):
-        # -ns/--namespaces is unchanged from its original behavior: it
-        # sets acceptedNamespaces, which only affects whether an
-        # in-body interwiki link is kept or stripped in extract.py. It
-        # has no effect on which pages collect_pages() yields -- confirm
-        # a non-'0' namespace stays excluded even when -ns is given a
-        # value that happens to name it.
-        we.acceptedNamespaces = set(['Category'])
+        # -ns/--namespaces (built into extractor_kwargs['acceptedNamespaces']
+        # in main(), then passed into each real Extractor) only affects
+        # whether an in-body interwiki link is kept or stripped in
+        # extract.py. It has no effect on which pages collect_pages()
+        # yields -- confirm a non-'0' namespace stays excluded regardless.
         xml = '''<mediawiki>
   <siteinfo><sitename>Test</sitename></siteinfo>
   <page>

--- a/tests/test_comment_removal.py
+++ b/tests/test_comment_removal.py
@@ -43,11 +43,11 @@ class CommentRemovalTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_comment_removal.py
+++ b/tests/test_comment_removal.py
@@ -43,7 +43,6 @@ class CommentRemovalTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_discard_element_slash.py
+++ b/tests/test_discard_element_slash.py
@@ -47,7 +47,6 @@ class SlashInAttributeTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_discard_element_slash.py
+++ b/tests/test_discard_element_slash.py
@@ -47,11 +47,11 @@ class SlashInAttributeTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_discard_elements.py
+++ b/tests/test_discard_elements.py
@@ -82,11 +82,11 @@ class DiscardElementsTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_discard_elements.py
+++ b/tests/test_discard_elements.py
@@ -82,7 +82,6 @@ class DiscardElementsTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_empty_section_dropping.py
+++ b/tests/test_empty_section_dropping.py
@@ -44,11 +44,11 @@ class EmptySectionDroppingTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_empty_section_dropping.py
+++ b/tests/test_empty_section_dropping.py
@@ -44,7 +44,6 @@ class EmptySectionDroppingTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_empty_section_whitespace.py
+++ b/tests/test_empty_section_whitespace.py
@@ -38,13 +38,15 @@ import unittest
 sys.path.insert(0, '..')  # allow running directly from tests/ without installing
 
 import wikiextractor.extract as ex
+from wikiextractor.extract import Extractor
 
 
 class WhitespaceOnlySectionDroppedTests(unittest.TestCase):
 
     def test_heading_followed_only_by_whitespace_residue_is_dropped(self):
         text = 'Intro.\n\n==Heading==\n \n\n==Next Heading==\nReal content.'
-        result = ex.compact(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.compact(text, extractor=_extractor)
         self.assertNotIn('Heading.', result)
         self.assertIn('Next Heading.', result)
         self.assertIn('Real content.', result)
@@ -61,7 +63,8 @@ class WhitespaceOnlySectionDroppedTests(unittest.TestCase):
                 ' \n\n'
                 '===Tertiary sources===\n'
                 ' \n')
-        result = ex.compact(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.compact(text, extractor=_extractor)
         self.assertNotIn('References.', result)
         self.assertNotIn('General sources.', result)
         self.assertNotIn('Secondary sources.', result)
@@ -77,7 +80,8 @@ class NonEmptySectionsStillKeptTests(unittest.TestCase):
 
     def test_heading_with_real_content_survives(self):
         text = 'Intro.\n\n==Heading==\nReal, substantive content here.\n'
-        result = ex.compact(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.compact(text, extractor=_extractor)
         self.assertIn('Heading.', result)
         self.assertIn('Real, substantive content here.', result)
 
@@ -85,7 +89,8 @@ class NonEmptySectionsStillKeptTests(unittest.TestCase):
         # Even very short real content (not just whitespace) must
         # still count as non-empty.
         text = 'Intro.\n\n==See also==\nRelated topic\n'
-        result = ex.compact(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.compact(text, extractor=_extractor)
         self.assertIn('See also.', result)
         self.assertIn('Related topic', result)
 

--- a/tests/test_frame_cleanup.py
+++ b/tests/test_frame_cleanup.py
@@ -44,11 +44,11 @@ class FrameCleanupOnExceptionTestCase(unittest.TestCase):
         self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_extractor(self, article_text):
         return Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                          "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
+                          "Test Article", [article_text], templates=self.templates, redirects=self.redirects, templatePrefix=self.templatePrefix)
 
 
 class FrameStaysCleanAfterExceptionTests(FrameCleanupOnExceptionTestCase):

--- a/tests/test_frame_cleanup.py
+++ b/tests/test_frame_cleanup.py
@@ -41,14 +41,14 @@ class FrameCleanupOnExceptionTestCase(unittest.TestCase):
 
     def setUp(self):
         self.templates = {}
+        self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_extractor(self, article_text):
         return Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                          "Test Article", [article_text], templates=self.templates)
+                          "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
 
 
 class FrameStaysCleanAfterExceptionTests(FrameCleanupOnExceptionTestCase):
@@ -59,7 +59,7 @@ class FrameStaysCleanAfterExceptionTests(FrameCleanupOnExceptionTestCase):
         # expandTemplates() that isn't a #invoke-specific failure
         # (those are already caught locally by callParserFunction's
         # own bare except, before ever reaching this append/pop pair).
-        ex.define_template('Template:Poison', ['poisoned body'], self.templates)
+        ex.define_template('Template:Poison', ['poisoned body'], self.templates, self.redirects)
 
         extractor = self.get_extractor('Before {{Poison}} after')
 
@@ -93,8 +93,8 @@ class FrameStaysCleanAfterExceptionTests(FrameCleanupOnExceptionTestCase):
         # an exception and continues on the same Extractor instance --
         # not true today, but this is what the fix actually protects
         # against.
-        ex.define_template('Template:Poison', ['poisoned body'], self.templates)
-        ex.define_template('Template:Fine', ['fine body'], self.templates)
+        ex.define_template('Template:Poison', ['poisoned body'], self.templates, self.redirects)
+        ex.define_template('Template:Fine', ['fine body'], self.templates, self.redirects)
 
         extractor = self.get_extractor('x')
         original_expand_templates = extractor.expandTemplates

--- a/tests/test_ignored_tags.py
+++ b/tests/test_ignored_tags.py
@@ -44,11 +44,11 @@ class IgnoredTagsTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_ignored_tags.py
+++ b/tests/test_ignored_tags.py
@@ -44,7 +44,6 @@ class IgnoredTagsTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_link_bracket_collapse.py
+++ b/tests/test_link_bracket_collapse.py
@@ -57,6 +57,7 @@ import unittest
 sys.path.insert(0, '..')  # allow running directly from tests/ without installing
 
 import wikiextractor.extract as ex
+from wikiextractor.extract import Extractor
 
 
 class SymmetricDoublingTests(unittest.TestCase):
@@ -67,17 +68,20 @@ class SymmetricDoublingTests(unittest.TestCase):
 
     def test_quadruple_bracket_link_resolves_with_no_residue(self):
         text = "کشمیر دے [[[[پاکستان]]]] دے نال"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "کشمیر دے پاکستان دے نال")
 
     def test_triple_bracket_variant_no_residue(self):
         text = "اوہ [[[پاکستان]]] گیا"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "اوہ پاکستان گیا")
 
     def test_quintuple_bracket_variant_no_residue(self):
         text = "اوہ [[[[[پاکستان]]]]] گیا"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "اوہ پاکستان گیا")
 
     def test_interwiki_table_entry_no_residue(self):
@@ -85,13 +89,15 @@ class SymmetricDoublingTests(unittest.TestCase):
         # table template -- baked into the template itself, so
         # transcluded (and repeated) across every page that includes it.
         text = "[[[[w:]]]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "w:")
 
     def test_symmetric_piped_link_no_residue(self):
         # Real example from Sindhi Wikipedia (a book citation).
         text = "[[[[ڀيرو مل مهرچند آڏواڻي|ڀيرومل مهرچند آڏواڻي]]]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "ڀيرومل مهرچند آڏواڻي")
 
 
@@ -104,7 +110,8 @@ class AsymmetricDoublingTests(unittest.TestCase):
         # Real example from Sindhi Wikipedia (an {{airport-dest-list}}
         # template usage): 4 opens, only 2 closes.
         text = "[[[[يوني ايئر(Uni Air)]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "يوني ايئر(Uni Air)")
 
     def test_asymmetric_category_link(self):
@@ -112,7 +119,8 @@ class AsymmetricDoublingTests(unittest.TestCase):
         # category link (which gets dropped entirely regardless, by
         # separate pre-existing category-handling logic).
         text = "[[[[زمرو:دستاويز سانچا]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "")
 
 
@@ -154,7 +162,8 @@ class AmbiguousComplexCaseTests(unittest.TestCase):
         # previously-correct result. Must match the original,
         # completely-unmodified behavior exactly.
         text = "بزم دے [[اردو]] /[[[[سرائیکی]] زبان|سرائیکی]] شعراء کرام"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "بزم دے اردو /سرائیکی شعراء کرام")
 
     def test_multi_link_case_left_untouched_not_partially_collapsed(self):
@@ -163,7 +172,8 @@ class AmbiguousComplexCaseTests(unittest.TestCase):
         # produce with no bracket-collapse fix applied at all: the
         # whole span treated as one piece, embedded brackets visible.
         text = "[[[[کراچی]] تا [[لاہور]] [[موٹر وے]] (KLM)]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "[[کراچی]] تا [[لاہور]] [[موٹر وے]] (KLM)")
 
 
@@ -172,19 +182,22 @@ class NormalLinkRegressionTests(unittest.TestCase):
 
     def test_normal_simple_link_unaffected(self):
         text = "اوہ [[پاکستان]] گیا"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "اوہ پاکستان گیا")
 
     def test_normal_piped_link_unaffected(self):
         text = "اوہ [[پاکستان|ملک]] گیا"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "اوہ ملک گیا")
 
     def test_two_adjacent_separate_links_unaffected(self):
         # Two genuinely separate, non-nested links with nothing between
         # them -- must not be mistaken for one doubled-bracket link.
         text = "[[پاکستان]][[بھارت]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "پاکستانبھارت")
 
     def test_log_paste_second_link_processed_independently_of_first_unclosed_bracket(self):
@@ -206,7 +219,8 @@ class NormalLinkRegressionTests(unittest.TestCase):
         # text is "log output" either, and would also attempt to
         # process that second link on its own.
         text = "dbk=[[ [[وڪيپيڊيا:اسان_سان_رابطو_ڪريو]] -> foo"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "dbk=[[  -> foo")
 
 
@@ -219,7 +233,8 @@ class LegitimateNestedLinkRegressionTests(unittest.TestCase):
     def test_nested_link_with_trailing_caption_text_unaffected(self):
         # Baseline (unpatched) result for this input: ''
         text = "[[File:x.jpg|thumb|caption with a [[real link]] inside]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "")
 
     def test_nested_link_as_last_thing_before_outer_close_unaffected(self):
@@ -228,7 +243,8 @@ class LegitimateNestedLinkRegressionTests(unittest.TestCase):
         # separate closes (inner link, then outer link), not a typo.
         # Baseline (unpatched) result for this input: ''
         text = "[[File:x.jpg|[[real link]]]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "")
 
 
@@ -251,14 +267,16 @@ class LinkTrailTests(unittest.TestCase):
 
     def test_simple_trail_concatenates_with_no_space(self):
         text = "the [[cat]]s sat down"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "the cats sat down")
 
     def test_real_saraiki_trail_example(self):
         # The real case found in the wild: a normal, non-doubled link
         # with a trail suffix forming the adjectival form "Pakistani".
         text = "آزاد کشمیر اسمبلی ، [[پاکستان]]ی کشمیر دا قانون"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "آزاد کشمیر اسمبلی ، پاکستانی کشمیر دا قانون")
 
     def test_trail_on_a_doubled_bracket_link_still_works(self):
@@ -267,7 +285,8 @@ class LinkTrailTests(unittest.TestCase):
         # its trail suffix correctly attached afterward, with no space
         # and no leftover brackets.
         text = "the [[[[cat]]]]s sat down"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "the cats sat down")
 
 
@@ -293,7 +312,8 @@ class DoubledBracketWithGenuineNestingTests(unittest.TestCase):
     def test_doubled_file_link_with_nested_real_link_fully_dropped(self):
         # Real example from Saraiki Wikipedia.
         text = "[[[[فائل:G M Lakha.jpg|thumb|[[غلام]] مرتضٰی لاکھا]]]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "")
 
     def test_doubled_plain_link_with_nested_real_link_resolves_cleanly(self):
@@ -305,7 +325,8 @@ class DoubledBracketWithGenuineNestingTests(unittest.TestCase):
         # here is that the OUTER doubled brackets resolve cleanly with
         # no residue.
         text = "[[[[Some Page|caption with a [[real link]] inside]]]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "caption with a [[real link]] inside")
 
 
@@ -356,7 +377,8 @@ class UnclosedLinkOpenTests(unittest.TestCase):
             "had success with their series ''[[Oumpah-pah]]'', which was "
             "published in ''[[Tintin (magazine)|Tintin]]'' magazine."
         )
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
 
         self.assertNotIn("[[File:", result)
         self.assertNotIn("Évariste Vital Luminais", result)  # dropped along with the whole File: link
@@ -375,7 +397,8 @@ class UnclosedLinkOpenTests(unittest.TestCase):
             "وفات: 10 دسمبر [[1198ء) مسلم فلسفی، ماہر [[فلکیات]] تے مقنن ہن۔\n"
             "[[مذہب]] تے فلسفیانہ حقیقت"
         )
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
 
         self.assertIn("[[1198ء)", result)  # left exactly as broken
         self.assertIn("فلکیات", result)
@@ -389,12 +412,14 @@ class UnclosedLinkOpenTests(unittest.TestCase):
         # broken one. A naive "neutralize the first N excess opens"
         # heuristic would get this wrong.
         text = "[[A]] and [[B stays open"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertEqual(result, "A and [[B stays open")
 
     def test_multiple_well_formed_links_after_an_unclosed_one_all_recover(self):
         text = "[[broken (no close and [[first]] and [[second]] and [[third]]"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertIn("[[broken (no close", result)
         self.assertIn("first", result)
         self.assertNotIn("[[first", result)
@@ -410,7 +435,8 @@ class UnclosedLinkOpenTests(unittest.TestCase):
         # within its own paragraph), so it's correctly identified as
         # genuinely unclosed regardless of paragraph boundaries.
         text = "First paragraph has [[unclosed (no close here\n\nSecond paragraph has [[a real link]] in it"
-        result = ex.replaceInternalLinks(text)
+        _extractor = Extractor(1, "1", "https://x", "Test", [text])
+        result = ex.replaceInternalLinks(text, _extractor)
         self.assertIn("[[unclosed", result)
         self.assertIn("a real link", result)
         self.assertNotIn("[[a real link", result)

--- a/tests/test_load_templates_output_file_whitespace.py
+++ b/tests/test_load_templates_output_file_whitespace.py
@@ -74,7 +74,6 @@ class LoadTemplatesOutputFileWhitespaceTests(unittest.TestCase):
     def setUp(self):
         we.templateNamespace = ''
         ex.Extractor.templatePrefix = ''
-        ex.redirects.clear()
         self._tmpdir = tempfile.mkdtemp()
         self.addCleanup(self._cleanup_tmpdir)
 

--- a/tests/test_load_templates_output_file_whitespace.py
+++ b/tests/test_load_templates_output_file_whitespace.py
@@ -73,7 +73,7 @@ class LoadTemplatesOutputFileWhitespaceTests(unittest.TestCase):
 
     def setUp(self):
         we.templateNamespace = ''
-        ex.Extractor.templatePrefix = ''
+        self.templatePrefix = ''
         self._tmpdir = tempfile.mkdtemp()
         self.addCleanup(self._cleanup_tmpdir)
 
@@ -98,12 +98,12 @@ class LoadTemplatesOutputFileWhitespaceTests(unittest.TestCase):
                 tag = m.group(2)
                 if tag == 'namespace' and 'key="10"' in line:
                     we.templateNamespace = m.group(3)
-                    ex.Extractor.templatePrefix = we.templateNamespace + ':'
+                    self.templatePrefix = we.templateNamespace + ':'
                 elif tag == '/siteinfo':
                     break
 
         with we.decode_open(dump_path) as f:
-            we.load_templates(f, output_file=output_path)
+            we.load_templates(f, output_file=output_path, template_prefix=self.templatePrefix)
 
         with open(output_path, encoding='utf-8') as f:
             return f.read()
@@ -139,7 +139,7 @@ class LoadTemplatesOutputFileWhitespaceTests(unittest.TestCase):
             f.write(output)
 
         we.templateNamespace = ''
-        ex.Extractor.templatePrefix = ''
+        roundtrip_prefix = ''
         with we.decode_open(roundtrip_path) as f:
             for line in f:
                 m = we.tagRE.search(line)
@@ -148,16 +148,17 @@ class LoadTemplatesOutputFileWhitespaceTests(unittest.TestCase):
                 tag = m.group(2)
                 if tag == 'namespace' and 'key="10"' in line:
                     we.templateNamespace = m.group(3)
-                    ex.Extractor.templatePrefix = we.templateNamespace + ':'
+                    roundtrip_prefix = we.templateNamespace + ':'
                 elif tag == '/siteinfo':
                     break
         roundtrip_templates = {}
         with we.decode_open(roundtrip_path) as f:
-            we.load_templates(f, templates=roundtrip_templates)
+            _count, roundtrip_prefix = we.load_templates(
+                f, templates=roundtrip_templates, template_prefix=roundtrip_prefix)
 
         wikitext = '{{Wrapper|value}}'
         extractor = ex.Extractor(1, '1', 'https://x', 'Test', [wikitext],
-                                  templates=roundtrip_templates)
+                                  templates=roundtrip_templates, templatePrefix=roundtrip_prefix)
         result = extractor.clean_text(wikitext, expand_templates=True)
         self.assertEqual(result, ['wrapped[value]'])
 

--- a/tests/test_new_tags.py
+++ b/tests/test_new_tags.py
@@ -60,7 +60,6 @@ class NewTagsTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
 
     def get_result(self, text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1", "Test", [text])

--- a/tests/test_noinclude_removal.py
+++ b/tests/test_noinclude_removal.py
@@ -50,7 +50,6 @@ class NoincludeTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_noinclude_removal.py
+++ b/tests/test_noinclude_removal.py
@@ -50,11 +50,11 @@ class NoincludeTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_orphaned_discard_close_tags.py
+++ b/tests/test_orphaned_discard_close_tags.py
@@ -50,11 +50,11 @@ class OrphanedDiscardCloseTagTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_orphaned_discard_close_tags.py
+++ b/tests/test_orphaned_discard_close_tags.py
@@ -50,7 +50,6 @@ class OrphanedDiscardCloseTagTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_output_format_modes.py
+++ b/tests/test_output_format_modes.py
@@ -43,33 +43,20 @@ import wikiextractor.extract as ex
 
 
 class OutputFormatModeTestCase(unittest.TestCase):
-    """Extractor.to_json/to_text/discard_empty are CLASS attributes,
-    shared mutable state rather than per-instance -- captured and
-    restored here so one test's mode selection can never leak into
-    another.
-    """
 
     def setUp(self):
-        self._orig_to_json = getattr(ex.Extractor, 'to_json', False)
-        self._orig_to_text = getattr(ex.Extractor, 'to_text', False)
-        self._orig_discard_empty = getattr(ex.Extractor, 'discard_empty', False)
-        ex.Extractor.templatePrefix = 'Template:'
+        self.templatePrefix = 'Template:'
 
-    def tearDown(self):
-        ex.Extractor.to_json = self._orig_to_json
-        ex.Extractor.to_text = self._orig_to_text
-        ex.Extractor.discard_empty = self._orig_discard_empty
-
-    def make_extractor(self, body_text, page_id=1, revid='100', title='My Title'):
+    def make_extractor(self, body_text, page_id=1, revid='100', title='My Title',
+                        to_json=False, to_text=False, discard_empty=False):
         return ex.Extractor(page_id, revid, 'https://test.wikipedia.org/wiki',
-                             title, [body_text])
+                             title, [body_text], templatePrefix=self.templatePrefix,
+                             to_json=to_json, to_text=to_text, discard_empty=discard_empty)
 
     def run_extract(self, body_text, to_json=False, to_text=False,
                      discard_empty=False, **kwargs):
-        ex.Extractor.to_json = to_json
-        ex.Extractor.to_text = to_text
-        ex.Extractor.discard_empty = discard_empty
-        extractor = self.make_extractor(body_text, **kwargs)
+        extractor = self.make_extractor(body_text, to_json=to_json, to_text=to_text,
+                                         discard_empty=discard_empty, **kwargs)
         buf = io.StringIO()
         extractor.extract(buf)
         return buf.getvalue()

--- a/tests/test_quote_aware_tag_matching.py
+++ b/tests/test_quote_aware_tag_matching.py
@@ -54,11 +54,11 @@ class QuoteAwareTagMatchingTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_quote_aware_tag_matching.py
+++ b/tests/test_quote_aware_tag_matching.py
@@ -54,7 +54,6 @@ class QuoteAwareTagMatchingTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_redirect_keywords.py
+++ b/tests/test_redirect_keywords.py
@@ -158,15 +158,15 @@ class UrduRedirectTests(RedirectKeywordsTestCase):
         # never set elsewhere in this file, since every other test
         # here checks define_template()'s own redirect detection
         # directly rather than going through full expansion. Without
-        # this, fullyQualifiedTemplateTitle() falls back to no prefix
-        # at all, every lookup below misses, and this test would pass
-        # trivially regardless of whether redirects=self.redirects is
-        # even correct -- confirmed directly: without both this line
-        # and redirects=self.redirects on the next one, "scope=col"
-        # leaks through exactly as this test exists to catch.
-        ex.Extractor.templatePrefix = 'سانچہ:'
+        # templatePrefix set correctly below, fullyQualifiedTemplateTitle()
+        # falls back to no prefix at all, every lookup misses, and this
+        # test would pass trivially regardless of whether redirects is
+        # even correct -- confirmed directly: without both templatePrefix
+        # and redirects passed correctly here, "scope=col" leaks through
+        # exactly as this test exists to catch.
         extractor = ex.Extractor('1', '1', 'https://x', 'Test', [wikitext],
-                                  templates=self.templates, redirects=self.redirects)
+                                  templates=self.templates, redirects=self.redirects,
+                                  templatePrefix='سانچہ:')
         result = extractor.clean_text(wikitext)
         joined = '\n'.join(result)
         self.assertNotIn('scope=col', joined)

--- a/tests/test_redirect_keywords.py
+++ b/tests/test_redirect_keywords.py
@@ -59,30 +59,30 @@ class RedirectKeywordsTestCase(unittest.TestCase):
 
     def setUp(self):
         self.templates = {}
+        self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
 
 
 class EnglishRedirectStillWorksTests(RedirectKeywordsTestCase):
     """Regression coverage for the original, pre-existing behavior."""
 
     def test_uppercase_redirect(self):
-        ex.define_template('Template:Foo', ['#REDIRECT [[Template:Bar]]'], self.templates)
-        self.assertEqual(ex.redirects.get('Template:Foo'), 'Template:Bar')
+        ex.define_template('Template:Foo', ['#REDIRECT [[Template:Bar]]'], self.templates, self.redirects)
+        self.assertEqual(self.redirects.get('Template:Foo'), 'Template:Bar')
         self.assertNotIn('Template:Foo', self.templates)
 
     def test_lowercase_redirect_case_insensitive(self):
-        ex.define_template('Template:Foo', ['#redirect [[Template:Bar]]'], self.templates)
-        self.assertEqual(ex.redirects.get('Template:Foo'), 'Template:Bar')
+        ex.define_template('Template:Foo', ['#redirect [[Template:Bar]]'], self.templates, self.redirects)
+        self.assertEqual(self.redirects.get('Template:Foo'), 'Template:Bar')
 
     def test_mixed_case_redirect(self):
-        ex.define_template('Template:Foo', ['#Redirect [[Template:Bar]]'], self.templates)
-        self.assertEqual(ex.redirects.get('Template:Foo'), 'Template:Bar')
+        ex.define_template('Template:Foo', ['#Redirect [[Template:Bar]]'], self.templates, self.redirects)
+        self.assertEqual(self.redirects.get('Template:Foo'), 'Template:Bar')
 
     def test_normal_non_redirect_template_unaffected(self):
-        ex.define_template('Template:Normal', ['Some ordinary template text.'], self.templates)
-        self.assertIsNone(ex.redirects.get('Template:Normal'))
+        ex.define_template('Template:Normal', ['Some ordinary template text.'], self.templates, self.redirects)
+        self.assertIsNone(self.redirects.get('Template:Normal'))
         self.assertIn('Template:Normal', self.templates)
 
 
@@ -90,8 +90,8 @@ class SindhiRedirectTests(RedirectKeywordsTestCase):
     """The new behavior this fix adds."""
 
     def test_sindhi_redirect_keyword(self):
-        ex.define_template('سانچو:حوالا', ['#چوريو [[سانچو:حوالو]]'], self.templates)
-        self.assertEqual(ex.redirects.get('سانچو:حوالا'), 'سانچو:حوالو')
+        ex.define_template('سانچو:حوالا', ['#چوريو [[سانچو:حوالو]]'], self.templates, self.redirects)
+        self.assertEqual(self.redirects.get('سانچو:حوالا'), 'سانچو:حوالو')
         self.assertNotIn('سانچو:حوالا', self.templates)
 
     def test_real_world_case_content_leak_is_gone(self):
@@ -103,8 +103,8 @@ class SindhiRedirectTests(RedirectKeywordsTestCase):
             '#چوريو [[سانچو:حوالو]]\n'
             '<div class="reflist" style="list-style-type: decimal;">\n'
             '{{#tag:references}}</div>'
-        ], self.templates)
-        self.assertEqual(ex.redirects.get('سانچو:حوالا'), 'سانچو:حوالو')
+        ], self.templates, self.redirects)
+        self.assertEqual(self.redirects.get('سانچو:حوالا'), 'سانچو:حوالو')
         self.assertNotIn('سانچو:حوالا', self.templates)
 
 
@@ -138,8 +138,8 @@ class UrduRedirectTests(RedirectKeywordsTestCase):
     """
 
     def test_urdu_redirect_keyword(self):
-        ex.define_template('سانچہ:ص.م/فتح', ['#رجوع_مکرر [[سانچہ:خانہ معلومات/آغاز]]'], self.templates)
-        self.assertEqual(ex.redirects.get('سانچہ:ص.م/فتح'), 'سانچہ:خانہ معلومات/آغاز')
+        ex.define_template('سانچہ:ص.م/فتح', ['#رجوع_مکرر [[سانچہ:خانہ معلومات/آغاز]]'], self.templates, self.redirects)
+        self.assertEqual(self.redirects.get('سانچہ:ص.م/فتح'), 'سانچہ:خانہ معلومات/آغاز')
         self.assertNotIn('سانچہ:ص.م/فتح', self.templates)
 
     def test_real_world_case_table_leak_is_gone(self):
@@ -147,14 +147,26 @@ class UrduRedirectTests(RedirectKeywordsTestCase):
         # actually available, the infobox's "{|" opener is reached and
         # the header row it should have wrapped gets correctly dropped
         # -- rather than leaking verbatim as in the real case above.
-        ex.define_template('سانچہ:ص.م/فتح', ['#رجوع_مکرر [[سانچہ:خانہ معلومات/آغاز]]'], self.templates)
-        ex.define_template('سانچہ:خانہ معلومات/آغاز', ['{| class="infobox"'], self.templates)
-        ex.define_template('سانچہ:خانہ معلومات/اختتام', ['|}'], self.templates)
-        ex.define_template('سانچہ:خ۔م/عنوان', ['! scope=col | {{{1}}}'], self.templates)
+        ex.define_template('سانچہ:ص.م/فتح', ['#رجوع_مکرر [[سانچہ:خانہ معلومات/آغاز]]'], self.templates, self.redirects)
+        ex.define_template('سانچہ:خانہ معلومات/آغاز', ['{| class="infobox"'], self.templates, self.redirects)
+        ex.define_template('سانچہ:خانہ معلومات/اختتام', ['|}'], self.templates, self.redirects)
+        ex.define_template('سانچہ:خ۔م/عنوان', ['! scope=col | {{{1}}}'], self.templates, self.redirects)
 
         wikitext = ('{{ص.م/فتح}}\n{{خ۔م/عنوان|Test}}\n{{خانہ معلومات/اختتام}}\n'
                     'Ordinary article prose follows.')
-        extractor = ex.Extractor('1', '1', 'https://x', 'Test', [wikitext], templates=self.templates)
+        # Real template resolution needs a real namespace prefix --
+        # never set elsewhere in this file, since every other test
+        # here checks define_template()'s own redirect detection
+        # directly rather than going through full expansion. Without
+        # this, fullyQualifiedTemplateTitle() falls back to no prefix
+        # at all, every lookup below misses, and this test would pass
+        # trivially regardless of whether redirects=self.redirects is
+        # even correct -- confirmed directly: without both this line
+        # and redirects=self.redirects on the next one, "scope=col"
+        # leaks through exactly as this test exists to catch.
+        ex.Extractor.templatePrefix = 'سانچہ:'
+        extractor = ex.Extractor('1', '1', 'https://x', 'Test', [wikitext],
+                                  templates=self.templates, redirects=self.redirects)
         result = extractor.clean_text(wikitext)
         joined = '\n'.join(result)
         self.assertNotIn('scope=col', joined)
@@ -169,18 +181,18 @@ class FalsePositiveBoundaryTests(RedirectKeywordsTestCase):
 
     def test_word_continuation_does_not_match(self):
         # "REDIRECTED" -- no word boundary right after "REDIRECT".
-        ex.define_template('Template:Foo', ['#REDIRECTED to a new place [[Template:Bar]]'], self.templates)
-        self.assertIsNone(ex.redirects.get('Template:Foo'))
+        ex.define_template('Template:Foo', ['#REDIRECTED to a new place [[Template:Bar]]'], self.templates, self.redirects)
+        self.assertIsNone(self.redirects.get('Template:Foo'))
         self.assertIn('Template:Foo', self.templates)
 
     def test_keyword_not_at_start_of_first_line_does_not_match(self):
-        ex.define_template('Template:Foo', ['Some text. #REDIRECT mentioned here [[Template:Bar]]'], self.templates)
-        self.assertIsNone(ex.redirects.get('Template:Foo'))
+        ex.define_template('Template:Foo', ['Some text. #REDIRECT mentioned here [[Template:Bar]]'], self.templates, self.redirects)
+        self.assertIsNone(self.redirects.get('Template:Foo'))
         self.assertIn('Template:Foo', self.templates)
 
     def test_keyword_with_no_wikilink_does_not_match(self):
-        ex.define_template('Template:Foo', ['#REDIRECT to somewhere, no link here'], self.templates)
-        self.assertIsNone(ex.redirects.get('Template:Foo'))
+        ex.define_template('Template:Foo', ['#REDIRECT to somewhere, no link here'], self.templates, self.redirects)
+        self.assertIsNone(self.redirects.get('Template:Foo'))
         self.assertIn('Template:Foo', self.templates)
 
     def test_keyword_appearing_only_in_a_later_line_does_not_match(self):
@@ -188,8 +200,8 @@ class FalsePositiveBoundaryTests(RedirectKeywordsTestCase):
         ex.define_template('Template:Foo', [
             'This is the real, first line of content.\n'
             '#REDIRECT [[Template:Bar]]\n'
-        ], self.templates)
-        self.assertIsNone(ex.redirects.get('Template:Foo'))
+        ], self.templates, self.redirects)
+        self.assertIsNone(self.redirects.get('Template:Foo'))
         self.assertIn('Template:Foo', self.templates)
 
 

--- a/tests/test_self_closing_text_tag.py
+++ b/tests/test_self_closing_text_tag.py
@@ -203,15 +203,23 @@ class TemplateContaminationTests(unittest.TestCase):
 
     def setUp(self):
         self.templates = {}
+        self.redirects = {}
         import wikiextractor.extract as ex
+        import wikiextractor.WikiExtractor as we
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
+        # load() below relies on load_templates()'s self-bootstrap
+        # namespace detection, which only ever fires once per process
+        # (while we.templateNamespace is still falsy) -- reset both
+        # here so this doesn't silently pick up a stale prefix left
+        # by some other, unrelated test file's own dump data.
+        we.templateNamespace = ''
+        ex.Extractor.templatePrefix = ''
 
     def load(self, xml_text):
         import io
         import wikiextractor.WikiExtractor as we
-        we.load_templates(io.StringIO(xml_text), templates=self.templates)
+        we.load_templates(io.StringIO(xml_text), templates=self.templates, redirects=self.redirects)
 
     def test_template_after_blanked_template_is_not_contaminated(self):
         xml = '''<mediawiki>
@@ -255,11 +263,11 @@ class TemplateContaminationTests(unittest.TestCase):
         # it got there.
         import wikiextractor.extract as ex
         try:
-            ex.define_template('Template:Blanked', [], self.templates)
+            ex.define_template('Template:Blanked', [], self.templates, self.redirects)
         except IndexError:
             self.fail("define_template() crashed on a genuinely empty page list")
         self.assertNotIn('Template:Blanked', self.templates)
-        self.assertNotIn('Template:Blanked', ex.redirects)
+        self.assertNotIn('Template:Blanked', self.redirects)
 
 
 if __name__ == '__main__':

--- a/tests/test_self_closing_text_tag.py
+++ b/tests/test_self_closing_text_tag.py
@@ -210,11 +210,10 @@ class TemplateContaminationTests(unittest.TestCase):
         ex.Extractor._parse_template.cache_clear()
         # load() below relies on load_templates()'s self-bootstrap
         # namespace detection, which only ever fires once per process
-        # (while we.templateNamespace is still falsy) -- reset both
-        # here so this doesn't silently pick up a stale prefix left
-        # by some other, unrelated test file's own dump data.
+        # (while we.templateNamespace is still falsy) -- reset here so
+        # this doesn't silently pick up a stale namespace left by some
+        # other, unrelated test file's own dump data.
         we.templateNamespace = ''
-        ex.Extractor.templatePrefix = ''
 
     def load(self, xml_text):
         import io

--- a/tests/test_selfclosing_tags.py
+++ b/tests/test_selfclosing_tags.py
@@ -76,7 +76,6 @@ class VoidElementTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def get_result(self, article_text):

--- a/tests/test_selfclosing_tags.py
+++ b/tests/test_selfclosing_tags.py
@@ -76,11 +76,11 @@ class VoidElementTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text])
+                               "Test Article", [article_text], templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_sharp_invoke_alias.py
+++ b/tests/test_sharp_invoke_alias.py
@@ -62,7 +62,7 @@ class SharpInvokeAliasTestCase(unittest.TestCase):
         self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
         # a minimal, deliberately-"no conversion" stand-in matching
         # the one actually shipped in extract.py's own `modules` dict
         # -- kept separate here so this test doesn't depend on that
@@ -73,7 +73,7 @@ class SharpInvokeAliasTestCase(unittest.TestCase):
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
+                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects, templatePrefix=self.templatePrefix)
         return extractor.clean_text(article_text, expand_templates=True)
 
 

--- a/tests/test_sharp_invoke_alias.py
+++ b/tests/test_sharp_invoke_alias.py
@@ -59,9 +59,9 @@ class SharpInvokeAliasTestCase(unittest.TestCase):
 
     def setUp(self):
         self.templates = {}
+        self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
         # a minimal, deliberately-"no conversion" stand-in matching
         # the one actually shipped in extract.py's own `modules` dict
@@ -73,7 +73,7 @@ class SharpInvokeAliasTestCase(unittest.TestCase):
 
     def get_result(self, article_text):
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [article_text], templates=self.templates)
+                               "Test Article", [article_text], templates=self.templates, redirects=self.redirects)
         return extractor.clean_text(article_text, expand_templates=True)
 
 
@@ -89,7 +89,7 @@ class AliasTemplateNameTests(SharpInvokeAliasTestCase):
         # function name "convert") happened to coincide with the
         # template's actual name. Included as a baseline, not as the
         # regression test itself.
-        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'], self.templates)
+        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'], self.templates, self.redirects)
         result = self.get_result('Value: {{convert|5|km}}')
         self.assertEqual(result, ['Value: 5 km'])
 
@@ -101,14 +101,14 @@ class AliasTemplateNameTests(SharpInvokeAliasTestCase):
         # "Template:Cvt" -- silently failing to empty output every
         # time, regardless of the underlying function being identical
         # and correctly registered.
-        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates)
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates, self.redirects)
         result = self.get_result('Value: {{cvt|5|km}}')
         self.assertEqual(result, ['Value: 5 km'])
 
     def test_original_buffalo_sentence(self):
         # The exact real-world sentence that surfaced this whole
         # investigation.
-        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates)
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates, self.redirects)
         text = ("Buffalo's lowest recorded temperature was {{cvt|−20|°F|0}}, "
                  "which occurred twice: on February 9, 1934, and February 2, 1961.")
         result = self.get_result(text)
@@ -121,9 +121,9 @@ class AliasTemplateNameTests(SharpInvokeAliasTestCase):
         # Not special-cased to "cvt" specifically -- any number of
         # differently-named templates invoking the same function
         # should all work identically.
-        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'], self.templates)
-        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates)
-        ex.define_template('Template:Convert2', ['{{#invoke:convert|convert}}'], self.templates)
+        ex.define_template('Template:Convert', ['{{#invoke:convert|convert}}'], self.templates, self.redirects)
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates, self.redirects)
+        ex.define_template('Template:Convert2', ['{{#invoke:convert|convert}}'], self.templates, self.redirects)
         for name in ('convert', 'cvt', 'convert2'):
             with self.subTest(template=name):
                 result = self.get_result(f'Value: {{{{{name}|5|km}}}}')
@@ -142,8 +142,8 @@ class FrameStackOrderingTests(SharpInvokeAliasTestCase):
         # itself call #invoke -- it calls Cvt, which does. The
         # #invoke call must pick up Cvt's own params (5, km), not
         # Wrapper's (999, mi).
-        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates)
-        ex.define_template('Template:Wrapper', ['See: {{cvt|{{{1}}}|{{{2}}}}}'], self.templates)
+        ex.define_template('Template:Cvt', ['{{#invoke:convert|convert}}'], self.templates, self.redirects)
+        ex.define_template('Template:Wrapper', ['See: {{cvt|{{{1}}}|{{{2}}}}}'], self.templates, self.redirects)
         result = self.get_result('Value: {{wrapper|5|km}}')
         self.assertEqual(result, ['Value: See: 5 km'])
 

--- a/tests/test_streaming_template_blob.py
+++ b/tests/test_streaming_template_blob.py
@@ -91,7 +91,7 @@ class LoadTemplatesBlobBuilderPathTests(unittest.TestCase):
 
     def setUp(self):
         we.templateNamespace = ''
-        ex.Extractor.templatePrefix = ''
+        self.templatePrefix = ''
 
     def load(self, xml_text):
         builder = tb.StreamingTemplateBlobBuilder()
@@ -104,12 +104,13 @@ class LoadTemplatesBlobBuilderPathTests(unittest.TestCase):
                 tag = m.group(2)
                 if tag == 'namespace' and 'key="10"' in line:
                     we.templateNamespace = m.group(3)
-                    ex.Extractor.templatePrefix = we.templateNamespace + ':'
+                    self.templatePrefix = we.templateNamespace + ':'
                 elif tag == '/siteinfo':
                     break
         with io.StringIO(xml_text) as f:
-            count = we.load_templates(f, blob_builder=builder,
-                                       redirects_blob_builder=redirects_builder)
+            count, self.templatePrefix = we.load_templates(
+                f, blob_builder=builder, redirects_blob_builder=redirects_builder,
+                template_prefix=self.templatePrefix)
         return count, builder, redirects_builder
 
     def test_plain_template_streamed_correctly(self):

--- a/tests/test_streaming_template_blob.py
+++ b/tests/test_streaming_template_blob.py
@@ -92,10 +92,10 @@ class LoadTemplatesBlobBuilderPathTests(unittest.TestCase):
     def setUp(self):
         we.templateNamespace = ''
         ex.Extractor.templatePrefix = ''
-        ex.redirects.clear()
 
     def load(self, xml_text):
         builder = tb.StreamingTemplateBlobBuilder()
+        redirects_builder = tb.StreamingTemplateBlobBuilder()
         with io.StringIO(xml_text) as f:
             for line in f:
                 m = we.tagRE.search(line)
@@ -108,8 +108,9 @@ class LoadTemplatesBlobBuilderPathTests(unittest.TestCase):
                 elif tag == '/siteinfo':
                     break
         with io.StringIO(xml_text) as f:
-            count = we.load_templates(f, blob_builder=builder)
-        return count, builder
+            count = we.load_templates(f, blob_builder=builder,
+                                       redirects_blob_builder=redirects_builder)
+        return count, builder, redirects_builder
 
     def test_plain_template_streamed_correctly(self):
         xml = """<mediawiki>
@@ -130,13 +131,13 @@ class LoadTemplatesBlobBuilderPathTests(unittest.TestCase):
 </page>
 </mediawiki>
 """
-        count, builder = self.load(xml)
+        count, builder, redirects_builder = self.load(xml)
         self.assertEqual(count, 1)
         records, titles, content = builder.finish()
         with tb.compact_blobs(records, titles, content) as (wrapper, _names):
             self.assertEqual(wrapper['Template:Greeting'], 'Hello, {{{1}}}!')
 
-    def test_redirect_goes_to_redirects_dict_not_the_blob(self):
+    def test_redirect_goes_to_the_redirects_blob_not_the_templates_blob(self):
         xml = """<mediawiki>
 <siteinfo>
 <namespaces>
@@ -155,11 +156,13 @@ class LoadTemplatesBlobBuilderPathTests(unittest.TestCase):
 </page>
 </mediawiki>
 """
-        count, builder = self.load(xml)
+        count, builder, redirects_builder = self.load(xml)
         self.assertEqual(count, 1)
-        self.assertEqual(ex.redirects.get('Template:Old'), 'Template:New')
         records, titles, content = builder.finish()
-        self.assertEqual(records, b'')  # nothing streamed into the blob itself
+        self.assertEqual(records, b'')  # nothing streamed into the templates blob
+        r_records, r_titles, r_content = redirects_builder.finish()
+        with tb.compact_blobs(r_records, r_titles, r_content) as (wrapper, _names):
+            self.assertEqual(wrapper['Template:Old'], 'Template:New')
 
     def test_noinclude_stripped_includeonly_kept_same_as_dict_based_path(self):
         xml = """<mediawiki>
@@ -185,7 +188,7 @@ documentation that must never appear
 </page>
 </mediawiki>
 """
-        count, builder = self.load(xml)
+        count, builder, redirects_builder = self.load(xml)
         records, titles, content = builder.finish()
         with tb.compact_blobs(records, titles, content) as (wrapper, _names):
             stored = wrapper['Template:WithDocs']

--- a/tests/test_template_boundary_newline_collapse.py
+++ b/tests/test_template_boundary_newline_collapse.py
@@ -78,7 +78,7 @@ class NewlineCollapseTestCase(unittest.TestCase):
         self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
+        self.templatePrefix = "Template:"
 
     def stored_body(self, page_lines):
         ex.define_template('Template:X', page_lines, self.templates, self.redirects)
@@ -112,7 +112,8 @@ class NoincludeTrailingNewlineTests(NewlineCollapseTestCase):
         ], self.templates, self.redirects)
         wikitext = 'cite: [{{LinkB|2|119}} Some Label]'
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [wikitext], templates=self.templates, redirects=self.redirects)
+                               "Test Article", [wikitext], templates=self.templates,
+                               redirects=self.redirects, templatePrefix=self.templatePrefix)
         result = extractor.clean_text(wikitext, expand_templates=True)
         self.assertEqual(result, ['cite: Some Label'])
 

--- a/tests/test_template_boundary_newline_collapse.py
+++ b/tests/test_template_boundary_newline_collapse.py
@@ -75,13 +75,13 @@ class NewlineCollapseTestCase(unittest.TestCase):
 
     def setUp(self):
         self.templates = {}
+        self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
 
     def stored_body(self, page_lines):
-        ex.define_template('Template:X', page_lines, self.templates)
+        ex.define_template('Template:X', page_lines, self.templates, self.redirects)
         return self.templates.get('Template:X')
 
 
@@ -106,13 +106,13 @@ class NoincludeTrailingNewlineTests(NewlineCollapseTestCase):
         ex.define_template('Template:Trim', [
             '<includeonly>{{safesubst:#if:1|{{{1|}}}}}</includeonly>'
             '<noinclude>\n{{documentation}}\n</noinclude>\n'
-        ], self.templates)
+        ], self.templates, self.redirects)
         ex.define_template('Template:LinkB', [
             'http://example.com?chapter={{Trim| {{{1}}} }}&verse={{Trim| {{{2}}} }}&done'
-        ], self.templates)
+        ], self.templates, self.redirects)
         wikitext = 'cite: [{{LinkB|2|119}} Some Label]'
         extractor = Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
-                               "Test Article", [wikitext], templates=self.templates)
+                               "Test Article", [wikitext], templates=self.templates, redirects=self.redirects)
         result = extractor.clean_text(wikitext, expand_templates=True)
         self.assertEqual(result, ['cite: Some Label'])
 

--- a/tests/test_template_loading_content.py
+++ b/tests/test_template_loading_content.py
@@ -128,7 +128,6 @@ class TemplateLoadingContentTests(unittest.TestCase):
         # cross-test isolation risk in sharing this single load.
         we.templateNamespace = ''
         ex.Extractor.templatePrefix = ''
-        ex.redirects.clear()
         with io.StringIO(_TEMPLATES_XML) as f:
             for line in f:
                 m = we.tagRE.search(line)
@@ -141,8 +140,9 @@ class TemplateLoadingContentTests(unittest.TestCase):
                 elif tag == '/siteinfo':
                     break
         cls.templates = {}
+        cls.redirects = {}
         with io.StringIO(_TEMPLATES_XML) as f:
-            cls.count = we.load_templates(f, templates=cls.templates)
+            cls.count = we.load_templates(f, templates=cls.templates, redirects=cls.redirects)
 
     def test_reported_count_matches_every_page_including_the_redirect(self):
         # 6 <page> elements total: 5 real templates + 1 redirect --
@@ -163,7 +163,7 @@ class TemplateLoadingContentTests(unittest.TestCase):
             'Born: {{{birth|unknown}}}, Died: {{{death|unknown}}}')
 
     def test_redirect_page_recorded_as_a_redirect_not_a_template(self):
-        self.assertEqual(ex.redirects.get('Template:Old name'), 'Template:New name')
+        self.assertEqual(self.redirects.get('Template:Old name'), 'Template:New name')
         self.assertNotIn('Template:Old name', self.templates)
 
     def test_redirect_target_itself_is_an_ordinary_stored_template(self):

--- a/tests/test_template_loading_content.py
+++ b/tests/test_template_loading_content.py
@@ -127,7 +127,7 @@ class TemplateLoadingContentTests(unittest.TestCase):
         # reads the result, none of them mutate it, so there's no
         # cross-test isolation risk in sharing this single load.
         we.templateNamespace = ''
-        ex.Extractor.templatePrefix = ''
+        cls.templatePrefix = ''
         with io.StringIO(_TEMPLATES_XML) as f:
             for line in f:
                 m = we.tagRE.search(line)
@@ -136,13 +136,15 @@ class TemplateLoadingContentTests(unittest.TestCase):
                 tag = m.group(2)
                 if tag == 'namespace' and 'key="10"' in line:
                     we.templateNamespace = m.group(3)
-                    ex.Extractor.templatePrefix = we.templateNamespace + ':'
+                    cls.templatePrefix = we.templateNamespace + ':'
                 elif tag == '/siteinfo':
                     break
         cls.templates = {}
         cls.redirects = {}
         with io.StringIO(_TEMPLATES_XML) as f:
-            cls.count = we.load_templates(f, templates=cls.templates, redirects=cls.redirects)
+            cls.count, cls.templatePrefix = we.load_templates(
+                f, templates=cls.templates, redirects=cls.redirects,
+                template_prefix=cls.templatePrefix)
 
     def test_reported_count_matches_every_page_including_the_redirect(self):
         # 6 <page> elements total: 5 real templates + 1 redirect --

--- a/tests/test_template_loop_guard.py
+++ b/tests/test_template_loop_guard.py
@@ -58,9 +58,9 @@ class TemplateLoopGuardTestCase(unittest.TestCase):
 
     def setUp(self):
         self.templates = {}
+        self.redirects = {}
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         # Normally set by load_templates() when scanning a real dump's
         # first Template-namespace page; tests define templates directly
         # via define_template(), so it must be set explicitly here.
@@ -75,7 +75,7 @@ class TemplateLoopGuardTestCase(unittest.TestCase):
     def make_extractor(self, article_text, article_id=1, title="Test Article"):
         return Extractor(article_id, str(article_id),
                           f"https://test.wikipedia.org/wiki?curid={article_id}",
-                          title, [article_text], templates=self.templates)
+                          title, [article_text], templates=self.templates, redirects=self.redirects)
 
 
 class LegitimateSelfRecursionTests(TemplateLoopGuardTestCase):
@@ -92,7 +92,7 @@ class LegitimateSelfRecursionTests(TemplateLoopGuardTestCase):
         ex.define_template(
             "Template:P2",
             ["{{{1}}}{{#if:{{{2|}}}|, {{P2|{{{2|}}}|{{{3|}}}|{{{4|}}}|{{{5|}}}}}|}}"],
-            self.templates
+            self.templates, self.redirects
         )
         article_text = "Population list: {{P2|CityA|CityB|CityC|CityD}}"
         extractor = self.make_extractor(article_text)
@@ -112,7 +112,7 @@ class LegitimateSelfRecursionTests(TemplateLoopGuardTestCase):
             "Template:P2",
             ["{{{1}}}{{#if:{{{2|}}}|, {{P2|{{{2|}}}|{{{3|}}}|{{{4|}}}|{{{5|}}}"
              "|{{{6|}}}|{{{7|}}}|{{{8|}}}}}|}}"],
-            self.templates
+            self.templates, self.redirects
         )
         article_text = ("{{P2|A|B|C|D|E|F|G|H}}")
         extractor = self.make_extractor(article_text)
@@ -152,7 +152,7 @@ Usage examples:
 {{Redirect-multi|3|A|B|C|use=x}}
 {{Redirect-multi|3|A|B|C|use=y}}
 {{Redirect-multi|3|A|B|C|use=z}}
-"""], self.templates)
+"""], self.templates, self.redirects)
         article_text = "Some article text.\n\n{{Redirect-multi|2|X|Y}}\n\nMore text."
         extractor = self.make_extractor(article_text)
 
@@ -176,7 +176,7 @@ Usage examples:
     def test_direct_immediate_self_reference_is_caught(self):
         # The simplest possible case: a template whose body invokes
         # itself with the exact same parameters, unconditionally.
-        ex.define_template("Template:Self", ["before {{Self|x}} after"], self.templates)
+        ex.define_template("Template:Self", ["before {{Self|x}} after"], self.templates, self.redirects)
         article_text = "{{Self|x}}"
         extractor = self.make_extractor(article_text)
 
@@ -201,7 +201,7 @@ class WarningLogDeduplicationTests(TemplateLoopGuardTestCase):
 {{Redirect-multi|3|A|B|C|use=x}}
 {{Redirect-multi|3|A|B|C|use=y}}
 {{Redirect-multi|3|A|B|C|use=z}}
-"""], self.templates)
+"""], self.templates, self.redirects)
         article_text = "{{Redirect-multi|2|X|Y}}"
         extractor = self.make_extractor(article_text)
 
@@ -233,7 +233,7 @@ class ErrorSummaryReportingTests(TemplateLoopGuardTestCase):
     """
 
     def test_loop_errs_included_in_summary_when_present(self):
-        ex.define_template("Template:Self", ["{{Self|x}}"], self.templates)
+        ex.define_template("Template:Self", ["{{Self|x}}"], self.templates, self.redirects)
         article_text = "{{Self|x}}"
         extractor = self.make_extractor(article_text)
 
@@ -255,7 +255,7 @@ class ErrorSummaryReportingTests(TemplateLoopGuardTestCase):
                       "per-article error summary should report the loop count")
 
     def test_no_spurious_errors_reported_for_clean_article(self):
-        ex.define_template("Template:Plain", ["just plain text"], self.templates)
+        ex.define_template("Template:Plain", ["just plain text"], self.templates, self.redirects)
         article_text = "{{Plain}}"
         extractor = self.make_extractor(article_text)
 

--- a/tests/test_template_loop_guard.py
+++ b/tests/test_template_loop_guard.py
@@ -64,18 +64,13 @@ class TemplateLoopGuardTestCase(unittest.TestCase):
         # Normally set by load_templates() when scanning a real dump's
         # first Template-namespace page; tests define templates directly
         # via define_template(), so it must be set explicitly here.
-        ex.Extractor.templatePrefix = "Template:"
-        # Normally set by WikiExtractor.py's main() (Extractor.to_json =
-        # args.json) before any Extractor.extract() call; tests that call
-        # .extract() directly need it set too, or it raises AttributeError
-        # (note: the class also defines an unused `toJson` attribute --
-        # a pre-existing, unrelated naming mismatch in extract.py).
-        ex.Extractor.to_json = False
+        self.templatePrefix = "Template:"
 
     def make_extractor(self, article_text, article_id=1, title="Test Article"):
         return Extractor(article_id, str(article_id),
                           f"https://test.wikipedia.org/wiki?curid={article_id}",
-                          title, [article_text], templates=self.templates, redirects=self.redirects)
+                          title, [article_text], templates=self.templates, redirects=self.redirects,
+                          templatePrefix=self.templatePrefix)
 
 
 class LegitimateSelfRecursionTests(TemplateLoopGuardTestCase):

--- a/tests/test_text_format.py
+++ b/tests/test_text_format.py
@@ -35,30 +35,23 @@ import wikiextractor.extract as ex
 
 
 class TextFormatTestCase(unittest.TestCase):
-    """Base class that resets wikiextractor's module-level template state
-    and output-format flags before each test, so tests don't leak state
-    into one another.
+    """Base class that resets wikiextractor's module-level template
+    cache state before each test, so tests don't leak state into one
+    another.
     """
 
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.Extractor.templatePrefix = "Template:"
-        # Reset all three output-format flags to their defaults; each
-        # test sets only the ones it needs.
-        ex.Extractor.to_json = False
-        ex.Extractor.to_text = False
-        ex.Extractor.discard_empty = False
+        self.templatePrefix = "Template:"
 
-    def make_extractor(self, article_text, article_id=1, title="Test Article"):
+    def make_extractor(self, article_text, article_id=1, title="Test Article", **flags):
         return Extractor(article_id, str(article_id),
                           f"https://test.wikipedia.org/wiki?curid={article_id}",
-                          title, [article_text])
+                          title, [article_text], templatePrefix=self.templatePrefix, **flags)
 
     def extract_output(self, article_text, **flags):
-        for name, value in flags.items():
-            setattr(ex.Extractor, name, value)
-        extractor = self.make_extractor(article_text)
+        extractor = self.make_extractor(article_text, **flags)
         out = StringIO()
         extractor.extract(out, html_safe=True)
         return out.getvalue()

--- a/tests/test_text_format.py
+++ b/tests/test_text_format.py
@@ -43,7 +43,6 @@ class TextFormatTestCase(unittest.TestCase):
     def setUp(self):
         ex.TemplateArg._parse_template.cache_clear()
         ex.Extractor._parse_template.cache_clear()
-        ex.redirects.clear()
         ex.Extractor.templatePrefix = "Template:"
         # Reset all three output-format flags to their defaults; each
         # test sets only the ones it needs.

--- a/tools/classify_missing_pages.py
+++ b/tools/classify_missing_pages.py
@@ -188,7 +188,8 @@ def collect_doc_ids(path, verbose_label):
     return ids
 
 
-def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None, templates=None, redirects=None):
+def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None, templates=None,
+                       redirects=None, template_prefix=''):
     """
     Stream through the original XML dump looking for <page> blocks whose
     page id is in target_ids. Returns {id: info_dict} where info_dict has
@@ -240,7 +241,8 @@ def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None, te
                 if '</page>' in line:
                     in_page = False
                     if page_id in remaining:
-                        results[page_id] = _parse_page_block(''.join(page_lines), ex_module, templates, redirects)
+                        results[page_id] = _parse_page_block(
+                            ''.join(page_lines), ex_module, templates, redirects, template_prefix)
                         remaining.discard(page_id)
                         pbar.set_postfix(found=f"{len(results)}/{total_targets}")
                     page_lines = []
@@ -250,7 +252,7 @@ def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None, te
     return results, remaining
 
 
-def _parse_page_block(block, ex_module=None, templates=None, redirects=None):
+def _parse_page_block(block, ex_module=None, templates=None, redirects=None, template_prefix=''):
     title_m = TITLE_RE.search(block)
     title = title_m.group(1) if title_m else ''
     has_redirect = bool(REDIRECT_TAG_RE.search(block))
@@ -290,7 +292,8 @@ def _parse_page_block(block, ex_module=None, templates=None, redirects=None):
         try:
             extractor = ex_module.Extractor(
                 page_id, page_id, f"https://example.org/wiki?curid={page_id}",
-                title, [stripped], templates=templates, redirects=redirects)
+                title, [stripped], templates=templates, redirects=redirects,
+                templatePrefix=template_prefix)
             # Run on the full page text, redirect line included, to
             # exactly mirror what the real extraction pipeline does in
             # Extractor.extract() -- not just the trailing portion in
@@ -363,6 +366,7 @@ def main():
     ex_module = None
     templates = None
     redirects = None
+    template_prefix = ''
     if not args.no_extraction_check:
         try:
             import wikiextractor.extract as ex_module
@@ -372,7 +376,7 @@ def main():
                 templates = {}
                 redirects = {}
                 with we.decode_open(args.templates) as f:
-                    count = we.load_templates(f, templates=templates, redirects=redirects)
+                    count, template_prefix = we.load_templates(f, templates=templates, redirects=redirects)
                 print(f"Loaded {count} templates.", file=sys.stderr)
         except ImportError as e:
             print(f"warning: --no-extraction-check was not given, but wikiextractor isn't "
@@ -396,7 +400,7 @@ def main():
     dump_info, not_found = scan_dump_for_ids(args.dump, missing,
                                               early_exit=not args.no_early_exit,
                                               ex_module=ex_module, templates=templates,
-                                              redirects=redirects)
+                                              redirects=redirects, template_prefix=template_prefix)
 
     rows = []
     counts = {}

--- a/tools/classify_missing_pages.py
+++ b/tools/classify_missing_pages.py
@@ -188,7 +188,7 @@ def collect_doc_ids(path, verbose_label):
     return ids
 
 
-def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None, templates=None):
+def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None, templates=None, redirects=None):
     """
     Stream through the original XML dump looking for <page> blocks whose
     page id is in target_ids. Returns {id: info_dict} where info_dict has
@@ -240,7 +240,7 @@ def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None, te
                 if '</page>' in line:
                     in_page = False
                     if page_id in remaining:
-                        results[page_id] = _parse_page_block(''.join(page_lines), ex_module, templates)
+                        results[page_id] = _parse_page_block(''.join(page_lines), ex_module, templates, redirects)
                         remaining.discard(page_id)
                         pbar.set_postfix(found=f"{len(results)}/{total_targets}")
                     page_lines = []
@@ -250,7 +250,7 @@ def scan_dump_for_ids(dump_path, target_ids, early_exit=True, ex_module=None, te
     return results, remaining
 
 
-def _parse_page_block(block, ex_module=None, templates=None):
+def _parse_page_block(block, ex_module=None, templates=None, redirects=None):
     title_m = TITLE_RE.search(block)
     title = title_m.group(1) if title_m else ''
     has_redirect = bool(REDIRECT_TAG_RE.search(block))
@@ -290,7 +290,7 @@ def _parse_page_block(block, ex_module=None, templates=None):
         try:
             extractor = ex_module.Extractor(
                 page_id, page_id, f"https://example.org/wiki?curid={page_id}",
-                title, [stripped], templates=templates)
+                title, [stripped], templates=templates, redirects=redirects)
             # Run on the full page text, redirect line included, to
             # exactly mirror what the real extraction pipeline does in
             # Extractor.extract() -- not just the trailing portion in
@@ -362,6 +362,7 @@ def main():
 
     ex_module = None
     templates = None
+    redirects = None
     if not args.no_extraction_check:
         try:
             import wikiextractor.extract as ex_module
@@ -369,8 +370,9 @@ def main():
                 import wikiextractor.WikiExtractor as we
                 print(f"Loading templates from {args.templates}...", file=sys.stderr)
                 templates = {}
+                redirects = {}
                 with we.decode_open(args.templates) as f:
-                    count = we.load_templates(f, templates=templates)
+                    count = we.load_templates(f, templates=templates, redirects=redirects)
                 print(f"Loaded {count} templates.", file=sys.stderr)
         except ImportError as e:
             print(f"warning: --no-extraction-check was not given, but wikiextractor isn't "
@@ -393,7 +395,8 @@ def main():
 
     dump_info, not_found = scan_dump_for_ids(args.dump, missing,
                                               early_exit=not args.no_early_exit,
-                                              ex_module=ex_module, templates=templates)
+                                              ex_module=ex_module, templates=templates,
+                                              redirects=redirects)
 
     rows = []
     counts = {}

--- a/tools/confirm_redirect_keyword_causation.py
+++ b/tools/confirm_redirect_keyword_causation.py
@@ -208,7 +208,7 @@ class RecordingDict(dict):
         return super().get(key, default)
 
 
-def find_redirect_templates_invoked(ex, page_id, wikitext, non_english_redirect_titles, templates):
+def find_redirect_templates_invoked(ex, page_id, wikitext, non_english_redirect_titles, templates, redirects):
     """
     Runs the real clean_text() on wikitext, instrumented to record
     every template title looked up, then returns the subset of those
@@ -216,25 +216,23 @@ def find_redirect_templates_invoked(ex, page_id, wikitext, non_english_redirect_
     the newly-recognized, non-English keywords -- genuine, per-article
     confirmation, not a file-wide pattern match.
 
-    templates: the real {title: text} dict, as populated by
+    templates, redirects: the real dicts, as populated by
     load_templates() in main() -- wrapped fresh here each call rather
     than mutating any shared global (there is no longer a module-level
-    `templates` in extract.py to save/swap/restore around this call at
-    all; the caller's own dict is untouched by the wrapping itself).
+    `templates`/`redirects` in extract.py to save/swap/restore around
+    this call at all; the caller's own dicts are untouched by the
+    wrapping itself).
     """
     looked_up = set()
-    original_redirects = ex.redirects
+    wrapped_templates = RecordingDict(templates, looked_up.add)
+    wrapped_redirects = RecordingDict(redirects, looked_up.add)
+    extractor = ex.Extractor(page_id, page_id, f"https://example.org/wiki?curid={page_id}",
+                              f"Page{page_id}", [wikitext], templates=wrapped_templates,
+                              redirects=wrapped_redirects)
     try:
-        wrapped_templates = RecordingDict(templates, looked_up.add)
-        ex.redirects = RecordingDict(ex.redirects, looked_up.add)
-        extractor = ex.Extractor(page_id, page_id, f"https://example.org/wiki?curid={page_id}",
-                                  f"Page{page_id}", [wikitext], templates=wrapped_templates)
-        try:
-            extractor.clean_text(wikitext, expand_templates=True)
-        except Exception:
-            pass  # a page that can't finish expanding still reveals what it looked up first
-    finally:
-        ex.redirects = original_redirects
+        extractor.clean_text(wikitext, expand_templates=True)
+    except Exception:
+        pass  # a page that can't finish expanding still reveals what it looked up first
     return looked_up & non_english_redirect_titles
 
 
@@ -349,9 +347,10 @@ def main():
 
     print("Loading templates into the real extract.py machinery...", file=sys.stderr)
     templates = {}
+    redirects = {}
     with open(args.templates, encoding='utf-8', errors='replace') as f:
         import wikiextractor.WikiExtractor as we
-        we.load_templates(f, templates=templates)
+        we.load_templates(f, templates=templates, redirects=redirects)
 
     source_texts = get_source_wikitext_by_id(args.dump, changed_ids)
     missing_from_source = [doc_id for doc_id in changed_ids if doc_id not in source_texts]
@@ -380,7 +379,7 @@ def main():
 
         if doc_id in source_texts:
             invoked = find_redirect_templates_invoked(
-                ex, doc_id, source_texts[doc_id], non_english_redirect_titles, templates)
+                ex, doc_id, source_texts[doc_id], non_english_redirect_titles, templates, redirects)
         else:
             invoked = None
 

--- a/tools/confirm_redirect_keyword_causation.py
+++ b/tools/confirm_redirect_keyword_causation.py
@@ -208,7 +208,8 @@ class RecordingDict(dict):
         return super().get(key, default)
 
 
-def find_redirect_templates_invoked(ex, page_id, wikitext, non_english_redirect_titles, templates, redirects):
+def find_redirect_templates_invoked(ex, page_id, wikitext, non_english_redirect_titles, templates,
+                                     redirects, template_prefix=''):
     """
     Runs the real clean_text() on wikitext, instrumented to record
     every template title looked up, then returns the subset of those
@@ -222,13 +223,18 @@ def find_redirect_templates_invoked(ex, page_id, wikitext, non_english_redirect_
     `templates`/`redirects` in extract.py to save/swap/restore around
     this call at all; the caller's own dicts are untouched by the
     wrapping itself).
+    template_prefix: the Template-namespace prefix (e.g. 'Template:'),
+        as discovered by load_templates() in main() -- without this,
+        a bare {{TemplateName}} call resolves to just 'TemplateName'
+        with no prefix at all, which never matches the real, stored
+        'Template:TemplateName' key, and every lookup silently misses.
     """
     looked_up = set()
     wrapped_templates = RecordingDict(templates, looked_up.add)
     wrapped_redirects = RecordingDict(redirects, looked_up.add)
     extractor = ex.Extractor(page_id, page_id, f"https://example.org/wiki?curid={page_id}",
                               f"Page{page_id}", [wikitext], templates=wrapped_templates,
-                              redirects=wrapped_redirects)
+                              redirects=wrapped_redirects, templatePrefix=template_prefix)
     try:
         extractor.clean_text(wikitext, expand_templates=True)
     except Exception:
@@ -350,7 +356,7 @@ def main():
     redirects = {}
     with open(args.templates, encoding='utf-8', errors='replace') as f:
         import wikiextractor.WikiExtractor as we
-        we.load_templates(f, templates=templates, redirects=redirects)
+        _count, template_prefix = we.load_templates(f, templates=templates, redirects=redirects)
 
     source_texts = get_source_wikitext_by_id(args.dump, changed_ids)
     missing_from_source = [doc_id for doc_id in changed_ids if doc_id not in source_texts]
@@ -379,7 +385,8 @@ def main():
 
         if doc_id in source_texts:
             invoked = find_redirect_templates_invoked(
-                ex, doc_id, source_texts[doc_id], non_english_redirect_titles, templates, redirects)
+                ex, doc_id, source_texts[doc_id], non_english_redirect_titles, templates, redirects,
+                template_prefix=template_prefix)
         else:
             invoked = None
 

--- a/tools/extract_templates_by_id.py
+++ b/tools/extract_templates_by_id.py
@@ -161,7 +161,7 @@ class RecordingDict(dict):
 
 def discover_and_extract(wikiextractor_extract_module, page_texts, templates_path, max_passes):
     ex = wikiextractor_extract_module
-    ex.Extractor.templatePrefix = determine_template_prefix(templates_path)
+    template_prefix = determine_template_prefix(templates_path)
 
     looked_up = set()
     # Local, not a module attribute: extract.py no longer has
@@ -185,7 +185,7 @@ def discover_and_extract(wikiextractor_extract_module, page_texts, templates_pat
             extractor = ex.Extractor(page_id, str(page_id),
                                       f"https://example.org/wiki?curid={page_id}",
                                       f"Page{page_id}", [wikitext], templates=templates,
-                                      redirects=redirects)
+                                      redirects=redirects, templatePrefix=template_prefix)
             try:
                 extractor.clean_text(wikitext, expand_templates=True)
             except Exception:

--- a/tools/extract_templates_by_id.py
+++ b/tools/extract_templates_by_id.py
@@ -164,17 +164,18 @@ def discover_and_extract(wikiextractor_extract_module, page_texts, templates_pat
     ex.Extractor.templatePrefix = determine_template_prefix(templates_path)
 
     looked_up = set()
-    # Local, not a module attribute: extract.py no longer has a
-    # module-level `templates` global at all for assigning to
-    # ex.templates to mean anything -- both define_template() and
-    # Extractor() take their templates dict as an explicit argument
-    # now, so that's how this RecordingDict actually gets used, same
-    # as any other templates source. templateCache is gone entirely
-    # (Extractor._parse_template() is its own lru_cache-decorated
-    # function now, not a dict expandTemplate() ever checks
-    # membership against), so there's nothing to instrument there.
+    # Local, not a module attribute: extract.py no longer has
+    # module-level `templates`/`redirects` globals at all for
+    # assigning to ex.templates/ex.redirects to mean anything -- both
+    # define_template() and Extractor() take these as explicit
+    # arguments now, so that's how these RecordingDicts actually get
+    # used, same as any other templates/redirects source. templateCache
+    # is gone entirely (Extractor._parse_template() is its own
+    # lru_cache-decorated function now, not a dict expandTemplate()
+    # ever checks membership against), so there's nothing to
+    # instrument there.
     templates = RecordingDict(on_lookup=looked_up.add)
-    ex.redirects.clear()
+    redirects = RecordingDict(on_lookup=looked_up.add)
 
     loaded_pages = {}  # title -> original <page> text, for writing to --output
 
@@ -183,7 +184,8 @@ def discover_and_extract(wikiextractor_extract_module, page_texts, templates_pat
         for page_id, wikitext in page_texts.items():
             extractor = ex.Extractor(page_id, str(page_id),
                                       f"https://example.org/wiki?curid={page_id}",
-                                      f"Page{page_id}", [wikitext], templates=templates)
+                                      f"Page{page_id}", [wikitext], templates=templates,
+                                      redirects=redirects)
             try:
                 extractor.clean_text(wikitext, expand_templates=True)
             except Exception:
@@ -208,7 +210,7 @@ def discover_and_extract(wikiextractor_extract_module, page_texts, templates_pat
             loaded_pages[title] = page_text
             text_match = re.search(r'<text[^>]*>(.*?)</text>', page_text, re.DOTALL)
             page_lines = [text_match.group(1)] if text_match else ['']
-            ex.define_template(title, page_lines, templates)
+            ex.define_template(title, page_lines, templates, redirects)
     else:
         print(f"WARNING: stopped after {max_passes} passes -- possible deep "
               f"nesting or a circular reference", file=sys.stderr)

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -70,8 +70,8 @@ from io import StringIO
 from multiprocessing import Queue, get_context, cpu_count, Value, Condition
 from timeit import default_timer
 
-from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces, \
-    resolve_template_page
+from .extract import Extractor, ignoreTag, define_template, \
+    resolve_template_page, _DEFAULT_IGNORED_TAG_PATTERNS
 from . import template_blob
 
 # ===========================================================================
@@ -112,11 +112,6 @@ def configure_mapreduce_logging(enabled):
             '%(levelname)s: %(asctime)s %(message)s'))
         mapreduce_logger.addHandler(handler)
     mapreduce_logger.propagate = False
-
-##
-# Defined in <siteinfo>
-# We include as default Template, when loading external template file.
-knownNamespaces = set(['Template'])
 
 ##
 # The namespace used for template definitions
@@ -222,7 +217,7 @@ tagRE = re.compile(r'(.*?)<(/?\w+)[^>]*>(?:([^<]*)(<.*?>)?)?')
 
 
 def load_templates(file, output_file=None, encoding='utf-8', templates=None, redirects=None,
-                    blob_builder=None, redirects_blob_builder=None):
+                    blob_builder=None, redirects_blob_builder=None, template_prefix=''):
     """
     Load templates from :param file:.
     :param output_file: file where to save templates and modules.
@@ -251,7 +246,22 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None, red
         expansion) and so is exposed to the identical fork/COW
         privatization growth confirmed for templates itself -- see
         template_blob.py's own module docstring.
-    :return: number of templates loaded.
+    :param template_prefix: the already-known Template-namespace
+        prefix (e.g. 'Template:'), if the caller already determined
+        it from the real dump's own siteinfo -- process_dump()'s own,
+        separate siteinfo scan does this before ever calling here.
+        When not given (empty), falls back to self-bootstrapping it
+        from the first colon-containing title encountered, same as
+        previously, just via a local variable instead of the (now
+        removed) Extractor.templatePrefix class attribute -- this
+        function never constructs any Extractor itself, it only needs
+        the prefix for its own page-filtering logic during loading.
+    :return: (number of templates loaded, the template_prefix that was
+        actually used -- either what was passed in, or whatever got
+        self-bootstrapped). The caller threads this into each real
+        Extractor(...) it constructs -- particularly the --article
+        path, which has no separate siteinfo scan of its own and
+        relies entirely on this return value.
     """
     global templateNamespace
     global moduleNamespace, modulePrefix
@@ -280,12 +290,12 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None, red
             page = []
         elif tag == 'title':
             title = m.group(3)
-            if not output_file and not templateNamespace:  # do not know it yet
+            if not output_file and not template_prefix:  # do not know it yet
                 # we reconstruct it from the first title
                 colon = title.find(':')
                 if colon > 1:
                     templateNamespace = title[:colon]
-                    Extractor.templatePrefix = title[:colon + 1]
+                    template_prefix = title[:colon + 1]
             # FIXME: should reconstruct also moduleNamespace
         elif tag == 'text':
             tag_end = line.index('>', m.start(2))
@@ -309,7 +319,7 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None, red
         elif inText:
             page.append(line)
         elif tag == '/page':
-            if title.startswith(Extractor.templatePrefix):
+            if title.startswith(template_prefix):
                 if blob_builder is not None or redirects_blob_builder is not None:
                     result = resolve_template_page(title, page)
                     if result is not None:
@@ -322,7 +332,7 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None, red
                     define_template(title, page, templates, redirects)
                 template_count += 1
             # save templates and modules to file
-            if output_file and (title.startswith(Extractor.templatePrefix) or
+            if output_file and (title.startswith(template_prefix) or
                                 title.startswith(modulePrefix)):
                 output.write('<page>\n')
                 output.write('   <title>%s</title>\n' % title)
@@ -339,7 +349,7 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None, red
     if output_file:
         output.close()
         logging.info("Saved %d templates to '%s'", template_count, output_file)
-    return template_count
+    return template_count, template_prefix
 
 
 def decode_open(filename, mode='rt', encoding='utf-8'):
@@ -500,15 +510,19 @@ def watchdog(jobs_queue, output_queue, reduce_proc, workers, stop_event, interva
             "%.1f" % sum(worker_mems) if worker_mems else "unknown")
 
 
-def load_and_compact_templates(template_file, input_file, input):
+def load_and_compact_templates(template_file, input_file, input, template_prefix=''):
     """Loads templates and redirects (from template_file if given,
     else input_file itself) and compacts each into its own
     shared-memory-backed view.
 
-    Returns (template_blob_ctx, redirects_blob_ctx, input) -- input is
-    returned because, when template_file isn't given, this scans and
-    then re-opens input_file itself, and the caller needs that updated
-    handle.
+    Returns (template_blob_ctx, redirects_blob_ctx, input, template_prefix)
+    -- input is returned because, when template_file isn't given, this
+    scans and then re-opens input_file itself, and the caller needs
+    that updated handle; template_prefix is returned because, when the
+    caller doesn't already know it (passes '' -- the --article path,
+    which has no separate siteinfo scan of its own), this discovers it
+    via load_templates()'s own self-bootstrap and the caller needs the
+    result to construct real Extractor instances correctly.
 
     Streams parsed templates and redirects directly into their own
     template_blob.StreamingTemplateBlobBuilder rather than building
@@ -544,16 +558,18 @@ def load_and_compact_templates(template_file, input_file, input):
     if template_file and os.path.exists(template_file):
         logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", template_file)
         file = decode_open(template_file)
-        template_count = load_templates(file, blob_builder=builder,
-                                         redirects_blob_builder=redirects_builder)
+        template_count, template_prefix = load_templates(
+            file, blob_builder=builder, redirects_blob_builder=redirects_builder,
+            template_prefix=template_prefix)
         file.close()
     else:
         if input_file == '-':
             # can't scan then reset stdin; must error w/ suggestion to specify template_file
             raise ValueError("to use templates with stdin dump, must supply explicit template-file")
         logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", input_file)
-        template_count = load_templates(input, template_file, blob_builder=builder,
-                                         redirects_blob_builder=redirects_builder)
+        template_count, template_prefix = load_templates(
+            input, template_file, blob_builder=builder, redirects_blob_builder=redirects_builder,
+            template_prefix=template_prefix)
         input.close()
         input = decode_open(input_file)
     logging.info("Loaded %d templates in %.1fs", template_count, default_timer() - template_load_start)
@@ -571,11 +587,12 @@ def load_and_compact_templates(template_file, input_file, input):
     redirects_blob_ctx = template_blob.compact_blobs(*redirects_builder.finish())
     logging.info("Compacted templates and redirects into shared memory in %.1fs",
                  default_timer() - compact_start)
-    return template_blob_ctx, redirects_blob_ctx, input
+    return template_blob_ctx, redirects_blob_ctx, input, template_prefix
 
 
 def process_dump(input_file, template_file, out_file, file_size, file_compress,
-                 process_count, html_safe, expand_templates=True, debug_map_reduce=False):
+                 process_count, html_safe, expand_templates=True, debug_map_reduce=False,
+                 extractor_kwargs=None):
     """
     :param input_file: name of the wikipedia dump file; '-' to read from stdin
     :param template_file: optional file with template definitions.
@@ -588,12 +605,25 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     :param debug_map_reduce: enables mapreduce_logger's DEBUG-level
         messages (see configure_mapreduce_logging()) -- per-page
         timing, queue dispatch, reducer progress, watchdog status.
+    :param extractor_kwargs: the CLI-derived subset of Extractor's own
+        constructor arguments (keepLinks, HtmlFormatting, to_json,
+        to_text, discard_empty, ignored_tag_patterns, and optionally
+        acceptedNamespaces), built once by main()'s
+        build_extractor_kwargs(). This function adds templatePrefix
+        and knownNamespaces to a copy of it, once real siteinfo has
+        been scanned below, and passes the complete result through to
+        every worker and every Extractor(...) constructed anywhere in
+        this run -- no piece of it is a shared global read implicitly
+        by anything.
     """
-    global knownNamespaces
+    extractor_kwargs = dict(extractor_kwargs) if extractor_kwargs else {}
+
     global templateNamespace
     global moduleNamespace, modulePrefix
 
     urlbase = ''                # This is obtained from <siteinfo>
+    known_namespaces = set(['Template'])
+    template_prefix = ''
 
     input = decode_open(input_file)
 
@@ -610,19 +640,23 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
             base = m.group(3)
             urlbase = base[:base.rfind("/")]
         elif tag == 'namespace':
-            knownNamespaces.add(m.group(3))
+            known_namespaces.add(m.group(3))
             if re.search('key="10"', line):
                 templateNamespace = m.group(3)
-                Extractor.templatePrefix = templateNamespace + ':'
+                template_prefix = templateNamespace + ':'
             elif re.search('key="828"', line):
                 moduleNamespace = m.group(3)
                 modulePrefix = moduleNamespace + ':'
         elif tag == '/siteinfo':
             break
 
+    extractor_kwargs['templatePrefix'] = template_prefix
+    extractor_kwargs['knownNamespaces'] = known_namespaces
+
     if expand_templates:
-        template_blob_ctx, redirects_blob_ctx, input = load_and_compact_templates(
-            template_file, input_file, input)
+        template_blob_ctx, redirects_blob_ctx, input, template_prefix = load_and_compact_templates(
+            template_file, input_file, input, template_prefix=template_prefix)
+        extractor_kwargs['templatePrefix'] = template_prefix
     else:
         # nullcontext, not None -- keeps the with-statement below
         # uniform regardless of whether templates are in play at all,
@@ -686,7 +720,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
         for _ in range(max(1, process_count)):
             extractor = Process(target=extract_process,
                                 args=(jobs_queue, output_queue, html_safe, debug_map_reduce,
-                                      template_blob_names, redirects_blob_names))
+                                      template_blob_names, redirects_blob_names, extractor_kwargs))
             extractor.daemon = True  # only live while parent process lives
             extractor.start()
             workers.append(extractor)
@@ -755,7 +789,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
 
 
 def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
-                     template_blob_names=None, redirects_blob_names=None):
+                     template_blob_names=None, redirects_blob_names=None, extractor_kwargs=None):
     """Pull tuples of raw page content, do CPU/regex-heavy fixup, push finished text
     :param jobs_queue: where to get jobs.
     :param output_queue: where to queue extracted text for output.
@@ -792,7 +826,17 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
         spawn instead of fork, which inherits nothing implicitly at
         all -- doing it this way now means extract_process()'s own
         body doesn't need to change shape later for that transition.
+    :param extractor_kwargs: the rest of Extractor's own constructor
+        arguments (templatePrefix, knownNamespaces, acceptedNamespaces,
+        ignored_tag_patterns, keepLinks, keepSections, HtmlFormatting,
+        to_json, to_text, discard_empty), built once by process_dump()
+        and passed through unchanged here -- same reasoning as
+        template_blob_names/redirects_blob_names above: every one of
+        these used to be a module- or class-level global a worker
+        picked up implicitly (several genuinely broken that way -- see
+        Extractor's own docstring), now plain, explicit arguments.
     """
+    extractor_kwargs = extractor_kwargs or {}
     configure_mapreduce_logging(debug_map_reduce)
     worker_ctx = (template_blob.attach(template_blob_names) if template_blob_names is not None
                   else contextlib.nullcontext(None))
@@ -808,7 +852,7 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
                                        os.getpid(), ordinal, page_id, title)
                 out = StringIO()  # memory buffer
                 Extractor(*job[:-1], templates=worker_templates,
-                          redirects=worker_redirects).extract(out, html_safe)  # (id, urlbase, title, page)
+                          redirects=worker_redirects, **extractor_kwargs).extract(out, html_safe)  # (id, urlbase, title, page)
                 finish = time.time()
                 mapreduce_logger.debug(
                     "PAGE_TIMING pid=%d ordinal=%d id=%s title=%r elapsed=%.2fs",
@@ -931,8 +975,6 @@ minFileSize = 200 * 1024
 
 
 def main():
-    global acceptedNamespaces
-
     parser = argparse.ArgumentParser(prog=os.path.basename(sys.argv[0]),
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
                                      description=__doc__)
@@ -997,13 +1039,25 @@ def main():
 
     args = parser.parse_args()
 
-    Extractor.keepLinks = args.links
-    Extractor.HtmlFormatting = args.html
+    keepLinks = args.links
     if args.html:
-        Extractor.keepLinks = True
-    Extractor.to_json = args.json
-    Extractor.to_text = args.text
-    Extractor.discard_empty = args.discard_empty
+        keepLinks = True
+    extractor_kwargs = {
+        'keepLinks': keepLinks,
+        'HtmlFormatting': args.html,
+        'to_json': args.json,
+        'to_text': args.text,
+        'discard_empty': args.discard_empty,
+        # Default set plus 'a' when links aren't being kept -- built
+        # explicitly, once, per run, rather than the old approach of
+        # mutating extract.py's own module-level list at import time
+        # (ignoreTag() is a pure function now: it returns the compiled
+        # pattern instead of appending it anywhere).
+        'ignored_tag_patterns': (list(_DEFAULT_IGNORED_TAG_PATTERNS) +
+                                  ([] if keepLinks else [ignoreTag('a')])),
+    }
+    if args.namespaces:
+        extractor_kwargs['acceptedNamespaces'] = set(args.namespaces.split(','))
 
     try:
         power = 'kmg'.find(args.bytes[-1].lower()) + 1
@@ -1014,9 +1068,6 @@ def main():
     except ValueError:
         logging.error('Insufficient or invalid size: %s', args.bytes)
         return
-
-    if args.namespaces:
-        acceptedNamespaces = set(args.namespaces.split(','))
 
     FORMAT = '%(levelname)s: %(message)s'
     logging.basicConfig(format=FORMAT)
@@ -1036,22 +1087,24 @@ def main():
 
     input_file = args.input
 
-    if not Extractor.keepLinks:
-        ignoreTag('a')
-
     if args.article:
         def compact_article_templates(templates_path):
             """Streams directly into blob builders, same as
             load_and_compact_templates() -- matches real behavior more
-            closely, and --article exists partly to validate that."""
+            closely, and --article exists partly to validate that.
+            Returns (owner, owner, template_prefix) -- the discovered
+            prefix from load_templates()'s own self-bootstrap, since
+            this path has no separate siteinfo scan of its own."""
             builder = template_blob.StreamingTemplateBlobBuilder()
             redirects_builder = template_blob.StreamingTemplateBlobBuilder()
             with decode_open(templates_path) as file:
-                load_templates(file, blob_builder=builder,
-                                redirects_blob_builder=redirects_builder)
+                _count, prefix = load_templates(file, blob_builder=builder,
+                                                 redirects_blob_builder=redirects_builder)
             return (template_blob.compact_blobs(*builder.finish()),
-                    template_blob.compact_blobs(*redirects_builder.finish()))
+                    template_blob.compact_blobs(*redirects_builder.finish()),
+                    prefix)
 
+        article_extractor_kwargs = dict(extractor_kwargs)
         if args.templates and os.path.exists(args.templates):
             # Same compaction as process_dump() -- deliberately not a
             # separate plain-dict path for --article just because
@@ -1059,7 +1112,9 @@ def main():
             # exists partly to validate real behavior, and exercising
             # a different templates lookup mechanism here than what
             # real multiprocess runs use would defeat that.
-            article_templates_ctx, article_redirects_ctx = compact_article_templates(args.templates)
+            article_templates_ctx, article_redirects_ctx, template_prefix = \
+                compact_article_templates(args.templates)
+            article_extractor_kwargs['templatePrefix'] = template_prefix
         else:
             article_templates_ctx = contextlib.nullcontext((None, None))
             article_redirects_ctx = contextlib.nullcontext((None, None))
@@ -1071,7 +1126,8 @@ def main():
                 for id, revid, title, page in collect_pages(input):
                     Extractor(id, revid, urlbase, title, page,
                               templates=article_templates,
-                              redirects=article_redirects).extract(sys.stdout)
+                              redirects=article_redirects,
+                              **article_extractor_kwargs).extract(sys.stdout)
         return
 
     output_path = args.output
@@ -1085,7 +1141,7 @@ def main():
     configure_mapreduce_logging(args.debug_map_reduce)
     process_dump(input_file, args.templates, output_path, file_size,
                  args.compress, args.processes, args.html_safe, not args.no_templates,
-                 args.debug_map_reduce)
+                 args.debug_map_reduce, extractor_kwargs=extractor_kwargs)
 
 if __name__ == '__main__':
     main()

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -71,7 +71,7 @@ from multiprocessing import Queue, get_context, cpu_count, Value, Condition
 from timeit import default_timer
 
 from .extract import Extractor, ignoreTag, define_template, acceptedNamespaces, \
-    resolve_template_page, redirects
+    resolve_template_page
 from . import template_blob
 
 # ===========================================================================
@@ -221,7 +221,8 @@ tagRE = re.compile(r'(.*?)<(/?\w+)[^>]*>(?:([^<]*)(<.*?>)?)?')
 #                    1     2               3      4
 
 
-def load_templates(file, output_file=None, encoding='utf-8', templates=None, blob_builder=None):
+def load_templates(file, output_file=None, encoding='utf-8', templates=None, redirects=None,
+                    blob_builder=None, redirects_blob_builder=None):
     """
     Load templates from :param file:.
     :param output_file: file where to save templates and modules.
@@ -235,11 +236,21 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None, blo
         -- this function mutates it in place, same as
         define_template() itself always has, just one level up.
         Ignored when blob_builder is given.
+    :param redirects: the {title: target_title} dict to populate --
+        same defaulting and mutate-in-place behavior as templates
+        above. Ignored when redirects_blob_builder is given.
     :param blob_builder: a template_blob.StreamingTemplateBlobBuilder
         to stream parsed templates directly into instead of
         populating `templates` -- for a real, full-scale dump, this
         avoids ever holding a full {title: text} dict in memory at
         all (see StreamingTemplateBlobBuilder's own docstring).
+    :param redirects_blob_builder: the equivalent streaming builder
+        for redirects, populated alongside blob_builder in the same
+        pass. redirects is typically far smaller than templates, but
+        it's read the same way (an ordinary .get() on every template
+        expansion) and so is exposed to the identical fork/COW
+        privatization growth confirmed for templates itself -- see
+        template_blob.py's own module docstring.
     :return: number of templates loaded.
     """
     global templateNamespace
@@ -247,6 +258,8 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None, blo
     modulePrefix = moduleNamespace + ':'
     if blob_builder is None and templates is None:
         templates = {}
+    if redirects_blob_builder is None and redirects is None:
+        redirects = {}
     articles = 0
     template_count = 0
     page = []
@@ -297,16 +310,16 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None, blo
             page.append(line)
         elif tag == '/page':
             if title.startswith(Extractor.templatePrefix):
-                if blob_builder is not None:
+                if blob_builder is not None or redirects_blob_builder is not None:
                     result = resolve_template_page(title, page)
                     if result is not None:
                         kind, value = result
                         if kind == 'redirect':
-                            redirects[title] = value
+                            redirects_blob_builder.add(title, value)
                         else:
                             blob_builder.add(title, value)
                 else:
-                    define_template(title, page, templates)
+                    define_template(title, page, templates, redirects)
                 template_count += 1
             # save templates and modules to file
             if output_file and (title.startswith(Extractor.templatePrefix) or
@@ -488,46 +501,59 @@ def watchdog(jobs_queue, output_queue, reduce_proc, workers, stop_event, interva
 
 
 def load_and_compact_templates(template_file, input_file, input):
-    """Loads templates (from template_file if given, else input_file
-    itself) and compacts them into a shared-memory-backed view.
+    """Loads templates and redirects (from template_file if given,
+    else input_file itself) and compacts each into its own
+    shared-memory-backed view.
 
-    Returns (template_blob_ctx, input) -- input is returned because,
-    when template_file isn't given, this scans and then re-opens
-    input_file itself, and the caller needs that updated handle.
+    Returns (template_blob_ctx, redirects_blob_ctx, input) -- input is
+    returned because, when template_file isn't given, this scans and
+    then re-opens input_file itself, and the caller needs that updated
+    handle.
 
-    Streams parsed templates directly into a
-    template_blob.StreamingTemplateBlobBuilder rather than building a
-    full {title: text} dict first and compacting it as a separate
-    pass -- at full EN scale (~900K templates), having both
-    representations resident at once meant this function's own peak
-    RSS was roughly double the size of the templates themselves,
-    confirmed directly on a real, memory-constrained production run
-    (mapper RSS: ~1.85GB after loading a plain dict, ~4.2GB once the
-    blob was also built alongside it -- and that ~1.85GB never fully
-    came back afterward either, even after the dict went out of scope
-    and an explicit gc.collect(): CPython's own allocator only returns
-    a fully-empty arena to the OS, and a dict with hundreds of
-    thousands of individually-allocated strings, built while other,
-    unrelated parsing allocations were happening at the same time,
-    left enough live stragglers scattered across arenas that most of
-    it stayed mapped). Streaming avoids the dict existing at all, so
-    there's nothing separate left to free or that can fail to be
-    freed -- the content blob's bytes are the only large allocation
-    made, once, directly.
+    Streams parsed templates and redirects directly into their own
+    template_blob.StreamingTemplateBlobBuilder rather than building
+    full dicts first and compacting them as a separate pass -- at full
+    EN scale (~900K templates), having both representations resident
+    at once meant this function's own peak RSS was roughly double the
+    size of the templates themselves, confirmed directly on a real,
+    memory-constrained production run (mapper RSS: ~1.85GB after
+    loading a plain dict, ~4.2GB once the blob was also built
+    alongside it -- and that ~1.85GB never fully came back afterward
+    either, even after the dict went out of scope and an explicit
+    gc.collect(): CPython's own allocator only returns a fully-empty
+    arena to the OS, and a dict with hundreds of thousands of
+    individually-allocated strings, built while other, unrelated
+    parsing allocations were happening at the same time, left enough
+    live stragglers scattered across arenas that most of it stayed
+    mapped). Streaming avoids the dict existing at all, so there's
+    nothing separate left to free or that can fail to be freed -- the
+    content blob's bytes are the only large allocation made, once,
+    directly.
+
+    redirects gets the identical treatment for a different reason:
+    it's typically far smaller than templates, but it's read the same
+    way -- an ordinary .get() on every template expansion -- and is
+    exposed to the identical fork/COW privatization growth confirmed
+    directly for templates itself (measured: 500K ordinary .get()
+    calls against a 200K-entry plain dict left 26.9MB of Private_Dirty
+    behind in a worker that never wrote to it directly at all).
     """
     builder = template_blob.StreamingTemplateBlobBuilder()
+    redirects_builder = template_blob.StreamingTemplateBlobBuilder()
     template_load_start = default_timer()
     if template_file and os.path.exists(template_file):
         logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", template_file)
         file = decode_open(template_file)
-        template_count = load_templates(file, blob_builder=builder)
+        template_count = load_templates(file, blob_builder=builder,
+                                         redirects_blob_builder=redirects_builder)
         file.close()
     else:
         if input_file == '-':
             # can't scan then reset stdin; must error w/ suggestion to specify template_file
             raise ValueError("to use templates with stdin dump, must supply explicit template-file")
         logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", input_file)
-        template_count = load_templates(input, template_file, blob_builder=builder)
+        template_count = load_templates(input, template_file, blob_builder=builder,
+                                         redirects_blob_builder=redirects_builder)
         input.close()
         input = decode_open(input_file)
     logging.info("Loaded %d templates in %.1fs", template_count, default_timer() - template_load_start)
@@ -535,15 +561,17 @@ def load_and_compact_templates(template_file, input_file, input):
     # See template_blob.py's own module docstring for why compaction
     # itself is necessary (fork()'s copy-on-write doesn't protect a
     # dict of Python objects the way it looks like it should).
-    # template_blob_ctx gets threaded through explicitly to
-    # extract_process() below (and to the single-article path in
-    # main()), which construct their own CompactedTemplates and pass
-    # it directly into each Extractor(..., templates=...).
+    # template_blob_ctx/redirects_blob_ctx get threaded through
+    # explicitly to extract_process() below (and to the single-article
+    # path in main()), which construct their own CompactedTemplates
+    # views and pass them directly into each
+    # Extractor(..., templates=..., redirects=...).
     compact_start = default_timer()
     template_blob_ctx = template_blob.compact_blobs(*builder.finish())
-    logging.info("Compacted templates into shared memory in %.1fs",
+    redirects_blob_ctx = template_blob.compact_blobs(*redirects_builder.finish())
+    logging.info("Compacted templates and redirects into shared memory in %.1fs",
                  default_timer() - compact_start)
-    return template_blob_ctx, input
+    return template_blob_ctx, redirects_blob_ctx, input
 
 
 def process_dump(input_file, template_file, out_file, file_size, file_compress,
@@ -593,13 +621,16 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
             break
 
     if expand_templates:
-        template_blob_ctx, input = load_and_compact_templates(template_file, input_file, input)
+        template_blob_ctx, redirects_blob_ctx, input = load_and_compact_templates(
+            template_file, input_file, input)
     else:
         # nullcontext, not None -- keeps the with-statement below
         # uniform regardless of whether templates are in play at all,
         # rather than needing a separate branch for --no-templates.
         template_blob_ctx = contextlib.nullcontext((None, None))
-    with template_blob_ctx as (_wrapper, template_blob_names):
+        redirects_blob_ctx = contextlib.nullcontext((None, None))
+    with template_blob_ctx as (_wrapper, template_blob_names), \
+            redirects_blob_ctx as (_redirects_wrapper, redirects_blob_names):
         # process pages
         logging.info("Starting page extraction from %s.", input_file)
         extract_start = default_timer()
@@ -655,7 +686,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
         for _ in range(max(1, process_count)):
             extractor = Process(target=extract_process,
                                 args=(jobs_queue, output_queue, html_safe, debug_map_reduce,
-                                      template_blob_names))
+                                      template_blob_names, redirects_blob_names))
             extractor.daemon = True  # only live while parent process lives
             extractor.start()
             workers.append(extractor)
@@ -723,7 +754,8 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
 # Multiprocess support
 
 
-def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False, template_blob_names=None):
+def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
+                     template_blob_names=None, redirects_blob_names=None):
     """Pull tuples of raw page content, do CPU/regex-heavy fixup, push finished text
     :param jobs_queue: where to get jobs.
     :param output_queue: where to queue extracted text for output.
@@ -740,31 +772,33 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
         PAGE_START line -- that's exactly the page it's stuck on, with
         no need to infer it from surrounding pages or wait to see
         whether it was "just slow".
-    :param template_blob_names: names of the shared-memory segments
-        built by template_blob.compact() in process_dump(), or None
-        if extraction is running with --no-templates. Attached here,
-        once, at worker startup, inside a with-block so this worker's
-        own view is closed automatically when the loop below exits
-        (never unlinked, though -- that's the creator's job alone via
-        CompactedTemplatesOwner, since a worker unlinking the shared
-        segment would destroy it out from under any sibling worker
-        still using it). The resulting view is passed explicitly into
-        every Extractor(...) constructed below -- not assigned to the
-        extract module's own `templates` global, which used to be how
-        a worker's template source got set up. Passing it as a
-        constructor argument means extract.py's own behavior is
-        visible in extract.py itself (Extractor takes a templates
-        argument) rather than being silently swappable only from
-        here; it's also what's actually required once this worker
-        starts being launched via spawn instead of fork, which
-        inherits nothing implicitly at all -- doing it this way now
-        means extract_process()'s own body doesn't need to change
-        shape later for that transition.
+    :param template_blob_names: :param redirects_blob_names: names of
+        the shared-memory segments built by template_blob.compact() in
+        process_dump(), or None if extraction is running with
+        --no-templates. Attached here, once, at worker startup, inside
+        a with-block so this worker's own view is closed automatically
+        when the loop below exits (never unlinked, though -- that's
+        the creator's job alone via CompactedTemplatesOwner, since a
+        worker unlinking the shared segment would destroy it out from
+        under any sibling worker still using it). The resulting views
+        are passed explicitly into every Extractor(...) constructed
+        below -- not assigned to the extract module's own `templates`/
+        `redirects` globals, which used to be how a worker's source
+        for each got set up. Passing them as constructor arguments
+        means extract.py's own behavior is visible in extract.py
+        itself (Extractor takes templates/redirects arguments) rather
+        than being silently swappable only from here; it's also what's
+        actually required once this worker starts being launched via
+        spawn instead of fork, which inherits nothing implicitly at
+        all -- doing it this way now means extract_process()'s own
+        body doesn't need to change shape later for that transition.
     """
     configure_mapreduce_logging(debug_map_reduce)
     worker_ctx = (template_blob.attach(template_blob_names) if template_blob_names is not None
                   else contextlib.nullcontext(None))
-    with worker_ctx as worker_templates:
+    redirects_ctx = (template_blob.attach(redirects_blob_names) if redirects_blob_names is not None
+                      else contextlib.nullcontext(None))
+    with worker_ctx as worker_templates, redirects_ctx as worker_redirects:
         while True:
             job = jobs_queue.get()  # job is (id, revid, urlbase, title, page, ordinal)
             if job:
@@ -773,7 +807,8 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
                 mapreduce_logger.debug("PAGE_START pid=%d ordinal=%d id=%s title=%r",
                                        os.getpid(), ordinal, page_id, title)
                 out = StringIO()  # memory buffer
-                Extractor(*job[:-1], templates=worker_templates).extract(out, html_safe)  # (id, urlbase, title, page)
+                Extractor(*job[:-1], templates=worker_templates,
+                          redirects=worker_redirects).extract(out, html_safe)  # (id, urlbase, title, page)
                 finish = time.time()
                 mapreduce_logger.debug(
                     "PAGE_TIMING pid=%d ordinal=%d id=%s title=%r elapsed=%.2fs",
@@ -1006,13 +1041,16 @@ def main():
 
     if args.article:
         def compact_article_templates(templates_path):
-            """Streams directly into a blob builder, same as
+            """Streams directly into blob builders, same as
             load_and_compact_templates() -- matches real behavior more
             closely, and --article exists partly to validate that."""
             builder = template_blob.StreamingTemplateBlobBuilder()
+            redirects_builder = template_blob.StreamingTemplateBlobBuilder()
             with decode_open(templates_path) as file:
-                load_templates(file, blob_builder=builder)
-            return template_blob.compact_blobs(*builder.finish())
+                load_templates(file, blob_builder=builder,
+                                redirects_blob_builder=redirects_builder)
+            return (template_blob.compact_blobs(*builder.finish()),
+                    template_blob.compact_blobs(*redirects_builder.finish()))
 
         if args.templates and os.path.exists(args.templates):
             # Same compaction as process_dump() -- deliberately not a
@@ -1021,16 +1059,19 @@ def main():
             # exists partly to validate real behavior, and exercising
             # a different templates lookup mechanism here than what
             # real multiprocess runs use would defeat that.
-            article_templates_ctx = compact_article_templates(args.templates)
+            article_templates_ctx, article_redirects_ctx = compact_article_templates(args.templates)
         else:
             article_templates_ctx = contextlib.nullcontext((None, None))
+            article_redirects_ctx = contextlib.nullcontext((None, None))
 
-        with article_templates_ctx as (article_templates, _names):
+        with article_templates_ctx as (article_templates, _names), \
+                article_redirects_ctx as (article_redirects, _redirects_names):
             urlbase = ''
             with decode_open(input_file) as input:
                 for id, revid, title, page in collect_pages(input):
                     Extractor(id, revid, urlbase, title, page,
-                              templates=article_templates).extract(sys.stdout)
+                              templates=article_templates,
+                              redirects=article_redirects).extract(sys.stdout)
         return
 
     output_path = args.output

--- a/wikiextractor/clean.py
+++ b/wikiextractor/clean.py
@@ -26,29 +26,28 @@ def clean_markup(markup, keep_links=False, ignore_headers=True):
     :param keep_links: keep literal HTML <a> tags in the output (escaped,
         not live) instead of stripping them. Does not affect [[wikilinks]]
         or [external links], which always reduce to their display text --
-        that's controlled separately, by Extractor.keepLinks.
+        that's controlled separately, by the Extractor's own keepLinks.
     :param ignore_headers: if set to True, the output list will not contain
     headers, only paragraphs.
 
     Returns a list of paragraphs (unicode strings).
     """
-    # Save/restore rather than calling resetIgnoredTags(): that clears
-    # extract.py's entire, shared ignored_tag_patterns list, not just
-    # the ignoreTag('a') call this function itself might make below.
-    saved_ignored_tag_patterns = list(_ex.ignored_tag_patterns)
-    try:
-        if not keep_links:
-            ignoreTag('a')
-        # id/revid/urlbase/title/page are placeholders: markup is
-        # passed directly to clean_text() below rather than via
-        # self.page, which only Extractor.extract() reads.
-        extractor = Extractor(0, '', '', '', [])
-        paragraphs = extractor.clean_text(markup,
-                                           mark_headers=True,
-                                           expand_templates=False,
-                                           html_safe=True)
-    finally:
-        _ex.ignored_tag_patterns = saved_ignored_tag_patterns
+    # Own list, passed straight into the constructor -- no shared,
+    # module-level list to save/restore around this call anymore.
+    # ignoreTag() is a pure function (returns the compiled pattern
+    # rather than appending it anywhere), and Extractor itself no
+    # longer has any class- or module-level state of this kind at all.
+    ignored_tag_patterns = list(_ex._DEFAULT_IGNORED_TAG_PATTERNS)
+    if not keep_links:
+        ignored_tag_patterns.append(ignoreTag('a'))
+    # id/revid/urlbase/title/page are placeholders: markup is
+    # passed directly to clean_text() below rather than via
+    # self.page, which only Extractor.extract() reads.
+    extractor = Extractor(0, '', '', '', [], ignored_tag_patterns=ignored_tag_patterns)
+    paragraphs = extractor.clean_text(markup,
+                                       mark_headers=True,
+                                       expand_templates=False,
+                                       html_safe=True)
     if ignore_headers:
         paragraphs = filter(lambda s: not s.startswith('## '), paragraphs)
     return paragraphs

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -49,7 +49,14 @@ syntaxhighlight = re.compile('&lt;syntaxhighlight .*?&gt;(.*?)&lt;/syntaxhighlig
 ##
 # Defined in <siteinfo>
 # We include as default Template, when loading external template file.
-knownNamespaces = set(['Template'])
+#
+# Static, import-time-only default -- never mutated after this point.
+# WikiExtractor.py used to reassign its own separately-imported copy of
+# this name from real siteinfo data, which never actually reached this,
+# the one Extractor instances really read (see Extractor.knownNamespaces
+# for the fix and the bug this used to be). Real, per-run values are
+# built explicitly in WikiExtractor.py and passed into each Extractor.
+_DEFAULT_KNOWN_NAMESPACES = frozenset(['Template'])
 
 ##
 # The #REDIRECT keyword, localized. MediaWiki's real redirect magic
@@ -105,7 +112,15 @@ discardElements = [
 # wiktionary: Wiki dictionary
 # wikt: shortcut for Wiktionary
 #
-acceptedNamespaces = ['w', 'wiktionary', 'wikt']
+# Static, import-time-only default -- never mutated after this point.
+# WikiExtractor.py used to reassign its own separately-imported copy of
+# this name from --namespaces, which (via `from .extract import
+# acceptedNamespaces` followed by a later reassignment) never actually
+# reached this, the one Extractor instances really read -- a plain
+# rebind of an imported name never propagates back to the defining
+# module. Real, per-run values are built explicitly in WikiExtractor.py
+# and passed into each Extractor.
+_DEFAULT_ACCEPTED_NAMESPACES = ('w', 'wiktionary', 'wikt')
 
 
 def get_url(urlbase, uid):
@@ -138,10 +153,10 @@ def clean(extractor, text, expand_templates=False, html_safe=True):
     text = dropNested(text, r'{\|', r'\|}')
 
     # replace external links
-    text = replaceExternalLinks(text)
+    text = replaceExternalLinks(text, extractor)
 
     # replace internal links
-    text = replaceInternalLinks(text)
+    text = replaceInternalLinks(text, extractor)
 
     # drop MagicWords behavioral switches
     text = magicWordsRE.sub('', text)
@@ -205,7 +220,7 @@ def clean(extractor, text, expand_templates=False, html_safe=True):
             spans.append((m.start(), m.end()))
 
     # Drop ignored tags
-    for left, right in ignored_tag_patterns:
+    for left, right in extractor.ignored_tag_patterns:
         for m in left.finditer(text):
             spans.append((m.start(), m.end()))
         for m in right.finditer(text):
@@ -296,9 +311,11 @@ listItem = {'*': '<li>%s</li>', '#': '<li>%s</<li>', ';': '<dt>%s</dt>',
             ':': '<dd>%s</dd>'}
 
 
-def compact(text, mark_headers=False):
+def compact(text, mark_headers=False, extractor=None):
     """Deal with headers, lists, empty sections, residuals of tables.
     :param text: convert to HTML
+    :param extractor: the calling Extractor, for its own
+        HtmlFormatting/keepSections settings.
     """
 
     page = []  # list of paragraph
@@ -309,7 +326,7 @@ def compact(text, mark_headers=False):
     for line in text.split('\n'):
 
         if not line.strip():
-            if len(listLevel):    # implies Extractor.HtmlFormatting
+            if len(listLevel):    # implies extractor.HtmlFormatting
                 for c in reversed(listLevel):
                     page.append(listClose[c])
                     listLevel = ''
@@ -320,7 +337,7 @@ def compact(text, mark_headers=False):
         if m:
             title = m.group(2)
             lev = len(m.group(1))
-            if Extractor.HtmlFormatting:
+            if extractor.HtmlFormatting:
                 page.append("<h%d>%s</h%d>" % (lev, title, lev))
             if title and title[-1] not in '!?':
                 title += '.'
@@ -346,7 +363,7 @@ def compact(text, mark_headers=False):
         # handle lists
         # @see https://www.mediawiki.org/wiki/Help:Formatting
         elif line[0] in '*#;':
-            if Extractor.HtmlFormatting:
+            if extractor.HtmlFormatting:
                 # close extra levels
                 l = 0
                 for c in listLevel:
@@ -370,7 +387,7 @@ def compact(text, mark_headers=False):
                 page.append(listItem[type] % line)
             else:
                 continue
-        elif len(listLevel):    # implies Extractor.HtmlFormatting
+        elif len(listLevel):    # implies extractor.HtmlFormatting
             for c in reversed(listLevel):
                 page.append(listClose[c])
             listLevel = []
@@ -382,7 +399,7 @@ def compact(text, mark_headers=False):
         elif (line[0] == '(' and line[-1] == ')') or line.strip('.-') == '':
             continue
         elif len(headers):
-            if Extractor.keepSections:
+            if extractor.keepSections:
                 items = sorted(headers.items())
                 for (i, v) in items:
                     page.append(v)
@@ -498,7 +515,7 @@ EXT_IMAGE_REGEX = re.compile(
     re.X | re.S | re.U)
 
 
-def replaceExternalLinks(text):
+def replaceExternalLinks(text, extractor):
     s = ''
     cur = 0
     for m in ExtLinkBracketedRegex.finditer(text):
@@ -520,30 +537,32 @@ def replaceExternalLinks(text):
         # This happened by accident in the original parser, but some people used it extensively
         m = EXT_IMAGE_REGEX.match(label)
         if m:
-            label = makeExternalImage(label)
+            label = makeExternalImage(label, extractor)
 
         # Use the encoded URL
         # This means that users can paste URLs directly into the text
         # Funny characters like ö aren't valid in URLs anyway
         # This was changed in August 2004
-        s += makeExternalLink(url, label)  # + trail
+        s += makeExternalLink(url, label, extractor)  # + trail
 
     return s + text[cur:]
 
 
-def makeExternalLink(url, anchor):
+def makeExternalLink(url, anchor, extractor):
     """Function applied to wikiLinks"""
-    if Extractor.keepLinks:
+    if extractor.keepLinks:
         return '<a href="%s">%s</a>' % (urlencode(url), anchor)
     else:
         return anchor
 
 
-def makeExternalImage(url, alt=''):
-    if Extractor.keepLinks:
+def makeExternalImage(url, extractor, alt=''):
+    """Function applied to wikiLinks whose label is itself an image URL."""
+    if extractor.keepLinks:
         return '<img src="%s" alt="%s">' % (url, alt)
     else:
         return alt
+
 
 
 # ----------------------------------------------------------------------
@@ -808,7 +827,7 @@ def neutralizeUnclosedLinkOpens(text):
 LINK_OPEN_PLACEHOLDER = '\x00\x00'
 
 
-def replaceInternalLinks(text):
+def replaceInternalLinks(text, extractor):
     """
     Replaces external links of the form:
     [[title |...|label]]trail
@@ -846,21 +865,21 @@ def replaceInternalLinks(text):
                     pipe = last  # advance
                 curp = e1
             label = inner[pipe + 1:].strip()
-        res += text[cur:s] + makeInternalLink(title, label) + trail
+        res += text[cur:s] + makeInternalLink(title, label, extractor) + trail
         cur = end
     return (res + text[cur:]).replace(LINK_OPEN_PLACEHOLDER, '[[')
 
 
-def makeInternalLink(title, label):
+def makeInternalLink(title, label, extractor):
     colon = title.find(':')
-    if colon > 0 and title[:colon] not in acceptedNamespaces:
+    if colon > 0 and title[:colon] not in extractor.acceptedNamespaces:
         return ''
     if colon == 0:
         # drop also :File:
         colon2 = title.find(':', colon + 1)
-        if colon2 > 1 and title[colon + 1:colon2] not in acceptedNamespaces:
+        if colon2 > 1 and title[colon + 1:colon2] not in extractor.acceptedNamespaces:
             return ''
-    if Extractor.keepLinks:
+    if extractor.keepLinks:
         return '<a href="%s">%s</a>' % (urlencode(title), label)
     else:
         return label
@@ -1067,8 +1086,9 @@ ignoredTags = (
 placeholder_tags = {'math': 'formula', 'code': 'codice'}
 
 
-def normalizeTitle(title):
+def normalizeTitle(title, known_namespaces=None):
     """Normalize title"""
+    known_namespaces = known_namespaces if known_namespaces is not None else _DEFAULT_KNOWN_NAMESPACES
     # remove leading/trailing whitespace and underscores
     title = title.strip(' _')
     # replace sequences of whitespace and underscore chars with a single space
@@ -1084,7 +1104,7 @@ def normalizeTitle(title):
         rest = m.group(3)
 
         ns = normalizeNamespace(prefix)
-        if ns in knownNamespaces:
+        if ns in known_namespaces:
             # If the prefix designates a known namespace, then it might be
             # followed by optional whitespace that should be removed to get
             # the canonical page name
@@ -1134,23 +1154,26 @@ def unescape(text):
 # The buggy template {{Template:T}} has a comment terminating with just "->"
 comment = re.compile(r'<!--.*?-->', re.DOTALL)
 
-# Match ignored tags
-ignored_tag_patterns = []
-
 
 def ignoreTag(tag):
+    """Compiles and returns the (open, close) regex pair for a tag to
+    be dropped from output, including its content. A pure function --
+    doesn't append anywhere itself, unlike its old behavior -- so the
+    caller decides what list this belongs in (an Extractor's own
+    per-instance ignored_tag_patterns, most commonly)."""
     left = re.compile(r'<%s\b.*?>' % tag, re.IGNORECASE | re.DOTALL)  # both <ref> and <reference>
     right = re.compile(r'</\s*%s\s*>' % tag, re.IGNORECASE)  # space allowed, such as </span >
-    ignored_tag_patterns.append((left, right))
+    return (left, right)
 
 
-def resetIgnoredTags():
-    global ignored_tag_patterns
-    ignored_tag_patterns = []
-
-
-for tag in ignoredTags:
-    ignoreTag(tag)
+# Match ignored tags. Static, import-time-only default -- never mutated
+# after this point (ignoreTag() itself no longer mutates anything).
+# WikiExtractor.py builds its own per-run list, starting from a copy of
+# this default and adding 'a' when --links isn't given, and passes that
+# explicitly into each Extractor -- see clean.py's own clean_markup()
+# for the same pattern at smaller scale (add 'a' or don't, no shared
+# state to save/restore around it either way).
+_DEFAULT_IGNORED_TAG_PATTERNS = [ignoreTag(tag) for tag in ignoredTags]
 
 # Match selfClosing HTML tags
 selfClosing_tag_patterns = [
@@ -1430,33 +1453,11 @@ class Extractor():
     """
     An extraction task on a article.
     """
-    ##
-    # Whether to preserve links in output
-    keepLinks = False
 
-    ##
-    # Whether to preserve section titles
-    keepSections = True
-
-    ##
-    # Whether to output text with HTML formatting elements in <doc> files.
-    HtmlFormatting = False
-
-    ##
-    # Whether to produce json instead of the default <doc> output format.
-    to_json = False
-    # Whether to produce text instead of the default <doc> output format.
-    to_text = False
-
-    ##
-    # Whether or not to discard empty (title only) documents
-    discard_empty = False
-
-    ##
-    # Obtained from TemplateNamespace
-    templatePrefix = ''
-
-    def __init__(self, id, revid, urlbase, title, page, templates=None, redirects=None):
+    def __init__(self, id, revid, urlbase, title, page, templates=None, redirects=None,
+                 templatePrefix='', knownNamespaces=None, acceptedNamespaces=None,
+                 ignored_tag_patterns=None, keepLinks=False, keepSections=True,
+                 HtmlFormatting=False, to_json=False, to_text=False, discard_empty=False):
         """
         :param page: a list of lines.
         :param templates: the {title: text} template lookup this
@@ -1475,6 +1476,23 @@ class Extractor():
         :param redirects: the {title: target_title} redirect lookup,
             same shape and same defaulting behavior as templates
             above -- also no longer a module-level global.
+        :param templatePrefix: :param knownNamespaces: :param
+            acceptedNamespaces: :param ignored_tag_patterns: :param
+            keepLinks: :param keepSections: :param HtmlFormatting:
+            :param to_json: :param to_text: :param discard_empty:
+            all formerly module- or class-level shared state (some of
+            it, for knownNamespaces/acceptedNamespaces, genuinely
+            broken shared state -- see the module-level defaults
+            below for why), now plain constructor arguments instead,
+            for the same reason templates/redirects are: no global,
+            of any kind, for a spawned worker process to silently miss
+            inheriting. Each defaults to a fresh copy of this module's
+            own static, never-mutated-after-import default when not
+            given, so existing callers that don't care about these
+            (most unit tests) see unchanged behavior. A caller that
+            DOES need real, CLI-configured values (extract_process(),
+            the --article path) builds and passes its own values
+            explicitly -- see WikiExtractor.py's own build_extractor_kwargs().
         """
         self.id = id
         self.revid = revid
@@ -1483,6 +1501,18 @@ class Extractor():
         self.page = page
         self.templates = templates if templates is not None else {}
         self.redirects = redirects if redirects is not None else {}
+        self.templatePrefix = templatePrefix
+        self.knownNamespaces = knownNamespaces if knownNamespaces is not None else set(_DEFAULT_KNOWN_NAMESPACES)
+        self.acceptedNamespaces = (acceptedNamespaces if acceptedNamespaces is not None
+                                    else list(_DEFAULT_ACCEPTED_NAMESPACES))
+        self.ignored_tag_patterns = (ignored_tag_patterns if ignored_tag_patterns is not None
+                                      else list(_DEFAULT_IGNORED_TAG_PATTERNS))
+        self.keepLinks = keepLinks
+        self.keepSections = keepSections
+        self.HtmlFormatting = HtmlFormatting
+        self.to_json = to_json
+        self.to_text = to_text
+        self.discard_empty = discard_empty
         self.magicWords = MagicWords()
         self.frame = []
         self.recursion_exceeded_1_errs = 0  # template recursion within expandTemplates()
@@ -1511,7 +1541,7 @@ class Extractor():
         text = clean(self, text, expand_templates=expand_templates,
                      html_safe=html_safe)
 
-        text = compact(text, mark_headers=mark_headers)
+        text = compact(text, mark_headers=mark_headers, extractor=self)
         return text
 
     def extract(self, out, html_safe=True):
@@ -1764,7 +1794,7 @@ class Extractor():
             ret = callParserFunction(funct, parts, self.frame)
             return self.expandTemplates(ret)
 
-        title = fullyQualifiedTemplateTitle(title)
+        title = fullyQualifiedTemplateTitle(title, self)
         if not title:
             self.template_title_errs += 1
             return ''
@@ -2131,7 +2161,7 @@ def lcfirst(string):
         return ''
 
 
-def fullyQualifiedTemplateTitle(templateTitle):
+def fullyQualifiedTemplateTitle(templateTitle, extractor):
     """
     Determine the namespace of the page being included through the template
     mechanism
@@ -2145,7 +2175,7 @@ def fullyQualifiedTemplateTitle(templateTitle):
             # colon found but not in the first position - check if it
             # designates a known namespace
             prefix = normalizeNamespace(m.group(1))
-            if prefix in knownNamespaces:
+            if prefix in extractor.knownNamespaces:
                 return prefix + ucfirst(m.group(2))
     # The title of the page being included is NOT in the main namespace and
     # lacks any other explicit designation of the namespace - therefore, it
@@ -2159,7 +2189,7 @@ def fullyQualifiedTemplateTitle(templateTitle):
     # space]], but having in the system a redirect page with an empty title
     # causes numerous problems, so we'll live happier without it.
     if templateTitle:
-        return Extractor.templatePrefix + ucfirst(templateTitle)
+        return extractor.templatePrefix + ucfirst(templateTitle)
     else:
         return ''  # caller may log as error
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -1456,7 +1456,7 @@ class Extractor():
     # Obtained from TemplateNamespace
     templatePrefix = ''
 
-    def __init__(self, id, revid, urlbase, title, page, templates=None):
+    def __init__(self, id, revid, urlbase, title, page, templates=None, redirects=None):
         """
         :param page: a list of lines.
         :param templates: the {title: text} template lookup this
@@ -1472,6 +1472,9 @@ class Extractor():
             DOES need real templates (extract_process(), the
             --article path) passes its own dict or CompactedTemplates
             view here explicitly.
+        :param redirects: the {title: target_title} redirect lookup,
+            same shape and same defaulting behavior as templates
+            above -- also no longer a module-level global.
         """
         self.id = id
         self.revid = revid
@@ -1479,6 +1482,7 @@ class Extractor():
         self.title = title
         self.page = page
         self.templates = templates if templates is not None else {}
+        self.redirects = redirects if redirects is not None else {}
         self.magicWords = MagicWords()
         self.frame = []
         self.recursion_exceeded_1_errs = 0  # template recursion within expandTemplates()
@@ -1765,7 +1769,7 @@ class Extractor():
             self.template_title_errs += 1
             return ''
 
-        redirected = redirects.get(title)
+        redirected = self.redirects.get(title)
         if redirected:
             title = redirected
 
@@ -2509,14 +2513,6 @@ def callParserFunction(functionName, args, frame):
 reNoinclude = re.compile(r'<noinclude>(?:.*?)</noinclude>\n?', re.DOTALL)
 reIncludeonly = re.compile(r'<includeonly>|</includeonly>', re.DOTALL)
 
-# redirects is still module-level, shared, mutable state -- deferred
-# deliberately, alongside templatePrefix/knownNamespaces/modules, as
-# its own separate piece of work (see define_template()'s own
-# docstring). templates itself no longer lives here: every reader
-# (Extractor) and writer (define_template()) now takes it as an
-# explicit argument instead.
-redirects = {}
-
 
 def resolve_template_page(title, page):
     """
@@ -2564,17 +2560,18 @@ def resolve_template_page(title, page):
     return ('template', text)
 
 
-def define_template(title, page, templates):
+def define_template(title, page, templates, redirects):
     """
-    Adds a template defined in the :param page: to :param templates:.
-    :param templates: the {title: text} dict to populate -- required,
-        not defaulted, since this function's entire job is writing
-        into it; a silent "if not given, use a throwaway empty dict"
-        default would make a forgotten argument fail silently (the
-        template is "defined" into a dict nobody keeps) rather than
-        loudly, which is worse than just requiring it.
+    Adds a template defined in the :param page: to :param templates:,
+    or a redirect to :param redirects:.
+    :param templates: the {title: text} dict to populate.
+    :param redirects: the {title: target_title} dict to populate.
+    Both required, not defaulted, since this function's entire job is
+    writing into one or the other; a silent "if not given, use a
+    throwaway empty dict" default would make a forgotten argument fail
+    silently (the page is "defined" into a dict nobody keeps) rather
+    than loudly, which is worse than just requiring it.
     """
-    global redirects
     result = resolve_template_page(title, page)
     if result is None:
         return

--- a/wikiextractor/test_external_links.py
+++ b/wikiextractor/test_external_links.py
@@ -1,0 +1,115 @@
+"""
+Tests for replaceExternalLinks()/makeExternalLink()/makeExternalImage()
+in extract.py -- previously entirely uncovered, which is exactly how a
+real, production-crashing bug got through undetected: makeExternalImage()'s
+signature had `alt=''` sitting between `url` and `extractor`, so its one
+real call site's second positional argument (the real Extractor) silently
+filled `alt` instead, leaving `extractor` at its own None default and
+crashing on `extractor.keepLinks` with an AttributeError -- but only on
+the rare path where an external link's label is itself an image URL
+(MediaWiki historically turned this into an <img> tag by accident; see
+the comment on replaceExternalLinks() itself). Every ordinary external
+link skips that branch entirely, so nothing in this codebase's earlier,
+real-pipeline testing ever exercised it.
+
+Fixed by giving makeExternalImage() the same required-second-positional-
+argument shape as makeExternalLink() already had (extractor right after
+the value being formatted, no default sitting in between) -- the whole
+class of "a keyword-defaulted parameter sits between two required ones"
+mistake is what let the wrong value land in the wrong slot silently
+rather than raising a clear TypeError immediately.
+
+Run with:
+    python -m unittest tests.test_external_links -v
+or, from the tests/ directory:
+    python -m unittest test_external_links -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+from wikiextractor.extract import Extractor
+
+
+class PlainExternalLinkTests(unittest.TestCase):
+    """Baseline coverage: an ordinary external link, neither an image
+    URL as its own label nor missing one -- never touches
+    makeExternalImage() at all.
+    """
+
+    def make_extractor(self, **kwargs):
+        return Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
+                          "Test Article", [], **kwargs)
+
+    def test_labeled_link_stripped_by_default(self):
+        extractor = self.make_extractor()
+        result = ex.replaceExternalLinks("[http://example.com Some Label]", extractor)
+        self.assertEqual(result, "Some Label")
+
+    def test_labeled_link_kept_as_anchor_with_keep_links(self):
+        extractor = self.make_extractor(keepLinks=True)
+        result = ex.replaceExternalLinks("[http://example.com Some Label]", extractor)
+        self.assertEqual(result, '<a href="http%3A//example.com">Some Label</a>')
+
+    def test_unlabeled_link_produces_empty_label_by_default(self):
+        # A bare [url] with no label: MediaWiki auto-numbers these in
+        # its own real renderer; this extractor's own, simpler
+        # handling just yields no visible label at all when links
+        # aren't being kept -- confirmed pre-existing, unrelated to
+        # this file's own regression coverage, just documented here
+        # as a baseline since nothing else in the suite covers it.
+        extractor = self.make_extractor()
+        result = ex.replaceExternalLinks("[http://example.com]", extractor)
+        self.assertEqual(result, "")
+
+
+class ExternalImageLabelRegressionTests(unittest.TestCase):
+    """The specific crash: an external link whose label is itself an
+    image URL (matches EXT_IMAGE_REGEX), routing through
+    makeExternalImage() -- the function whose parameter order used to
+    silently misroute the extractor argument into alt instead.
+    """
+
+    def make_extractor(self, **kwargs):
+        return Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
+                          "Test Article", [], **kwargs)
+
+    def test_image_labeled_link_does_not_crash_with_keep_links_false(self):
+        # This exact shape crashed in production before the fix:
+        # AttributeError: 'NoneType' object has no attribute 'keepLinks',
+        # since extractor itself silently landed in alt's slot instead.
+        extractor = self.make_extractor()
+        wikitext = "[http://example.com/photo.jpg http://example.com/photo.jpg]"
+        result = ex.replaceExternalLinks(wikitext, extractor)
+        self.assertEqual(result, "")
+
+    def test_image_labeled_link_produces_nested_img_in_anchor_with_keep_links_true(self):
+        extractor = self.make_extractor(keepLinks=True)
+        wikitext = "[http://example.com/photo.jpg http://example.com/photo.jpg]"
+        result = ex.replaceExternalLinks(wikitext, extractor)
+        self.assertEqual(
+            result,
+            '<a href="http%3A//example.com/photo.jpg">'
+            '<img src="http://example.com/photo.jpg" alt="">'
+            '</a>')
+
+    def test_makeExternalImage_called_directly_does_not_crash(self):
+        # Direct unit coverage of the function itself, not just via
+        # the full replaceExternalLinks() pipeline -- confirms the
+        # fixed signature's argument order is actually correct, not
+        # just that the one real call site happens to work.
+        extractor = self.make_extractor(keepLinks=True)
+        result = ex.makeExternalImage("http://example.com/x.png", extractor)
+        self.assertEqual(result, '<img src="http://example.com/x.png" alt="">')
+
+    def test_makeExternalImage_respects_keep_links_false(self):
+        extractor = self.make_extractor()
+        result = ex.makeExternalImage("http://example.com/x.png", extractor)
+        self.assertEqual(result, "")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`redirects` and several of the class variables in Extractor are global state.  These all need to be turned into member variables of Extractor and passed to the worker process.  Otherwise, `fork` allows the children process to see these values, but a `spawn` sees all of those values initialized to their defaults, as opposed to the values the mapper process (eg, the parent) have compiled.

`redirects` can be passed using the same `template_blob` mechanism as the `templates`