### PR TITLE
Template # expression expansion, debugging message filtering

### DIFF
--- a/tests/test_detail_log_level.py
+++ b/tests/test_detail_log_level.py
@@ -1,0 +1,111 @@
+"""
+Tests for the DETAIL log level -- a custom level between INFO (20)
+and DEBUG (10), registered via logging.addLevelName() in extract.py.
+
+Motivation: extract.py's per-article "Template errors in article..."
+summary needed a home between two extremes. WARNING was too broad --
+on a real, full-wiki run, a single common broken shared template can
+leave a large fraction of all articles with some nonzero error count,
+turning "one WARNING line per article" into hundreds of thousands of
+lines (see test_extract_process_worker_summary.py for the aggregate
+fix that came first). But DEBUG was too narrow a gate to put it
+behind -- DEBUG in extract.py also includes low-level extraction-
+mechanics tracing (template invocation, parameter substitution) that
+is entirely unrelated to "which pages have errors" and vastly more
+voluminous, confirmed directly: on a small, 313-page real-data test,
+--debug produced 76,202 log lines versus --verbose's 16.
+
+DETAIL is that middle ground: enabled via WikiExtractor.py's
+--verbose flag, shows per-article error detail without the mechanics
+tracing that only --debug enables.
+"""
+
+import logging
+import sys
+import unittest
+from io import StringIO
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+
+
+class DetailLevelDefinitionTests(unittest.TestCase):
+
+    def test_detail_is_between_info_and_debug(self):
+        self.assertLess(logging.DEBUG, ex.DETAIL)
+        self.assertLess(ex.DETAIL, logging.INFO)
+
+    def test_detail_has_a_registered_level_name(self):
+        # Confirms addLevelName() was actually called -- otherwise a
+        # DETAIL-level record renders with a bare numeric level
+        # ("Level 15: ...") instead of "DETAIL: ...".
+        self.assertEqual(logging.getLevelName(ex.DETAIL), 'DETAIL')
+
+
+class DetailLevelFilteringTests(unittest.TestCase):
+    """Confirms each threshold shows exactly what it should: the
+    per-article summary is reachable at DETAIL without requiring full
+    DEBUG, and stays hidden at the plain INFO default.
+    """
+
+    def make_extractor(self):
+        return ex.Extractor(1, "1", "https://x", "Test Article", ["{{BadExpr}}"],
+                             templates={'Template:BadExpr': '{{#expr: 1 + }}'},
+                             templatePrefix='Template:')
+
+    def run_at_level(self, level):
+        extractor = self.make_extractor()
+        log_stream = StringIO()
+        handler = logging.StreamHandler(log_stream)
+        root_logger = logging.getLogger()
+        original_level = root_logger.level
+        root_logger.addHandler(handler)
+        root_logger.setLevel(level)
+        try:
+            out = StringIO()
+            extractor.extract(out, html_safe=True)
+        finally:
+            root_logger.removeHandler(handler)
+            root_logger.setLevel(original_level)
+        return log_stream.getvalue()
+
+    def test_not_shown_at_default_info_level(self):
+        log_output = self.run_at_level(logging.INFO)
+        self.assertNotIn("Template errors in article", log_output)
+
+    def test_shown_at_detail_level(self):
+        log_output = self.run_at_level(ex.DETAIL)
+        self.assertIn("Template errors in article", log_output)
+
+    def test_shown_at_debug_level_too(self):
+        # DEBUG (10) is more permissive than DETAIL (15), so anything
+        # visible at DETAIL must still be visible at DEBUG.
+        log_output = self.run_at_level(logging.DEBUG)
+        self.assertIn("Template errors in article", log_output)
+
+    def test_extraction_mechanics_tracing_not_shown_at_detail_level(self):
+        # The actual point of DETAIL existing as a separate level from
+        # DEBUG: low-level invocation/substitution tracing must NOT
+        # leak through at DETAIL, only the per-article summary should.
+        templates = {'Template:Simple': 'hello world'}
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [],
+                                  templates=templates, templatePrefix='Template:')
+        log_stream = StringIO()
+        handler = logging.StreamHandler(log_stream)
+        root_logger = logging.getLogger()
+        original_level = root_logger.level
+        root_logger.addHandler(handler)
+        root_logger.setLevel(ex.DETAIL)
+        try:
+            extractor.clean_text('{{Simple}}', expand_templates=True)
+        finally:
+            root_logger.removeHandler(handler)
+            root_logger.setLevel(original_level)
+        log_output = log_stream.getvalue()
+        self.assertNotIn("INVOCATION", log_output)
+        self.assertNotIn("TITLE", log_output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_detail_log_level.py
+++ b/tests/test_detail_log_level.py
@@ -58,16 +58,20 @@ class DetailLevelFilteringTests(unittest.TestCase):
         extractor = self.make_extractor()
         log_stream = StringIO()
         handler = logging.StreamHandler(log_stream)
-        root_logger = logging.getLogger()
-        original_level = root_logger.level
-        root_logger.addHandler(handler)
-        root_logger.setLevel(level)
+        # 'wikiextractor.extract' specifically, not the root logger --
+        # wikiextractor's own logging no longer touches the root
+        # logger at all (see configure_wikiextractor_logging() in
+        # WikiExtractor.py).
+        extract_logger = logging.getLogger('wikiextractor.extract')
+        original_level = extract_logger.level
+        extract_logger.addHandler(handler)
+        extract_logger.setLevel(level)
         try:
             out = StringIO()
             extractor.extract(out, html_safe=True)
         finally:
-            root_logger.removeHandler(handler)
-            root_logger.setLevel(original_level)
+            extract_logger.removeHandler(handler)
+            extract_logger.setLevel(original_level)
         return log_stream.getvalue()
 
     def test_not_shown_at_default_info_level(self):
@@ -93,15 +97,15 @@ class DetailLevelFilteringTests(unittest.TestCase):
                                   templates=templates, templatePrefix='Template:')
         log_stream = StringIO()
         handler = logging.StreamHandler(log_stream)
-        root_logger = logging.getLogger()
-        original_level = root_logger.level
-        root_logger.addHandler(handler)
-        root_logger.setLevel(ex.DETAIL)
+        extract_logger = logging.getLogger('wikiextractor.extract')
+        original_level = extract_logger.level
+        extract_logger.addHandler(handler)
+        extract_logger.setLevel(ex.DETAIL)
         try:
             extractor.clean_text('{{Simple}}', expand_templates=True)
         finally:
-            root_logger.removeHandler(handler)
-            root_logger.setLevel(original_level)
+            extract_logger.removeHandler(handler)
+            extract_logger.setLevel(original_level)
         log_output = log_stream.getvalue()
         self.assertNotIn("INVOCATION", log_output)
         self.assertNotIn("TITLE", log_output)

--- a/tests/test_extract_process_worker_summary.py
+++ b/tests/test_extract_process_worker_summary.py
@@ -1,0 +1,129 @@
+"""
+Tests for extract_process()'s worker-level aggregate error summary.
+
+Real, full-wiki runs can have a large fraction of all articles report
+some template/#expr issue -- confirmed directly against a real
+ur.wikipedia.org run: a single common, broken shared template (a
+date-navigation infobox) reached enough articles that the per-article
+WARNING-level summary line alone (extract.py's own "Template errors
+in article...") produced over 160,000 log lines, drowning out
+everything else in the output.
+
+The fix: that per-article line moved to DEBUG (see
+test_template_loop_guard.ErrorSummaryReportingTests, updated for
+this), and extract_process() now accumulates the same six counters
+(title, recursion x3, loop, expr) across every article a single
+worker processes, logging ONE WARNING-level aggregate line per worker
+when its job queue is exhausted -- a handful of lines total (one per
+worker process) instead of one per problematic article, while still
+preserving the total counts needed to gauge scope.
+
+These tests call extract_process() directly, in-process, using plain
+queue.Queue objects rather than spawning real OS processes -- it only
+ever calls .get()/.put() on them, so a plain Queue is a faithful,
+much faster stand-in for these purposes.
+
+Run with:
+    python -m unittest tests.test_extract_process_worker_summary -v
+or, from the tests/ directory:
+    python -m unittest test_extract_process_worker_summary -v
+"""
+
+import logging
+import queue
+import sys
+import unittest
+from io import StringIO
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+import wikiextractor.WikiExtractor as we
+
+
+def run_extract_process(jobs, templates=None, redirects=None, template_prefix=''):
+    """Feeds `jobs` (a list of (id, revid, urlbase, title, page) tuples,
+    ordinal assigned automatically) through the real extract_process(),
+    then a sentinel None to make it exit its loop. Returns (log_output,
+    output_queue_contents).
+    """
+    jobs_queue = queue.Queue()
+    for ordinal, job in enumerate(jobs):
+        jobs_queue.put(job + (ordinal,))
+    jobs_queue.put(None)  # sentinel: tells the worker to stop
+
+    output_queue = queue.Queue()
+    extractor_kwargs = {'templatePrefix': template_prefix} if template_prefix else {}
+
+    log_stream = StringIO()
+    handler = logging.StreamHandler(log_stream)
+    root_logger = logging.getLogger()
+    original_level = root_logger.level
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.WARNING)
+    try:
+        we.extract_process(jobs_queue, output_queue, html_safe=True,
+                            template_blob_names=None, redirects_blob_names=None,
+                            extractor_kwargs={**extractor_kwargs, 'templates': templates,
+                                               'redirects': redirects} if templates is not None
+                            else extractor_kwargs)
+    finally:
+        root_logger.removeHandler(handler)
+        root_logger.setLevel(original_level)
+
+    outputs = []
+    while not output_queue.empty():
+        outputs.append(output_queue.get())
+    return log_stream.getvalue(), outputs
+
+
+class WorkerAggregateSummaryTests(unittest.TestCase):
+
+    def test_worker_with_no_problem_articles_logs_nothing(self):
+        jobs = [
+            (1, "1", "https://x", "Clean Article", ["just plain text"]),
+            (2, "2", "https://x", "Another Clean Article", ["more plain text"]),
+        ]
+        log_output, outputs = run_extract_process(jobs)
+        self.assertEqual(log_output, "")
+        self.assertEqual(len(outputs), 2)
+
+    def test_worker_with_problem_articles_logs_exactly_one_aggregate_line(self):
+        jobs = [
+            (1, "1", "https://x", "Bad Article One", ["{{#expr: 1 + }}"]),
+            (2, "2", "https://x", "Clean Article", ["just plain text"]),
+            (3, "3", "https://x", "Bad Article Two", ["{{#expr: 2 + }}"]),
+        ]
+        log_output, outputs = run_extract_process(jobs)
+        lines = [line for line in log_output.splitlines() if line.strip()]
+        self.assertEqual(len(lines), 1,
+                          "one aggregate WARNING line per worker, not one per article")
+        self.assertIn("2/3 articles had template errors", log_output)
+
+    def test_aggregate_counts_sum_correctly_across_articles(self):
+        # Two malformed #expr calls in the first article, one in the
+        # second -- the aggregate expr(...) count should be 3, not 2
+        # (the article count) or 1 (a single article's own count).
+        jobs = [
+            (1, "1", "https://x", "Bad Article One",
+             ["{{#expr: 1 + }}", "{{#expr: 2 + }}"]),
+            (2, "2", "https://x", "Bad Article Two", ["{{#expr: 3 + }}"]),
+        ]
+        log_output, outputs = run_extract_process(jobs)
+        self.assertIn("expr(3)", log_output)
+
+    def test_per_article_detail_not_present_at_worker_summary_warning_level(self):
+        # The per-article "Template errors in article '...'" line
+        # lives at DEBUG now (see test_template_loop_guard.py) -- it
+        # must not also appear at WARNING, or the whole point of this
+        # aggregation is defeated.
+        jobs = [
+            (1, "1", "https://x", "Bad Article One", ["{{#expr: 1 + }}"]),
+        ]
+        log_output, outputs = run_extract_process(jobs)
+        self.assertNotIn("Template errors in article", log_output)
+        self.assertIn("Worker pid=", log_output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_extract_process_worker_summary.py
+++ b/tests/test_extract_process_worker_summary.py
@@ -55,12 +55,21 @@ def run_extract_process(jobs, templates=None, redirects=None, template_prefix=''
     output_queue = queue.Queue()
     extractor_kwargs = {'templatePrefix': template_prefix} if template_prefix else {}
 
+    # extract_process() itself calls configure_wikiextractor_logging(),
+    # which sets wikiextractor_logger's own level (WARNING by default,
+    # matching what's wanted here) and gives it its own handler with
+    # propagate=False -- messages no longer reach the root logger at
+    # all, by design (see configure_wikiextractor_logging()'s own
+    # docstring), so capture directly from wikiextractor_logger
+    # instead. Attaching this handler first means
+    # configure_wikiextractor_logging()'s own "if not handlers" check
+    # won't add its default one on top of it.
     log_stream = StringIO()
     handler = logging.StreamHandler(log_stream)
-    root_logger = logging.getLogger()
-    original_level = root_logger.level
-    root_logger.addHandler(handler)
-    root_logger.setLevel(logging.WARNING)
+    wikiextractor_logger = logging.getLogger('wikiextractor')
+    original_level = wikiextractor_logger.level
+    original_propagate = wikiextractor_logger.propagate
+    wikiextractor_logger.addHandler(handler)
     try:
         we.extract_process(jobs_queue, output_queue, html_safe=True,
                             template_blob_names=None, redirects_blob_names=None,
@@ -68,8 +77,9 @@ def run_extract_process(jobs, templates=None, redirects=None, template_prefix=''
                                                'redirects': redirects} if templates is not None
                             else extractor_kwargs)
     finally:
-        root_logger.removeHandler(handler)
-        root_logger.setLevel(original_level)
+        wikiextractor_logger.removeHandler(handler)
+        wikiextractor_logger.setLevel(original_level)
+        wikiextractor_logger.propagate = original_propagate
 
     outputs = []
     while not output_queue.empty():

--- a/tests/test_formatnum.py
+++ b/tests/test_formatnum.py
@@ -1,0 +1,115 @@
+"""
+Tests for formatnum -- note no '#' prefix, unlike most parser
+functions in extract.py; matches real MediaWiki's own syntax for
+this one (it's technically a "string function", not a
+ParserFunctions-family branching function like #expr/#ifexpr/#switch,
+though it's registered in the same parserFunctions dict).
+
+Real MediaWiki's formatnum is locale-dependent: digit-grouping
+convention and whether to substitute "national" digits (e.g. Urdu/
+Persian ۰-۹) both come from the source wiki's own language
+configuration, which nothing in this codebase tracks. This is
+necessarily an approximation:
+  - Forward mode (no |R): comma thousands separators only (the
+    English-Wikipedia convention, and the most common on Wikipedia
+    overall). No national-digit output.
+  - Reverse mode (|R): strips comma grouping and maps known local
+    digit sets (Arabic-Indic, Extended Arabic-Indic) back to ASCII --
+    both fixed, context-free substitutions with no locale ambiguity,
+    unlike guessing a thousands-separator convention from the text
+    alone.
+
+Reverse mode is the direction that actually matters in practice:
+confirmed directly against a real, on-wiki template (Format price on
+ur.wikipedia.org) that every #ifexpr comparison in its digit-grouping
+chain had a blank left operand before this existed, since
+{{formatnum:{{{1}}}|R}} -- used throughout to normalize a value
+before doing #expr arithmetic on it -- always returned nothing.
+
+Run with:
+    python -m unittest tests.test_formatnum -v
+or, from the tests/ directory:
+    python -m unittest test_formatnum -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+
+
+class FormatnumForwardModeTests(unittest.TestCase):
+
+    def test_integer_gets_comma_grouped(self):
+        self.assertEqual(ex.sharp_formatnum('1234567'), '1,234,567')
+
+    def test_float_gets_comma_grouped_preserving_decimal(self):
+        self.assertEqual(ex.sharp_formatnum('1234567.89'), '1,234,567.89')
+
+    def test_small_number_unaffected(self):
+        self.assertEqual(ex.sharp_formatnum('42'), '42')
+
+    def test_negative_number(self):
+        self.assertEqual(ex.sharp_formatnum('-1234567'), '-1,234,567')
+
+    def test_non_numeric_input_passed_through_unchanged(self):
+        # Matches real MediaWiki's own graceful degradation on
+        # malformed input, rather than raising.
+        self.assertEqual(ex.sharp_formatnum('not a number'), 'not a number')
+
+
+class FormatnumReverseModeTests(unittest.TestCase):
+
+    def test_strips_comma_grouping(self):
+        self.assertEqual(ex.sharp_formatnum('1,234,567', 'R'), '1234567')
+
+    def test_negative_number_sign_preserved(self):
+        self.assertEqual(ex.sharp_formatnum('-1,234', 'R'), '-1234')
+
+    def test_converts_extended_arabic_indic_urdu_persian_digits(self):
+        self.assertEqual(ex.sharp_formatnum('۱۲۳۴', 'R'), '1234')
+
+    def test_converts_arabic_indic_digits(self):
+        self.assertEqual(ex.sharp_formatnum('١٢٣٤', 'R'), '1234')
+
+    def test_plain_ascii_number_unaffected(self):
+        self.assertEqual(ex.sharp_formatnum('1234', 'R'), '1234')
+
+    def test_result_is_usable_as_sharp_expr_input(self):
+        # The actual, real-world motivation: formatnum|R exists to
+        # normalize a value immediately before #expr arithmetic on
+        # it -- confirm the round trip actually works.
+        normalized = ex.sharp_formatnum('1,234', 'R')
+        self.assertEqual(ex.sharp_expr(normalized + ' + 1'), '1235')
+
+
+class FormatnumRealEndToEndTests(unittest.TestCase):
+    """Not sharp_formatnum() in isolation -- the real chain
+    (clean_text() -> expandTemplate() -> callParserFunction() ->
+    sharp_formatnum()), matching the real on-wiki shape (formatnum|R
+    feeding a value into a #expr comparison) that motivated this.
+    """
+
+    def test_real_pipeline_normalizes_a_comma_grouped_value_for_expr(self):
+        templates = {
+            'Template:DoubleIt': '{{#expr: {{formatnum:{{{1}}}|R}} * 2 }}',
+        }
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [], templates=templates,
+                                  templatePrefix='Template:')
+        result = extractor.clean_text('{{DoubleIt|1,234}}', expand_templates=True)
+        self.assertIn('2468', '\n'.join(result))
+
+    def test_real_pipeline_forward_mode_formats_a_computed_result(self):
+        templates = {
+            'Template:BigNumber': '{{formatnum:{{#expr: 1000 * 1234 }}}}',
+        }
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [], templates=templates,
+                                  templatePrefix='Template:')
+        result = extractor.clean_text('{{BigNumber}}', expand_templates=True)
+        self.assertIn('1,234,000', '\n'.join(result))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_padleft_padright.py
+++ b/tests/test_padleft_padright.py
@@ -1,0 +1,98 @@
+"""
+Tests for padleft/padright -- note no '#' prefix, matching real
+MediaWiki's own syntax for these (part of the "string functions"
+extension, like formatnum, lc, uc, urlencode -- not the '#'-prefixed
+ParserFunctions-family branching functions like #if/#switch/#expr).
+
+padleft was previously "implemented" but silently, completely broken:
+its lambda referenced a variable (`pad`) that was never defined
+anywhere in its own scope, so every call raised NameError, which
+callParserFunction()'s own catch-all swallowed into an empty result
+with no warning logged at all -- confirmed directly before this fix:
+{{padleft:7|3|0}} returned '' every time. padright didn't exist even
+as a stub.
+
+Both are now implemented via a single shared core (_sharp_pad),
+matching PHP's own str_pad() semantics that real MediaWiki's
+implementation is built on: the padding string is repeated as many
+times as needed to cover the gap, then truncated to exactly that many
+characters (not repeated a whole number of times and left over-long)
+before being attached to the original string.
+
+Run with:
+    python -m unittest tests.test_padleft_padright -v
+or, from the tests/ directory:
+    python -m unittest test_padleft_padright -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+
+
+class PadleftTests(unittest.TestCase):
+
+    def test_default_padding_character_is_zero(self):
+        self.assertEqual(ex.sharp_padleft('7', '3'), '007')
+
+    def test_multi_character_padding_repeats_then_truncates_not_whole_repetitions(self):
+        # Needs 3 characters of padding (width 4 - len("1")). "xy"
+        # repeated is "xyxyxy..."; truncated to 3 chars is "xyx" --
+        # not "xy1" (short by one) and not "xyxy1" (one whole extra
+        # repetition, four characters instead of three).
+        self.assertEqual(ex.sharp_padleft('1', '4', 'xy'), 'xyx1')
+
+    def test_string_already_at_or_past_target_width_is_unchanged(self):
+        self.assertEqual(ex.sharp_padleft('12345', '3'), '12345')
+
+    def test_string_exactly_at_target_width_is_unchanged(self):
+        self.assertEqual(ex.sharp_padleft('123', '3'), '123')
+
+    def test_non_numeric_width_leaves_string_unchanged(self):
+        self.assertEqual(ex.sharp_padleft('7', 'notanumber'), '7')
+
+    def test_negative_width_leaves_string_unchanged(self):
+        self.assertEqual(ex.sharp_padleft('7', '-1'), '7')
+
+    def test_empty_padding_string_leaves_value_unchanged(self):
+        # Nothing to repeat -- must not loop forever or divide by zero.
+        self.assertEqual(ex.sharp_padleft('7', '5', ''), '7')
+
+    def test_whitespace_around_width_is_tolerated(self):
+        self.assertEqual(ex.sharp_padleft('7', ' 3 '), '007')
+
+
+class PadrightTests(unittest.TestCase):
+
+    def test_default_padding_character_is_zero(self):
+        self.assertEqual(ex.sharp_padright('7', '3'), '700')
+
+    def test_multi_character_padding_repeats_then_truncates(self):
+        self.assertEqual(ex.sharp_padright('1', '4', 'xy'), '1xyx')
+
+    def test_string_already_at_or_past_target_width_is_unchanged(self):
+        self.assertEqual(ex.sharp_padright('12345', '3'), '12345')
+
+
+class PadRealEndToEndTests(unittest.TestCase):
+    """Not sharp_padleft()/sharp_padright() in isolation -- the real
+    chain (clean_text() -> expandTemplate() -> callParserFunction()),
+    matching a real, common on-wiki shape: zero-padding a date or ID
+    number inside a template.
+    """
+
+    def test_real_pipeline_zero_pads_a_computed_day_number(self):
+        templates = {
+            'Template:TwoDigitDay': '{{padleft:{{{1}}}|2}}',
+        }
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [], templates=templates,
+                                  templatePrefix='Template:')
+        result = extractor.clean_text('{{TwoDigitDay|7}}', expand_templates=True)
+        self.assertIn('07', '\n'.join(result))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_sharp_expr_security.py
+++ b/tests/test_sharp_expr_security.py
@@ -379,5 +379,66 @@ class SharpExprCascadeSuppressionTests(unittest.TestCase):
         self.assertEqual(extractor.malformed_expr_errs, 3)
 
 
+class SharpIfexprTests(unittest.TestCase):
+    """{{#ifexpr: EXPR | THEN | ELSE}} -- deliberately implemented as a
+    thin wrapper around sharp_expr() itself, reusing its safe AST-only
+    evaluation, malformed-expression logging, and per-article dedup
+    entirely rather than duplicating any of it. Not related to Lua/
+    Scribunto (#invoke) at all -- #ifexpr is a plain ParserFunctions
+    branch on a numeric expression, same family as #if/#ifeq/#switch.
+    """
+
+    def test_nonzero_selects_true_branch(self):
+        self.assertEqual(ex.sharp_ifexpr("5 > 3", "yes", "no"), "yes")
+
+    def test_zero_selects_false_branch(self):
+        self.assertEqual(ex.sharp_ifexpr("5 - 5", "yes", "no"), "no")
+
+    def test_false_comparison_selects_false_branch(self):
+        self.assertEqual(ex.sharp_ifexpr("5 > 30", "yes", "no"), "no")
+
+    def test_branches_are_stripped_like_if_and_ifeq_already_are(self):
+        self.assertEqual(ex.sharp_ifexpr("1", "  yes  ", "no"), "yes")
+
+    def test_missing_branches_default_to_empty(self):
+        self.assertEqual(ex.sharp_ifexpr("1"), "")
+        self.assertEqual(ex.sharp_ifexpr("0"), "")
+
+    def test_malformed_expression_reports_and_returns_error_span_not_a_guessed_branch(self):
+        # Real MediaWiki #ifexpr semantics on a malformed condition:
+        # an error indicator, not a silently-chosen branch -- #if and
+        # #ifeq never fail this way at all, since their own condition
+        # is a plain string comparison, never itself evaluated as an
+        # expression.
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            result = ex.sharp_ifexpr("commodity", "yes", "no")
+        self.assertEqual(result, ex._SHARP_EXPR_ERROR_SPAN)
+        self.assertIn('Malformed #expr', logs.output[0])
+
+    def test_malformed_condition_shares_the_same_per_article_dedup_as_expr(self):
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [])
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            for _ in range(3):
+                ex.sharp_ifexpr("commodity", "yes", "no", page_title="Test Article",
+                                page_id="1", extractor=extractor)
+        self.assertEqual(len(logs.output), 1)
+        self.assertEqual(extractor.malformed_expr_errs, 3)
+
+    def test_real_end_to_end_pipeline_computes_a_real_result_instead_of_nothing(self):
+        # Not #ifexpr in isolation -- confirms the real chain
+        # (clean_text() -> expandTemplate() -> callParserFunction() ->
+        # sharp_ifexpr() -> sharp_expr()) actually threads through
+        # correctly end to end, matching the real on-wiki template
+        # shape (a #switch{{#expr: X mod Y}} pattern) that motivated
+        # this feature.
+        templates = {
+            'Template:NextDay': '{{#ifexpr: {{{day}}} mod 2 = 0 | even day | odd day }}',
+        }
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [], templates=templates,
+                                  templatePrefix='Template:')
+        result = extractor.clean_text('{{NextDay|day=4}}', expand_templates=True)
+        self.assertIn('even day', '\n'.join(result))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sharp_expr_security.py
+++ b/tests/test_sharp_expr_security.py
@@ -134,7 +134,7 @@ class SharpExprSecurityTests(unittest.TestCase):
         # actually malformed. page_title/page_id, when supplied (as
         # expandTemplate() does for every real call), make a failure
         # directly traceable back to the article instead.
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             result = ex.sharp_expr("3in5", page_title="Some Article", page_id="123")
         self.assertEqual(result, self.ERROR_SPAN)
         self.assertEqual(len(logs.output), 1)
@@ -149,7 +149,7 @@ class SharpExprSecurityTests(unittest.TestCase):
         # that: it's what shows up if the caller is watching logs
         # rather than inspecting the return value directly, and costs
         # nothing extra to include.
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             result = ex.sharp_expr("3in5")
         self.assertEqual(result, self.ERROR_SPAN)
         self.assertEqual(len(logs.output), 1)
@@ -158,7 +158,7 @@ class SharpExprSecurityTests(unittest.TestCase):
 
     def test_valid_expr_logs_nothing_even_with_page_info(self):
         with self.assertRaises(AssertionError):
-            with self.assertLogs('wikiextractor.extract', level='WARNING'):
+            with self.assertLogs('wikiextractor.extract', level='DEBUG'):
                 ex.sharp_expr("2 + 3", page_title="Some Article", page_id="123")
 
     def test_string_literal_is_rejected_not_evaluated(self):
@@ -229,7 +229,7 @@ class SharpExprRepeatedFailureDedupTests(unittest.TestCase):
 
     def test_direct_calls_only_log_the_first_occurrence(self):
         extractor = self.make_extractor()
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             for _ in range(5):
                 result = ex.sharp_expr("3in5", page_title="Test Article", page_id="1",
                                         extractor=extractor)
@@ -242,7 +242,7 @@ class SharpExprRepeatedFailureDedupTests(unittest.TestCase):
         # per article" -- a second, genuinely different malformed
         # expression is still worth knowing about.
         extractor = self.make_extractor()
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             ex.sharp_expr("3in5", page_title="Test Article", page_id="1", extractor=extractor)
             ex.sharp_expr("3in5", page_title="Test Article", page_id="1", extractor=extractor)
             ex.sharp_expr("4in6", page_title="Test Article", page_id="1", extractor=extractor)
@@ -256,7 +256,7 @@ class SharpExprRepeatedFailureDedupTests(unittest.TestCase):
         first_extractor = self.make_extractor()
         second_extractor = ex.Extractor(2, "2", "https://test.wikipedia.org/wiki?curid=2",
                                          "Second Article", [])
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             ex.sharp_expr("3in5", page_title="Test Article", page_id="1", extractor=first_extractor)
             ex.sharp_expr("3in5", page_title="Second Article", page_id="2", extractor=second_extractor)
         self.assertEqual(len(logs.output), 2)
@@ -275,7 +275,7 @@ class SharpExprRepeatedFailureDedupTests(unittest.TestCase):
         extractor = ex.Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
                                   "Test Article", [article_text], templates=templates,
                                   redirects=redirects, templatePrefix='Template:')
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             extractor.clean_text(article_text, expand_templates=True)
         expr_warnings = [line for line in logs.output if 'Malformed #expr' in line]
         self.assertEqual(len(expr_warnings), 1)
@@ -315,7 +315,7 @@ class SharpExprCascadeSuppressionTests(unittest.TestCase):
                           "test setup sanity check: every cascade expression must be distinct, "
                           "or this test wouldn't be distinguishing cascade suppression from the "
                           "ordinary exact-match dedup tested elsewhere")
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             for e in cascade_exprs:
                 ex.sharp_expr(e, page_title="Test Article", page_id="1", extractor=extractor)
         self.assertEqual(len(logs.output), 1)
@@ -328,7 +328,7 @@ class SharpExprCascadeSuppressionTests(unittest.TestCase):
         # useful, actionable one, and must not be swallowed by cascade
         # suppression (which only applies to the *downstream* links).
         extractor = self.make_extractor()
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             ex.sharp_expr("3in5", page_title="Test Article", page_id="1", extractor=extractor)
             ex.sharp_expr(ex._SHARP_EXPR_ERROR_SPAN + " + 1", page_title="Test Article",
                           page_id="1", extractor=extractor)
@@ -342,7 +342,7 @@ class SharpExprCascadeSuppressionTests(unittest.TestCase):
         # malformed expression elsewhere in the same article is still
         # worth its own warning.
         extractor = self.make_extractor()
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             ex.sharp_expr(ex._SHARP_EXPR_ERROR_SPAN + " + 1", page_title="Test Article",
                           page_id="1", extractor=extractor)
             ex.sharp_expr("4in6", page_title="Test Article", page_id="1", extractor=extractor)
@@ -354,7 +354,7 @@ class SharpExprCascadeSuppressionTests(unittest.TestCase):
         # inherit cascade suppression from a previous one.
         first_extractor = self.make_extractor(page_id=1)
         second_extractor = self.make_extractor(page_id=2)
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             ex.sharp_expr(ex._SHARP_EXPR_ERROR_SPAN + " + 1", page_title="Test Article",
                           page_id="1", extractor=first_extractor)
             ex.sharp_expr(ex._SHARP_EXPR_ERROR_SPAN + " + 1", page_title="Test Article",
@@ -367,7 +367,7 @@ class SharpExprCascadeSuppressionTests(unittest.TestCase):
         # run through the full clean_text() pipeline.
         extractor = self.make_extractor()
         wikitext = "{{#expr: {{#expr: {{#expr: 3in5 }} + 1 }} + 2 }}"
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             extractor.clean_text(wikitext, expand_templates=True)
         expr_warnings = [line for line in logs.output if 'Malformed #expr' in line]
         # The innermost failure (3in5) is the root, standalone one;
@@ -410,14 +410,14 @@ class SharpIfexprTests(unittest.TestCase):
         # #ifeq never fail this way at all, since their own condition
         # is a plain string comparison, never itself evaluated as an
         # expression.
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             result = ex.sharp_ifexpr("commodity", "yes", "no")
         self.assertEqual(result, ex._SHARP_EXPR_ERROR_SPAN)
         self.assertIn('Malformed #expr', logs.output[0])
 
     def test_malformed_condition_shares_the_same_per_article_dedup_as_expr(self):
         extractor = ex.Extractor(1, "1", "https://x", "Test Article", [])
-        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+        with self.assertLogs('wikiextractor.extract', level='DEBUG') as logs:
             for _ in range(3):
                 ex.sharp_ifexpr("commodity", "yes", "no", page_title="Test Article",
                                 page_id="1", extractor=extractor)

--- a/tests/test_sharp_expr_security.py
+++ b/tests/test_sharp_expr_security.py
@@ -90,15 +90,17 @@ class SharpExprSecurityTests(unittest.TestCase):
         self.assertEqual(result, self.ERROR_SPAN)
 
     def test_original_syntaxwarning_trigger_handled_safely(self):
-        # The exact pattern that surfaced this investigation in the
-        # first place: a number directly adjacent to a parenthesized
-        # expression, which Python's own compile() step (not its
-        # parser) flags as likely a mistake. Confirmed directly (see
-        # project history) that ast.parse() alone -- what this
-        # evaluator actually uses -- never reaches that compile step,
-        # so this fix also happens to eliminate the original warning,
-        # not just the security hole; asserted here directly rather
-        # than assumed.
+        # The specific pattern that first surfaced this investigation:
+        # a number directly adjacent to a parenthesized expression.
+        # Confirmed directly (see project history) that ast.parse()
+        # alone -- what this evaluator actually uses -- doesn't warn
+        # for THIS particular shape, unlike full compile(). It does
+        # still warn for a different shape (a number directly adjacent
+        # to a keyword, e.g. "3in5") -- see
+        # test_keyword_adjacent_number_warning_suppressed below for
+        # that one, and sharp_expr()'s own warnings.catch_warnings()
+        # block, which covers both regardless of which shape triggers
+        # it.
         #
         # record=True rather than simplefilter("error") deliberately:
         # sharp_expr()'s own bare except would swallow a
@@ -111,6 +113,53 @@ class SharpExprSecurityTests(unittest.TestCase):
             result = ex.sharp_expr("2(3+4)")
         self.assertEqual(result, self.ERROR_SPAN)
         self.assertEqual(caught, [], "a warning was emitted where none should be")
+
+    def test_keyword_adjacent_number_warning_suppressed(self):
+        # A different trigger shape than the one above: a number
+        # directly adjacent to a Python keyword -- "3 in 5" typed (or
+        # produced by template substitution) as "3in5" -- which
+        # ast.parse() itself does warn about, as a side effect of
+        # tokenizing, before still correctly failing to parse right
+        # after. Real-world #expr input from actual wikitext, not a
+        # synthetic case: this is what a real, full-scale run surfaced.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = ex.sharp_expr("3in5")
+        self.assertEqual(result, self.ERROR_SPAN)
+        self.assertEqual(caught, [], "a warning was emitted where none should be")
+
+    def test_malformed_expr_logs_article_title_and_id_when_given(self):
+        # The Python-level SyntaxWarning above says only "<unknown>:1"
+        # -- useless for finding which real, on-wiki #expr call is
+        # actually malformed. page_title/page_id, when supplied (as
+        # expandTemplate() does for every real call), make a failure
+        # directly traceable back to the article instead.
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            result = ex.sharp_expr("3in5", page_title="Some Article", page_id="123")
+        self.assertEqual(result, self.ERROR_SPAN)
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("3in5", logs.output[0])
+        self.assertIn("Some Article", logs.output[0])
+        self.assertIn("123", logs.output[0])
+
+    def test_malformed_expr_logs_without_article_detail_when_page_info_not_given(self):
+        # A direct caller not going through expandTemplate() -- the
+        # only kind that exists today -- still knows what expression
+        # it passed, but a log line is still useful independent of
+        # that: it's what shows up if the caller is watching logs
+        # rather than inspecting the return value directly, and costs
+        # nothing extra to include.
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            result = ex.sharp_expr("3in5")
+        self.assertEqual(result, self.ERROR_SPAN)
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("3in5", logs.output[0])
+        self.assertNotIn("article", logs.output[0])
+
+    def test_valid_expr_logs_nothing_even_with_page_info(self):
+        with self.assertRaises(AssertionError):
+            with self.assertLogs('wikiextractor.extract', level='WARNING'):
+                ex.sharp_expr("2 + 3", page_title="Some Article", page_id="123")
 
     def test_string_literal_is_rejected_not_evaluated(self):
         # #expr's own real grammar has no string type at all -- a
@@ -139,6 +188,176 @@ class SharpExprLegitimateUseTests(unittest.TestCase):
 
     def test_round(self):
         self.assertEqual(ex.sharp_expr("3.14159 round 2"), "3.14")
+
+
+class SharpExprRepeatedFailureDedupTests(unittest.TestCase):
+    """The same malformed #expr call is frequently invoked many times
+    within a single article (e.g. once per row of a table built from
+    a broken shared template) -- one genuine occurrence could
+    otherwise produce hundreds of identical log lines. Same dedup
+    shape as expandTemplate()'s own template-loop detection: count
+    every occurrence, but only log the first one per (article,
+    expression) pair -- see test_template_loop_guard.py's
+    test_warning_logged_once_despite_many_repeats for the template
+    side of the same pattern.
+    """
+
+    ERROR_SPAN = '<span class="error"></span>'
+
+    def make_extractor(self):
+        return ex.Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
+                             "Test Article", [])
+
+    def test_direct_calls_only_log_the_first_occurrence(self):
+        extractor = self.make_extractor()
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            for _ in range(5):
+                result = ex.sharp_expr("3in5", page_title="Test Article", page_id="1",
+                                        extractor=extractor)
+                self.assertEqual(result, self.ERROR_SPAN)
+        self.assertEqual(len(logs.output), 1)
+        self.assertEqual(extractor.malformed_expr_errs, 5)
+
+    def test_different_malformed_expressions_each_log_once(self):
+        # Dedup is per-expression, not a blanket "one #expr warning
+        # per article" -- a second, genuinely different malformed
+        # expression is still worth knowing about.
+        extractor = self.make_extractor()
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            ex.sharp_expr("3in5", page_title="Test Article", page_id="1", extractor=extractor)
+            ex.sharp_expr("3in5", page_title="Test Article", page_id="1", extractor=extractor)
+            ex.sharp_expr("4in6", page_title="Test Article", page_id="1", extractor=extractor)
+        self.assertEqual(len(logs.output), 2)
+        self.assertEqual(extractor.malformed_expr_errs, 3)
+
+    def test_same_expression_in_a_different_article_logs_again(self):
+        # Dedup keys on (article id, expression) together -- a fresh
+        # Extractor (a new article) must not inherit suppression from
+        # a previous one.
+        first_extractor = self.make_extractor()
+        second_extractor = ex.Extractor(2, "2", "https://test.wikipedia.org/wiki?curid=2",
+                                         "Second Article", [])
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            ex.sharp_expr("3in5", page_title="Test Article", page_id="1", extractor=first_extractor)
+            ex.sharp_expr("3in5", page_title="Second Article", page_id="2", extractor=second_extractor)
+        self.assertEqual(len(logs.output), 2)
+
+    def test_real_end_to_end_pipeline_dedups_across_many_template_invocations(self):
+        # Not just sharp_expr() in isolation -- confirms the real
+        # chain (clean_text() -> expandTemplate() ->
+        # callParserFunction() -> sharp_expr()) actually threads the
+        # same Extractor through on every call, the way a real,
+        # multiply-transcluded broken template would in practice.
+        templates = {
+            'Template:BadExpr': '{{#expr: 3in5 }}',
+        }
+        redirects = {}
+        article_text = '\n'.join(['{{BadExpr}}'] * 5)
+        extractor = ex.Extractor(1, "1", "https://test.wikipedia.org/wiki?curid=1",
+                                  "Test Article", [article_text], templates=templates,
+                                  redirects=redirects, templatePrefix='Template:')
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            extractor.clean_text(article_text, expand_templates=True)
+        expr_warnings = [line for line in logs.output if 'Malformed #expr' in line]
+        self.assertEqual(len(expr_warnings), 1)
+        self.assertEqual(extractor.malformed_expr_errs, 5)
+
+
+class SharpExprCascadeSuppressionTests(unittest.TestCase):
+    """A second, distinct source of noise the (article, expression)
+    dedup above can't catch on its own: nested #expr calls where an
+    inner failure's own error-span output gets substituted as literal
+    text into the enclosing #expr's input, which then also fails --
+    producing a genuinely different, unique expr string at every
+    level, so exact-string dedup correctly does NOT collapse them.
+    Confirmed directly against a real, reported case: a chain of a
+    dozen distinct expr strings, each differing only by an appended
+    "+N"/"-N", every one already containing a prior error span before
+    it even started.
+    """
+
+    def make_extractor(self, page_id=1):
+        return ex.Extractor(page_id, str(page_id), f"https://test.wikipedia.org/wiki?curid={page_id}",
+                             "Test Article", [])
+
+    def test_chain_of_distinct_cascade_expressions_logs_only_once(self):
+        # The exact real-world shape reported: each expression is
+        # textually unique (so the plain dedup key alone wouldn't
+        # catch it), but each one already embeds the previous
+        # failure's error span.
+        extractor = self.make_extractor()
+        cascade_exprs = [
+            '- ' + ex._SHARP_EXPR_ERROR_SPAN,
+            ex._SHARP_EXPR_ERROR_SPAN + ' + 1',
+            ex._SHARP_EXPR_ERROR_SPAN + ' + 2',
+            ex._SHARP_EXPR_ERROR_SPAN + ' + 3',
+        ]
+        self.assertEqual(len(set(cascade_exprs)), len(cascade_exprs),
+                          "test setup sanity check: every cascade expression must be distinct, "
+                          "or this test wouldn't be distinguishing cascade suppression from the "
+                          "ordinary exact-match dedup tested elsewhere")
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            for e in cascade_exprs:
+                ex.sharp_expr(e, page_title="Test Article", page_id="1", extractor=extractor)
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("chain of nested #expr calls", logs.output[0])
+        self.assertEqual(extractor.malformed_expr_errs, 4)
+
+    def test_root_failure_before_a_cascade_still_logs_its_own_warning(self):
+        # The first, standalone failure that actually starts a chain
+        # doesn't itself contain an error span -- it's the genuinely
+        # useful, actionable one, and must not be swallowed by cascade
+        # suppression (which only applies to the *downstream* links).
+        extractor = self.make_extractor()
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            ex.sharp_expr("3in5", page_title="Test Article", page_id="1", extractor=extractor)
+            ex.sharp_expr(ex._SHARP_EXPR_ERROR_SPAN + " + 1", page_title="Test Article",
+                          page_id="1", extractor=extractor)
+        self.assertEqual(len(logs.output), 2)
+        self.assertNotIn("chain of nested", logs.output[0])
+        self.assertIn("chain of nested", logs.output[1])
+
+    def test_unrelated_non_cascade_failure_in_same_article_still_logs_separately(self):
+        # Cascade suppression must not become a blanket "one #expr
+        # warning per article" -- a completely unrelated, standalone
+        # malformed expression elsewhere in the same article is still
+        # worth its own warning.
+        extractor = self.make_extractor()
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            ex.sharp_expr(ex._SHARP_EXPR_ERROR_SPAN + " + 1", page_title="Test Article",
+                          page_id="1", extractor=extractor)
+            ex.sharp_expr("4in6", page_title="Test Article", page_id="1", extractor=extractor)
+        self.assertEqual(len(logs.output), 2)
+
+    def test_cascade_in_a_different_article_logs_again(self):
+        # Same (article, cascade) keying discipline as the plain
+        # dedup case -- a fresh Extractor (a new article) must not
+        # inherit cascade suppression from a previous one.
+        first_extractor = self.make_extractor(page_id=1)
+        second_extractor = self.make_extractor(page_id=2)
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            ex.sharp_expr(ex._SHARP_EXPR_ERROR_SPAN + " + 1", page_title="Test Article",
+                          page_id="1", extractor=first_extractor)
+            ex.sharp_expr(ex._SHARP_EXPR_ERROR_SPAN + " + 1", page_title="Test Article",
+                          page_id="2", extractor=second_extractor)
+        self.assertEqual(len(logs.output), 2)
+
+    def test_real_end_to_end_pipeline_suppresses_a_genuine_nested_expr_cascade(self):
+        # Not just sharp_expr() in isolation -- a real, nested #expr
+        # call (the actual on-wiki shape that produces this pattern)
+        # run through the full clean_text() pipeline.
+        extractor = self.make_extractor()
+        wikitext = "{{#expr: {{#expr: {{#expr: 3in5 }} + 1 }} + 2 }}"
+        with self.assertLogs('wikiextractor.extract', level='WARNING') as logs:
+            extractor.clean_text(wikitext, expand_templates=True)
+        expr_warnings = [line for line in logs.output if 'Malformed #expr' in line]
+        # The innermost failure (3in5) is the root, standalone one;
+        # the two outer levels each fail on the inner one's error-span
+        # output and get suppressed as cascade continuations.
+        self.assertEqual(len(expr_warnings), 2)
+        self.assertNotIn("chain of nested", expr_warnings[0])
+        self.assertIn("chain of nested", expr_warnings[1])
+        self.assertEqual(extractor.malformed_expr_errs, 3)
 
 
 if __name__ == '__main__':

--- a/tests/test_sharp_expr_security.py
+++ b/tests/test_sharp_expr_security.py
@@ -182,6 +182,25 @@ class SharpExprLegitimateUseTests(unittest.TestCase):
         self.assertEqual(ex.sharp_expr("10 mod 3"), "1")
         self.assertEqual(ex.sharp_expr("10 div 4"), "2.5")
 
+    def test_mod_keyword_has_a_word_boundary_like_div_and_round_already_did(self):
+        # "mod" used to be substituted without \b (unlike div/round,
+        # which already had it): "1 mod2" (no space before the second
+        # operand) would have silently matched anyway -- 'd' and '2'
+        # are both word characters, so even \b wouldn't treat that as
+        # a real boundary -- producing "1 %2", which Python happily
+        # evaluates to 1. That's a real, silently wrong answer for
+        # input that was never actually valid #expr mod syntax at all.
+        # Confirmed this now correctly fails to parse instead.
+        result = ex.sharp_expr("1 mod2")
+        self.assertNotEqual(result, "1")
+        self.assertEqual(result, '<span class="error"></span>')
+
+    def test_mod_as_a_substring_of_another_word_is_left_alone(self):
+        # Same underlying fix, the more common real-world shape: a
+        # word that merely contains "mod" (leaked-through wikitext, a
+        # stray word) must not get mangled mid-word.
+        self.assertEqual(ex.sharp_expr("commodity 5"), ex.sharp_expr("xyz 5"))
+
     def test_equality_and_comparison(self):
         self.assertEqual(ex.sharp_expr("5 = 5"), "1")
         self.assertEqual(ex.sharp_expr("3 < 5 and 5 < 10"), "1")

--- a/tests/test_string_functions.py
+++ b/tests/test_string_functions.py
@@ -1,0 +1,152 @@
+"""
+Tests for the "String functions" extension family: len, pos, rpos,
+sub, count, replace, explode. All '#'-prefixed, matching real
+MediaWiki's own syntax for this extension -- unlike the core case/url
+magic words (lc, uc, padleft, padright, urlencode, urldecode), which
+aren't prefixed.
+
+Several of these have real, documented semantics that a naive
+implementation would get wrong:
+  - #sub matches PHP's substr() precisely, including negative START
+    (count from the end) and negative LENGTH (stop that many
+    characters before the end of the *whole string*, not relative to
+    START) -- not a plain Python slice translation.
+  - #pos returns an empty string when the target isn't found; #rpos
+    returns -1. This asymmetry is real and documented in the
+    extension itself, not a bug to reconcile between the two.
+  - #count, #replace (empty search), and #explode (empty delimiter)
+    all diverge from what Python's own string methods would naively
+    do with an empty argument, since Python's semantics there aren't
+    the same as PHP's (what real MediaWiki is built on).
+
+Run with:
+    python -m unittest tests.test_string_functions -v
+or, from the tests/ directory:
+    python -m unittest test_string_functions -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+
+
+class LenTests(unittest.TestCase):
+
+    def test_basic_length(self):
+        self.assertEqual(ex.sharp_len('hello'), '5')
+
+    def test_empty_string(self):
+        self.assertEqual(ex.sharp_len(''), '0')
+
+
+class PosTests(unittest.TestCase):
+
+    def test_found_returns_zero_based_index(self):
+        self.assertEqual(ex.sharp_pos('hello world', 'world'), '6')
+
+    def test_not_found_returns_empty_string_not_negative_one(self):
+        self.assertEqual(ex.sharp_pos('hello', 'xyz'), '')
+
+    def test_offset_skips_earlier_occurrences(self):
+        self.assertEqual(ex.sharp_pos('abcabc', 'abc', '1'), '3')
+
+
+class RposTests(unittest.TestCase):
+
+    def test_found_returns_index_of_last_occurrence(self):
+        self.assertEqual(ex.sharp_rpos('hello hello', 'hello'), '6')
+
+    def test_not_found_returns_negative_one_not_empty(self):
+        # Deliberately asymmetric with #pos above -- this is the real,
+        # documented behavior of the actual extension.
+        self.assertEqual(ex.sharp_rpos('hello', 'xyz'), '-1')
+
+
+class SubTests(unittest.TestCase):
+
+    def test_positive_start_and_length(self):
+        self.assertEqual(ex.sharp_sub('Hello world', '0', '5'), 'Hello')
+
+    def test_negative_start_counts_from_end(self):
+        self.assertEqual(ex.sharp_sub('Hello world', '-5'), 'world')
+
+    def test_length_omitted_goes_to_end(self):
+        self.assertEqual(ex.sharp_sub('Hello world', '6'), 'world')
+
+    def test_negative_length_stops_before_whole_strings_own_end(self):
+        # The case a naive s[start:start+length] translation gets
+        # wrong: PHP substr("Hello world", 6, -2) is "wor" (stop 2
+        # short of the *whole string's* end), not computed relative
+        # to start (which would give a nonsensical empty slice).
+        self.assertEqual(ex.sharp_sub('Hello world', '6', '-2'), 'wor')
+
+    def test_negative_length_matches_php_semantics_from_start_zero(self):
+        self.assertEqual(ex.sharp_sub('Hello world', '0', '-6'), 'Hello')
+
+
+class CountTests(unittest.TestCase):
+
+    def test_counts_non_overlapping_occurrences(self):
+        self.assertEqual(ex.sharp_count('abcabcabc', 'abc'), '3')
+
+    def test_empty_substring_returns_zero_not_pythons_own_count_quirk(self):
+        # Python's own "abc".count('') == 4 (a match between every
+        # character) isn't a meaningful answer for this function.
+        self.assertEqual(ex.sharp_count('abc', ''), '0')
+
+
+class ReplaceTests(unittest.TestCase):
+
+    def test_basic_replace(self):
+        self.assertEqual(ex.sharp_replace('hello world', 'world', 'there'), 'hello there')
+
+    def test_empty_search_is_a_no_op(self):
+        # PHP's str_replace() with an empty search matches nothing;
+        # Python's own str.replace('', x) inserts x between every
+        # character, which is not the semantics to reproduce here.
+        self.assertEqual(ex.sharp_replace('hello', ''), 'hello')
+
+    def test_limit_caps_the_number_of_replacements(self):
+        self.assertEqual(ex.sharp_replace('a-a-a-a', '-', '_', '2'), 'a_a_a-a')
+
+
+class ExplodeTests(unittest.TestCase):
+
+    def test_returns_the_segment_at_position(self):
+        self.assertEqual(ex.sharp_explode('a-b-c', '-', '1'), 'b')
+
+    def test_negative_position_counts_from_the_end(self):
+        self.assertEqual(ex.sharp_explode('a-b-c', '-', '-1'), 'c')
+
+    def test_position_out_of_range_returns_empty(self):
+        self.assertEqual(ex.sharp_explode('a-b-c', '-', '5'), '')
+
+    def test_empty_delimiter_returns_empty_rather_than_raising(self):
+        self.assertEqual(ex.sharp_explode('abc', ''), '')
+
+    def test_limit_caps_segment_count_last_segment_absorbs_the_rest(self):
+        self.assertEqual(ex.sharp_explode('a-b-c-d', '-', '2', '3'), 'c-d')
+
+
+class StringFunctionsRealEndToEndTests(unittest.TestCase):
+    """Not the functions in isolation -- the real chain
+    (clean_text() -> expandTemplate() -> callParserFunction()),
+    matching a real, plausible on-wiki shape: extracting a file
+    extension from a filename inside a template.
+    """
+
+    def test_real_pipeline_extracts_a_file_extension(self):
+        templates = {
+            'Template:Extension': '{{#sub:{{{1}}}|{{#pos:{{{1}}}|.}}}}',
+        }
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [], templates=templates,
+                                  templatePrefix='Template:')
+        result = extractor.clean_text('{{Extension|photo.jpg}}', expand_templates=True)
+        self.assertIn('.jpg', '\n'.join(result))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_template_loop_guard.py
+++ b/tests/test_template_loop_guard.py
@@ -205,7 +205,7 @@ class WarningLogDeduplicationTests(TemplateLoopGuardTestCase):
         root_logger = logging.getLogger()
         original_level = root_logger.level
         root_logger.addHandler(handler)
-        root_logger.setLevel(logging.WARNING)
+        root_logger.setLevel(logging.DEBUG)
         try:
             extractor.clean_text(article_text, expand_templates=True)
         finally:

--- a/tests/test_template_loop_guard.py
+++ b/tests/test_template_loop_guard.py
@@ -237,7 +237,14 @@ class ErrorSummaryReportingTests(TemplateLoopGuardTestCase):
         root_logger = logging.getLogger()
         original_level = root_logger.level
         root_logger.addHandler(handler)
-        root_logger.setLevel(logging.WARNING)
+        # DEBUG, not WARNING: the per-article summary moved to DEBUG
+        # -- see extract()'s own comment for why (a common broken
+        # shared template can flag a large fraction of all articles on
+        # a real run, and one WARNING line per article at that scale
+        # drowns out everything else). extract_process() now logs a
+        # WARNING-level aggregate per worker instead; that's covered
+        # separately in test_extract_process_worker_summary.py.
+        root_logger.setLevel(logging.DEBUG)
         try:
             out = StringIO()
             extractor.extract(out, html_safe=True)

--- a/tests/test_template_loop_guard.py
+++ b/tests/test_template_loop_guard.py
@@ -35,6 +35,7 @@ or, from the tests/ directory:
     python -m unittest test_template_loop_guard -v
 """
 
+import contextlib
 import logging
 import sys
 import time
@@ -71,6 +72,32 @@ class TemplateLoopGuardTestCase(unittest.TestCase):
                           f"https://test.wikipedia.org/wiki?curid={article_id}",
                           title, [article_text], templates=self.templates, redirects=self.redirects,
                           templatePrefix=self.templatePrefix)
+
+    @contextlib.contextmanager
+    def capture_extract_logger(self, level):
+        """Captures messages from extract.py's own 'wikiextractor.extract'
+        logger specifically -- not the root logger, which
+        wikiextractor's own logging no longer touches at all (see
+        configure_wikiextractor_logging() in WikiExtractor.py). Tests
+        here call Extractor methods directly rather than going through
+        extract_process(), so capturing from 'wikiextractor.extract'
+        itself is also more robust than relying on propagation through
+        'wikiextractor' -- whether that happens depends on whether
+        some other test in the same process has already called
+        configure_wikiextractor_logging(), which sets propagate=False
+        on it.
+        """
+        log_stream = StringIO()
+        handler = logging.StreamHandler(log_stream)
+        extract_logger = logging.getLogger('wikiextractor.extract')
+        original_level = extract_logger.level
+        extract_logger.addHandler(handler)
+        extract_logger.setLevel(level)
+        try:
+            yield log_stream
+        finally:
+            extract_logger.removeHandler(handler)
+            extract_logger.setLevel(original_level)
 
 
 class LegitimateSelfRecursionTests(TemplateLoopGuardTestCase):
@@ -200,17 +227,8 @@ class WarningLogDeduplicationTests(TemplateLoopGuardTestCase):
         article_text = "{{Redirect-multi|2|X|Y}}"
         extractor = self.make_extractor(article_text)
 
-        log_stream = StringIO()
-        handler = logging.StreamHandler(log_stream)
-        root_logger = logging.getLogger()
-        original_level = root_logger.level
-        root_logger.addHandler(handler)
-        root_logger.setLevel(logging.DEBUG)
-        try:
+        with self.capture_extract_logger(logging.DEBUG) as log_stream:
             extractor.clean_text(article_text, expand_templates=True)
-        finally:
-            root_logger.removeHandler(handler)
-            root_logger.setLevel(original_level)
 
         log_output = log_stream.getvalue()
         occurrences = log_output.count("Template loop detected")
@@ -232,25 +250,14 @@ class ErrorSummaryReportingTests(TemplateLoopGuardTestCase):
         article_text = "{{Self|x}}"
         extractor = self.make_extractor(article_text)
 
-        log_stream = StringIO()
-        handler = logging.StreamHandler(log_stream)
-        root_logger = logging.getLogger()
-        original_level = root_logger.level
-        root_logger.addHandler(handler)
-        # DEBUG, not WARNING: the per-article summary moved to DEBUG
-        # -- see extract()'s own comment for why (a common broken
-        # shared template can flag a large fraction of all articles on
-        # a real run, and one WARNING line per article at that scale
-        # drowns out everything else). extract_process() now logs a
-        # WARNING-level aggregate per worker instead; that's covered
-        # separately in test_extract_process_worker_summary.py.
-        root_logger.setLevel(logging.DEBUG)
-        try:
+        # DETAIL, not WARNING: the per-article summary lives at the
+        # DETAIL level (between INFO and DEBUG -- see extract.py's own
+        # DETAIL definition and comment for why). extract_process()
+        # separately logs a WARNING-level aggregate per worker; that's
+        # covered in test_extract_process_worker_summary.py.
+        with self.capture_extract_logger(ex.DETAIL) as log_stream:
             out = StringIO()
             extractor.extract(out, html_safe=True)
-        finally:
-            root_logger.removeHandler(handler)
-            root_logger.setLevel(original_level)
 
         log_output = log_stream.getvalue()
         self.assertIn("loop(", log_output,
@@ -261,18 +268,9 @@ class ErrorSummaryReportingTests(TemplateLoopGuardTestCase):
         article_text = "{{Plain}}"
         extractor = self.make_extractor(article_text)
 
-        log_stream = StringIO()
-        handler = logging.StreamHandler(log_stream)
-        root_logger = logging.getLogger()
-        original_level = root_logger.level
-        root_logger.addHandler(handler)
-        root_logger.setLevel(logging.WARNING)
-        try:
+        with self.capture_extract_logger(logging.WARNING) as log_stream:
             out = StringIO()
             extractor.extract(out, html_safe=True)
-        finally:
-            root_logger.removeHandler(handler)
-            root_logger.setLevel(original_level)
 
         self.assertEqual(log_stream.getvalue(), "",
                           "a clean article with no template errors should "

--- a/tests/test_urlencode_urldecode.py
+++ b/tests/test_urlencode_urldecode.py
@@ -1,0 +1,96 @@
+"""
+Tests for urlencode/urldecode -- note no '#' prefix, matching real
+MediaWiki's own syntax for these (part of the "string functions"
+extension, like formatnum, lc, uc, padleft/padright -- not the
+'#'-prefixed ParserFunctions-family branching functions).
+
+urlencode already existed (a direct alias for urllib.parse.quote) but
+had no dedicated test coverage anywhere in this suite -- confirmed via
+a direct search before writing these. urldecode is new, added as the
+matching inverse (urllib.parse.unquote), deliberately chosen to stay
+consistent with whatever urlencode actually does today: both are
+built on Python's plain quote()/unquote() pair (%20 for spaces), not
+quote_plus()/unquote_plus() (+ for spaces) -- so a round trip through
+both is correct even though this doesn't implement MediaWiki's
+optional second "type" parameter (QUERY/PATH/WIKI) that would select
+between those conventions; neither function accepts it today, and
+both silently discard it via their own *rest catch-all in the
+parserFunctions dict if a real template happens to pass one.
+
+Both are plain aliases (from urllib.parse import quote as urlencode /
+unquote as urldecode), not separately-named wrapper functions like
+sharp_padleft/sharp_formatnum -- so they're tested directly as
+ex.urlencode()/ex.urldecode() below, and separately through the real
+parser-function dispatch path via clean_text() in the end-to-end test.
+
+Run with:
+    python -m unittest tests.test_urlencode_urldecode -v
+or, from the tests/ directory:
+    python -m unittest test_urlencode_urldecode -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+
+
+class UrlencodeTests(unittest.TestCase):
+
+    def test_spaces_become_percent_20(self):
+        self.assertEqual(ex.urlencode('hello world'), 'hello%20world')
+
+    def test_reserved_characters_are_encoded(self):
+        self.assertEqual(ex.urlencode('a=b&c?d'), 'a%3Db%26c%3Fd')
+
+    def test_non_ascii_text_is_encoded(self):
+        # Matches the actual kind of data this codebase processes --
+        # Urdu script, not just English test strings.
+        encoded = ex.urlencode('سائی را')
+        self.assertNotIn('سائی', encoded)
+        self.assertTrue(encoded.startswith('%'))
+
+
+class UrldecodeTests(unittest.TestCase):
+
+    def test_percent_20_becomes_space(self):
+        self.assertEqual(ex.urldecode('hello%20world'), 'hello world')
+
+    def test_reserved_characters_are_decoded(self):
+        self.assertEqual(ex.urldecode('a%3Db%26c%3Fd'), 'a=b&c?d')
+
+
+class UrlencodeUrldecodeRoundTripTests(unittest.TestCase):
+    """The property that actually matters most in practice: encoding
+    then decoding returns the original text exactly, for the kind of
+    content this codebase really processes (non-ASCII script, and
+    reserved URL characters together in the same string).
+    """
+
+    def test_round_trip_ascii_with_reserved_characters(self):
+        original = 'a=b&c?d e'
+        self.assertEqual(ex.urldecode(ex.urlencode(original)), original)
+
+    def test_round_trip_non_ascii_text(self):
+        original = 'سائی را نرسمہا ریڈی & foo=bar'
+        self.assertEqual(ex.urldecode(ex.urlencode(original)), original)
+
+    def test_real_pipeline_round_trip_through_nested_template_calls(self):
+        # Not the functions in isolation -- the real chain
+        # (clean_text() -> expandTemplate() -> callParserFunction()),
+        # confirming both are actually reachable and correctly nested
+        # via real wikitext syntax, not just callable directly.
+        # Avoids '&' here specifically: clean_text()'s own output is
+        # HTML-escaped (a separate, correct, already-covered concern
+        # elsewhere), which would turn a literal '&' into '&amp;' and
+        # have nothing to do with url encode/decode round-tripping.
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [])
+        wikitext = '{{urldecode:{{urlencode:سائی را نرسمہا ریڈی ? foo=bar}}}}'
+        result = extractor.clean_text(wikitext, expand_templates=True)
+        self.assertIn('سائی را نرسمہا ریڈی ? foo=bar', '\n'.join(result))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -80,21 +80,30 @@ from . import template_blob
 # Program version
 __version__ = '3.0.8'
 
-# Separate from extract.py's own 'wikiextractor.extract' logger (which
-# covers the extraction mechanics themselves -- template substitution,
-# link processing, etc., under --debug): this one covers map/reduce
-# coordination -- per-page timing, queue dispatch, reducer progress,
-# and worker/reducer liveness -- under --debug_map_reduce. Named and
-# configured independently so either can be enabled without the other.
+# This module's own logger -- everything logged directly from
+# WikiExtractor.py (CLI progress, per-worker error summaries) goes
+# through this, never the root logger, so a programmatic caller can
+# configure/silence/redirect wikiextractor's own output independently
+# of anything else running in the same process.
+wikiextractor_logger = logging.getLogger('wikiextractor')
+
+# Separate from wikiextractor_logger above and from extract.py's own
+# 'wikiextractor.extract' logger (which covers the extraction
+# mechanics themselves -- template substitution, link processing,
+# etc., under --debug): this one covers map/reduce coordination --
+# per-page timing, queue dispatch, reducer progress, and
+# worker/reducer liveness -- under --debug_map_reduce. Named and
+# configured independently so any of the three can be enabled without
+# the others.
 mapreduce_logger = logging.getLogger('wikiextractor.mapreduce')
 
 
 def configure_mapreduce_logging(enabled):
     """
     Sets mapreduce_logger's level and gives it its own handler/format
-    (including a timestamp, %(asctime)s -- the root logger's own
+    (including a timestamp, %(asctime)s -- wikiextractor_logger's own
     format has none) with propagate=False, so its messages go out
-    through this handler only, not duplicated via the root logger's.
+    through this handler only, never duplicated via wikiextractor_logger's.
 
     Must be called at the start of extract_process() and
     reduce_process() specifically, not just once in the parent: both
@@ -115,18 +124,36 @@ def configure_mapreduce_logging(enabled):
     mapreduce_logger.propagate = False
 
 
-def configure_root_logging(log_level):
+def configure_wikiextractor_logging(log_level):
     """
-    Sets the root logger's own level and format -- same reasoning and
-    same required call sites as configure_mapreduce_logging() above
-    (start of extract_process() and reduce_process(), not just once in main()).
+    Sets wikiextractor_logger's own level and gives it its own
+    handler/format, with propagate=False -- same pattern as
+    configure_mapreduce_logging() above, and the same reasoning for
+    why: this keeps wikiextractor's own logging entirely off the root
+    logger, so nothing here touches process-wide logging state that a
+    programmatic caller (embedding this as a library rather than
+    running it as a CLI script) might have configured for their own,
+    unrelated purposes. extract.py's own 'wikiextractor.extract'
+    logger is a child of this one by name and has no explicit level
+    or handler of its own, so its messages simply propagate up to and
+    render through this handler -- inheriting this level by default,
+    while still independently overridable by a caller who wants
+    different verbosity for just the extraction-mechanics messages
+    (logging.getLogger('wikiextractor.extract').setLevel(...)).
 
-    On a spawn, main()'s own logging.basicConfig()/logger.setLevel() calls
-    never ran in that process at all, so this call sets up the logging
-    for the children processes.
+    Must be called at the start of extract_process() and
+    reduce_process() specifically, not just once in main(): both are
+    real multiprocessing.Process instances, and under the "spawn"
+    start method (unlike "fork"), a child re-imports the module fresh
+    and does NOT inherit a level set on the parent's already-running
+    logger after import.
     """
-    logging.basicConfig(format='%(levelname)s: %(message)s')
-    logging.getLogger().setLevel(log_level)
+    wikiextractor_logger.setLevel(log_level)
+    if not wikiextractor_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+        wikiextractor_logger.addHandler(handler)
+    wikiextractor_logger.propagate = False
 
 ##
 # The namespace used for template definitions
@@ -360,10 +387,10 @@ def load_templates(file, output_file=None, encoding='utf-8', templates=None, red
             page = []
             articles += 1
             if articles % 100000 == 0:
-                logging.info("Preprocessed %d pages", articles)
+                wikiextractor_logger.info("Preprocessed %d pages", articles)
     if output_file:
         output.close()
-        logging.info("Saved %d templates to '%s'", template_count, output_file)
+        wikiextractor_logger.info("Saved %d templates to '%s'", template_count, output_file)
     return template_count, template_prefix
 
 
@@ -571,7 +598,7 @@ def load_and_compact_templates(template_file, input_file, input, template_prefix
     redirects_builder = template_blob.StreamingTemplateBlobBuilder()
     template_load_start = default_timer()
     if template_file and os.path.exists(template_file):
-        logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", template_file)
+        wikiextractor_logger.info("Preprocessing '%s' to collect template definitions: this may take some time.", template_file)
         file = decode_open(template_file)
         template_count, template_prefix = load_templates(
             file, blob_builder=builder, redirects_blob_builder=redirects_builder,
@@ -581,13 +608,13 @@ def load_and_compact_templates(template_file, input_file, input, template_prefix
         if input_file == '-':
             # can't scan then reset stdin; must error w/ suggestion to specify template_file
             raise ValueError("to use templates with stdin dump, must supply explicit template-file")
-        logging.info("Preprocessing '%s' to collect template definitions: this may take some time.", input_file)
+        wikiextractor_logger.info("Preprocessing '%s' to collect template definitions: this may take some time.", input_file)
         template_count, template_prefix = load_templates(
             input, template_file, blob_builder=builder, redirects_blob_builder=redirects_builder,
             template_prefix=template_prefix)
         input.close()
         input = decode_open(input_file)
-    logging.info("Loaded %d templates in %.1fs", template_count, default_timer() - template_load_start)
+    wikiextractor_logger.info("Loaded %d templates in %.1fs", template_count, default_timer() - template_load_start)
 
     # See template_blob.py's own module docstring for why compaction
     # itself is necessary (fork()'s copy-on-write doesn't protect a
@@ -600,7 +627,7 @@ def load_and_compact_templates(template_file, input_file, input, template_prefix
     compact_start = default_timer()
     template_blob_ctx = template_blob.compact_blobs(*builder.finish())
     redirects_blob_ctx = template_blob.compact_blobs(*redirects_builder.finish())
-    logging.info("Compacted templates and redirects into shared memory in %.1fs",
+    wikiextractor_logger.info("Compacted templates and redirects into shared memory in %.1fs",
                  default_timer() - compact_start)
     return template_blob_ctx, redirects_blob_ctx, input, template_prefix
 
@@ -630,11 +657,14 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
         every worker and every Extractor(...) constructed anywhere in
         this run -- no piece of it is a shared global read implicitly
         by anything.
-    :param log_level: the root logger's own level, as set up in
-        main() -- passed through to reduce_process()/extract_process()
-        so each can reapply it via configure_root_logging(), since
-        main()'s own logging.basicConfig()/logger.setLevel() calls
-        never run in a process started via "spawn" at all.
+    :param log_level: wikiextractor_logger's own level, as set up in
+        main() by calling configure_wikiextractor_logging() (not the
+        root logger, so this stays independent of any logging setup
+        a programmatic caller has done for their own purposes) --
+        passed through to reduce_process()/extract_process() so each
+        can call that same function again itself, since a process
+        started via "spawn" re-imports the module fresh and does not
+        inherit a level set on the parent's already-running logger.
     """
     extractor_kwargs = dict(extractor_kwargs) if extractor_kwargs else {}
 
@@ -686,7 +716,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
     with template_blob_ctx as (_wrapper, template_blob_names), \
             redirects_blob_ctx as (_redirects_wrapper, redirects_blob_names):
         # process pages
-        logging.info("Starting page extraction from %s.", input_file)
+        wikiextractor_logger.info("Starting page extraction from %s.", input_file)
         extract_start = default_timer()
 
         # Parallel Map/Reduce:
@@ -765,7 +795,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
         jobs_queue = mp_context.Queue(maxsize=maxsize)
 
         # start worker processes
-        logging.info("Using %d extract processes.", process_count)
+        wikiextractor_logger.info("Using %d extract processes.", process_count)
         workers = []
         for _ in range(max(1, process_count)):
             extractor = Process(target=extract_process,
@@ -831,7 +861,7 @@ def process_dump(input_file, template_file, out_file, file_size, file_compress,
 
     extract_duration = default_timer() - extract_start
     extract_rate = ordinal / extract_duration
-    logging.info("Finished %d-process extraction of %d articles in %.1fs (%.1f art/s)",
+    wikiextractor_logger.info("Finished %d-process extraction of %d articles in %.1fs (%.1f art/s)",
                  process_count, ordinal, extract_duration, extract_rate)
 
 
@@ -887,15 +917,18 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
         these used to be a module- or class-level global a worker
         picked up implicitly (several genuinely broken that way -- see
         Extractor's own docstring), now plain, explicit arguments.
-    :param log_level: this process's own root logger level (see
-        configure_root_logging()) -- without this, template/#expr
-        warnings still show (they're already at WARNING, Python's own
-        default), but this worker's part of any INFO-level diagnostics
-        would silently be lost under "spawn", same underlying cause as
+    :param log_level: this process's own wikiextractor_logger level
+        (see configure_wikiextractor_logging()) -- without this, the
+        worker-summary WARNING line below would still show (Python's
+        own root logger defaults to an effective level of WARNING,
+        with a built-in "handler of last resort" for exactly this
+        case), but this worker's part of any INFO-level progress or
+        DETAIL-level per-article diagnostics would silently be lost
+        under "spawn", same underlying cause as
         debug_map_reduce/mapreduce_logger above.
     """
     extractor_kwargs = extractor_kwargs or {}
-    configure_root_logging(log_level)
+    configure_wikiextractor_logging(log_level)
     configure_mapreduce_logging(debug_map_reduce)
     worker_ctx = (template_blob.attach(template_blob_names) if template_blob_names is not None
                   else contextlib.nullcontext(None))
@@ -951,7 +984,7 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
             else:
                 break
     if articles_with_errors:
-        logging.warning(
+        wikiextractor_logger.warning(
             "Worker pid=%d finished: %d/%d articles had template errors -- "
             "title(%d) recursion(%d, %d, %d) loop(%d) expr(%d) total "
             "occurrences across this worker's articles (per-article detail "
@@ -979,9 +1012,9 @@ def reduce_process(output_queue, out_file, file_size, file_compress, next_ordina
         enabled, logs REDUCER_PROGRESS for every page written (ordinal,
         current buffer depth) -- shares the same logger as the workers'
         PAGE_START/PAGE_TIMING logging.
-    :param log_level: this process's own root logger level (see
-        configure_root_logging()) -- without this, every ordinary
-        logging.info()/logging.warning() call below (progress lines,
+    :param log_level: this process's own wikiextractor_logger level
+        (see configure_wikiextractor_logging()) -- without this, every
+        ordinary progress/status message below (progress lines,
         REDUCER_EXIT status) silently stops appearing under "spawn",
         since main()'s own level-setting code never runs in this
         process at all.
@@ -1000,12 +1033,12 @@ def reduce_process(output_queue, out_file, file_size, file_compress, next_ordina
     On exit, always logs the status of the exit (except in the case
     of a SIGKILL)
     """
-    configure_root_logging(log_level)
+    configure_wikiextractor_logging(log_level)
     configure_mapreduce_logging(debug_map_reduce)
     if out_file == '-':
         output = sys.stdout
         if file_compress:
-            logging.warning("writing to stdout, so no output compression "
+            wikiextractor_logger.warning("writing to stdout, so no output compression "
                              "(use an external tool)")
     else:
         nextFile = NextFile(out_file)
@@ -1029,7 +1062,7 @@ def reduce_process(output_queue, out_file, file_size, file_compress, next_ordina
                 # progress report
                 if next_ordinal % period == 0:
                     interval_rate = period / (default_timer() - interval_start)
-                    logging.info("Extracted %d articles (%.1f art/s)",
+                    wikiextractor_logger.info("Extracted %d articles (%.1f art/s)",
                                  next_ordinal, interval_rate)
                     interval_start = default_timer()
             else:
@@ -1040,7 +1073,7 @@ def reduce_process(output_queue, out_file, file_size, file_compress, next_ordina
                 ordinal, text = pair
                 ordering_buffer[ordinal] = text
     finally:
-        # Always logged (on the root logger, not gated by
+        # Always logged (on wikiextractor_logger, not gated by
         # --debug_map_reduce at all): whether this
         # process is exiting cleanly (every buffered page successfully
         # written, nothing left over) or with pages still stuck in
@@ -1052,13 +1085,13 @@ def reduce_process(output_queue, out_file, file_size, file_compress, next_ordina
         # appears -- the absence of it, following the last
         # REDUCER_PROGRESS line, is itself the signal.
         if ordering_buffer:
-            logging.warning(
+            wikiextractor_logger.warning(
                 "REDUCER_EXIT incomplete: next_ordinal=%d, %d page(s) still "
                 "buffered and never written: ordinals=%s",
                 next_ordinal, len(ordering_buffer),
                 sorted(ordering_buffer.keys())[:20])
         else:
-            logging.info("REDUCER_EXIT clean: wrote %d article(s) total",
+            wikiextractor_logger.info("REDUCER_EXIT clean: wrote %d article(s) total",
                          next_ordinal)
         # This process's own writes are buffered in its own memory.
         # Since this process now opens its own output itself (rather
@@ -1149,6 +1182,15 @@ def main():
 
     args = parser.parse_args()
 
+    log_level = logging.WARNING  # Python's own default
+    if not args.quiet:
+        log_level = logging.INFO
+    if args.verbose:
+        log_level = DETAIL  # between INFO (20) and DEBUG (10) -- see DETAIL's own definition
+    if args.debug:
+        log_level = logging.DEBUG
+    configure_wikiextractor_logging(log_level)
+
     keepLinks = args.links
     if args.html:
         keepLinks = True
@@ -1176,28 +1218,15 @@ def main():
         if file_size and file_size < minFileSize:
             raise ValueError()
     except ValueError:
-        logging.error('Insufficient or invalid size: %s', args.bytes)
+        wikiextractor_logger.error('Insufficient or invalid size: %s', args.bytes)
         return
 
-    FORMAT = '%(levelname)s: %(message)s'
-    logging.basicConfig(format=FORMAT)
-
-    logger = logging.getLogger()
-    log_level = logging.WARNING  # Python's own default
-    if not args.quiet:
-        log_level = logging.INFO
-    if args.verbose:
-        log_level = DETAIL  # between INFO (20) and DEBUG (10) -- see DETAIL's own definition
-    if args.debug:
-        log_level = logging.DEBUG
-    logger.setLevel(log_level)
-
     if args.json:
-        logger.debug("Outputting to json format")
+        wikiextractor_logger.debug("Outputting to json format")
     elif args.text:
-        logger.debug("Outputting to text format")
+        wikiextractor_logger.debug("Outputting to text format")
     else:
-        logger.debug("Outputting to <doc> format")
+        wikiextractor_logger.debug("Outputting to <doc> format")
 
     input_file = args.input
 
@@ -1249,7 +1278,7 @@ def main():
         try:
             os.makedirs(output_path)
         except:
-            logging.error('Could not create: %s', output_path)
+            wikiextractor_logger.error('Could not create: %s', output_path)
             return
 
     configure_mapreduce_logging(args.debug_map_reduce)

--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -72,7 +72,7 @@ from multiprocessing import get_context, cpu_count
 from timeit import default_timer
 
 from .extract import Extractor, ignoreTag, define_template, \
-    resolve_template_page, _DEFAULT_IGNORED_TAG_PATTERNS
+    resolve_template_page, _DEFAULT_IGNORED_TAG_PATTERNS, DETAIL
 from . import template_blob
 
 # ===========================================================================
@@ -901,6 +901,24 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
                   else contextlib.nullcontext(None))
     redirects_ctx = (template_blob.attach(redirects_blob_names) if redirects_blob_names is not None
                       else contextlib.nullcontext(None))
+    # Aggregated across every article this worker processes, logged as
+    # a single summary line when the worker exits -- not per article.
+    # A real, full-wiki run can have a large fraction of all articles
+    # report *some* template/#expr issue (a single common, broken
+    # shared template reaches many pages), which turns "one WARNING
+    # line per problematic article" into hundreds of thousands of
+    # lines in practice -- individually still deduped and genuine, but
+    # collectively drowning out anything else in the log. The
+    # per-article detail (extract.py's own "Template errors in
+    # article..." line) still exists, at the DETAIL level (between
+    # INFO and DEBUG, see extract.py's own DETAIL definition) enabled
+    # via --verbose, for digging into which specific pages have
+    # issues without the much larger volume of low-level extraction-
+    # mechanics tracing --debug also includes. This worker-level total
+    # is what's actually useful for a first pass at gauging scope.
+    articles_processed = 0
+    articles_with_errors = 0
+    total_errs = [0, 0, 0, 0, 0, 0]  # title, recursion(1,2,3), loop, expr
     with worker_ctx as worker_templates, redirects_ctx as worker_redirects:
         while True:
             job = jobs_queue.get()  # job is (id, revid, urlbase, title, page, ordinal)
@@ -910,8 +928,9 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
                 mapreduce_logger.debug("PAGE_START pid=%d ordinal=%d id=%s title=%r",
                                        os.getpid(), ordinal, page_id, title)
                 out = StringIO()  # memory buffer
-                Extractor(*job[:-1], templates=worker_templates,
-                          redirects=worker_redirects, **extractor_kwargs).extract(out, html_safe)  # (id, urlbase, title, page)
+                extractor = Extractor(*job[:-1], templates=worker_templates,
+                                       redirects=worker_redirects, **extractor_kwargs)
+                extractor.extract(out, html_safe)  # (id, urlbase, title, page)
                 finish = time.time()
                 mapreduce_logger.debug(
                     "PAGE_TIMING pid=%d ordinal=%d id=%s title=%r elapsed=%.2fs",
@@ -919,8 +938,25 @@ def extract_process(jobs_queue, output_queue, html_safe, debug_map_reduce=False,
                 text = out.getvalue()
                 output_queue.put((job[-1], text))  # (ordinal, extracted_text)
                 out.close()
+                articles_processed += 1
+                errs = (extractor.template_title_errs,
+                        extractor.recursion_exceeded_1_errs,
+                        extractor.recursion_exceeded_2_errs,
+                        extractor.recursion_exceeded_3_errs,
+                        extractor.template_loop_errs,
+                        extractor.malformed_expr_errs)
+                if any(errs):
+                    articles_with_errors += 1
+                    total_errs = [t + e for t, e in zip(total_errs, errs)]
             else:
                 break
+    if articles_with_errors:
+        logging.warning(
+            "Worker pid=%d finished: %d/%d articles had template errors -- "
+            "title(%d) recursion(%d, %d, %d) loop(%d) expr(%d) total "
+            "occurrences across this worker's articles (per-article detail "
+            "available via --verbose)",
+            os.getpid(), articles_with_errors, articles_processed, *total_errs)
 
 
 def reduce_process(output_queue, out_file, file_size, file_compress, next_ordinal_shared, progress_condition,
@@ -1083,6 +1119,13 @@ def main():
     groupS = parser.add_argument_group('Special')
     groupS.add_argument("-q", "--quiet", action="store_true",
                         help="suppress reporting progress info")
+    groupS.add_argument("--verbose", action="store_true",
+                        help="in addition to normal progress info, report which "
+                             "specific articles had template/#expr errors and how "
+                             "many of each (title/recursion/loop/expr).  "
+                             "Look at the per-worker WARNING summary first "
+                             "(shown regardless of this flag) to gauge overall scope, "
+                             "then use --verbose to see which specific pages to target.")
     groupS.add_argument("--debug", action="store_true",
                         help="print debug info")
     groupS.add_argument("--debug_map_reduce", action="store_true",
@@ -1143,6 +1186,8 @@ def main():
     log_level = logging.WARNING  # Python's own default
     if not args.quiet:
         log_level = logging.INFO
+    if args.verbose:
+        log_level = DETAIL  # between INFO (20) and DEBUG (10) -- see DETAIL's own definition
     if args.debug:
         log_level = logging.DEBUG
     logger.setLevel(log_level)

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -23,6 +23,7 @@ import html
 import json
 import ast
 import operator
+import warnings
 from functools import lru_cache
 from itertools import zip_longest
 from urllib.parse import quote as urlencode
@@ -1521,6 +1522,8 @@ class Extractor():
         self.template_title_errs = 0
         self.template_loop_errs = 0  # same (title, params) reappearing in its own expansion chain
         self.warned_loop_keys = set()  # (id, title) pairs already warned about, to avoid log spam
+        self.malformed_expr_errs = 0
+        self.warned_expr_keys = set()  # (id, expr) pairs already warned about, to avoid log spam
 
     def clean_text(self, text, mark_headers=False, expand_templates=True,
                    html_safe=True):
@@ -1583,9 +1586,11 @@ class Extractor():
                 self.recursion_exceeded_1_errs,
                 self.recursion_exceeded_2_errs,
                 self.recursion_exceeded_3_errs,
-                self.template_loop_errs)
+                self.template_loop_errs,
+                self.malformed_expr_errs)
         if any(errs):
-            logger.warning("Template errors in article '%s' (%s): title(%d) recursion(%d, %d, %d) loop(%d)",
+            logger.warning("Template errors in article '%s' (%s): title(%d) recursion(%d, %d, %d) "
+                         "loop(%d) expr(%d)",
                          self.title, self.id, *errs)
 
     # ----------------------------------------------------------------------
@@ -1791,7 +1796,8 @@ class Extractor():
             funct = title[:colon]
             parts[0] = title[colon + 1:].strip()  # side-effect (parts[0] not used later)
             # arguments after first are not evaluated
-            ret = callParserFunction(funct, parts, self.frame)
+            ret = callParserFunction(funct, parts, self.frame,
+                                      page_title=self.title, page_id=self.id, extractor=self)
             return self.expandTemplates(ret)
 
         title = fullyQualifiedTemplateTitle(title, self)
@@ -2228,6 +2234,13 @@ _SHARP_EXPR_COMPARISONS = {
     ast.GtE: operator.ge,
 }
 
+# The exact fallback sharp_expr() returns on any failure -- named here
+# (rather than repeating the literal) both to avoid duplicating it and
+# because sharp_expr() also checks incoming expr text for this exact
+# string, to detect a failed #expr's output being fed as literal input
+# into an enclosing #expr call (see sharp_expr()'s own except block).
+_SHARP_EXPR_ERROR_SPAN = '<span class="error"></span>'
+
 
 def _sharp_expr_eval_node(node):
     """
@@ -2318,16 +2331,71 @@ def _sharp_expr_eval_node(node):
     raise ValueError(f"disallowed #expr element: {type(node).__name__}")
 
 
-def sharp_expr(expr):
+def sharp_expr(expr, page_title=None, page_id=None, extractor=None):
     try:
+        orig_expr = expr
         expr = re.sub('=', '==', expr)
         expr = re.sub('mod', '%', expr)
         expr = re.sub(r'\bdiv\b', '/', expr)
         expr = re.sub(r'\bround\b', '|ROUND|', expr)
-        tree = ast.parse(expr, mode='eval')
+        # Malformed #expr input -- number directly adjacent to a
+        # Python keyword, e.g. "3 in 5" -> "3in5" -- makes ast.parse()
+        # emit SyntaxWarning: invalid decimal literal as a side effect
+        # of tokenizing, even though the parse still correctly fails
+        # right after and gets caught below. Wikitext isn't Python
+        # source and was never going to satisfy Python's tokenizer
+        # rules; this warning has nothing to tell a reader here --
+        # the article-identifying warning logged in the except branch
+        # below is what's actually useful for finding and fixing the
+        # real, on-wiki #expr call this came from.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', SyntaxWarning)
+            tree = ast.parse(expr, mode='eval')
         return str(_sharp_expr_eval_node(tree))
     except Exception:
-        return '<span class="error"></span>'
+        # The same malformed #expr call is frequently invoked many
+        # times over within a single article (e.g. once per row of a
+        # table built from a broken shared template) -- one genuine
+        # occurrence can otherwise produce hundreds of identical log
+        # lines. Same dedup shape as expandTemplate()'s own loop
+        # detection: count every occurrence, but only log the first
+        # one per (article, expression) pair.
+        #
+        # A second, distinct source of noise this same dedup can't
+        # catch: nested #expr calls, e.g. {{#expr:{{#expr:X-1}}+1}},
+        # where an inner failure's own _SHARP_EXPR_ERROR_SPAN output
+        # gets substituted as literal text into the enclosing #expr's
+        # input, which then also fails (a span tag isn't numeric).
+        # Distinct cascades within the same article are each reported
+        # only once.
+        if _SHARP_EXPR_ERROR_SPAN in orig_expr:
+            if extractor is not None:
+                extractor.malformed_expr_errs += 1
+                cascadeKey = (page_id, 'cascade')
+                if cascadeKey in extractor.warned_expr_keys:
+                    return _SHARP_EXPR_ERROR_SPAN
+                extractor.warned_expr_keys.add(cascadeKey)
+            if page_title is not None:
+                logger.warning("Malformed #expr: %r (article %s, id %s) -- this looks like "
+                               "a chain of nested #expr calls; further such chained failures "
+                               "in this article are counted but not logged",
+                               orig_expr, page_title, page_id)
+            else:
+                logger.warning("Malformed #expr: %r", orig_expr)
+            return _SHARP_EXPR_ERROR_SPAN
+        if extractor is not None:
+            extractor.malformed_expr_errs += 1
+            exprKey = (page_id, orig_expr)
+            if exprKey in extractor.warned_expr_keys:
+                return _SHARP_EXPR_ERROR_SPAN
+            extractor.warned_expr_keys.add(exprKey)
+        if page_title is not None:
+            logger.warning("Malformed #expr: %r (article %s, id %s) -- further identical "
+                           "occurrences in this article are counted but not logged",
+                           orig_expr, page_title, page_id)
+        else:
+            logger.warning("Malformed #expr: %r", orig_expr)
+        return _SHARP_EXPR_ERROR_SPAN
 
 
 def sharp_if(testValue, valueIfTrue, valueIfFalse=None, *args):
@@ -2458,7 +2526,10 @@ def sharp_invoke(module, function, frame):
 
 parserFunctions = {
 
-    '#expr': sharp_expr,
+    # '#expr' is handled directly in callParserFunction(), same as
+    # '#invoke' below it, not dispatched through this dict -- it
+    # needs page_title/page_id threaded through for its own failure
+    # logging, which no other entry here needs.
 
     '#if': sharp_if,
 
@@ -2501,12 +2572,25 @@ parserFunctions = {
 }
 
 
-def callParserFunction(functionName, args, frame):
+def callParserFunction(functionName, args, frame, page_title=None, page_id=None, extractor=None):
     """
     Parser functions have similar syntax as templates, except that
     the first argument is everything after the first colon.
     :param functionName: nameof the parser function
     :param args: the arguments to the function
+    :param page_title: :param page_id: the calling article's own
+        title/id (not necessarily the template's -- a #expr call
+        reached here may live inside a transcluded template, but the
+        article is what a real investigation would start from anyway,
+        and it's what's actually available here). Threaded through to
+        #expr specifically, which logs them on failure to make a
+        malformed on-wiki call findable; no other parser function
+        currently needs them.
+    :param extractor: the calling Extractor, threaded through to
+        #expr specifically for its own per-article malformed-#expr
+        counting/dedup (see sharp_expr()'s own docstring) -- same
+        reasoning as page_title/page_id above, no other parser
+        function currently needs it.
     :return: the result of the invocation, None in case of failure.
 
     http://meta.wikimedia.org/wiki/Help:ParserFunctions
@@ -2518,6 +2602,8 @@ def callParserFunction(functionName, args, frame):
             ret = sharp_invoke(args[0].strip(), args[1].strip(), frame)
             # logger.debug('parserFunction> %s %s', args[1], ret)
             return ret
+        if functionName == '#expr':
+            return sharp_expr(*args, page_title=page_title, page_id=page_id, extractor=extractor)
         if functionName in parserFunctions:
             ret = parserFunctions[functionName](*args)
             # logger.debug('parserFunction> %s(%s) %s', functionName, args, ret)

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -2515,6 +2515,67 @@ def sharp_switch(primary, *params):
     return ''
 
 
+# Digit sets used by some wikis for "national digit" display, mapped
+# back to plain ASCII for formatnum's reverse (|R) mode. Each mapping
+# is a fixed, one-to-one character substitution with no locale
+# ambiguity -- unlike thousands-separator conventions, which
+# genuinely differ by locale in ways that can't be safely guessed
+# from the text alone (e.g. "1.234" means 1234 in some locales, 1.234
+# in others). Covers Arabic-Indic and Extended Arabic-Indic (used by
+# Persian, Urdu, and other Arabic-script wikis) since those are the
+# ones actually observed in practice; add more sets here if another
+# wiki's real output needs them.
+_FORMATNUM_LOCAL_DIGITS = str.maketrans(
+    '٠١٢٣٤٥٦٧٨٩'   # Arabic-Indic
+    '۰۱۲۳۴۵۶۷۸۹',  # Extended Arabic-Indic (Persian/Urdu)
+    '01234567890123456789'
+)
+
+
+def sharp_formatnum(num, flag='', *args):
+    """
+    {{formatnum: NUM }} / {{formatnum: NUM | R }} -- note no '#'
+    prefix, unlike most parser functions here; matches real
+    MediaWiki's own syntax for this one.
+
+    Real MediaWiki's formatnum is locale-dependent: which digit-
+    grouping convention to use, and whether to substitute "national"
+    digits (e.g. Urdu ۰-۹), both come from the source wiki's own
+    language configuration -- which nothing in this codebase tracks
+    (there's no concept of "which wiki this dump is from" anywhere).
+    This is necessarily an approximation, not an exact match for
+    every wiki's own output.
+
+    Reverse mode (flag == 'R') is the direction actually exercised by
+    real, on-wiki templates chaining into #expr arithmetic (e.g.
+    {{formatnum:{{{1}}}|R}} to normalize an argument before doing
+    math on it -- confirmed directly: this is exactly what left every
+    #ifexpr comparison in a real, on-wiki Format price template
+    blank before this existed, since the value being compared was
+    always empty). This direction is safe to implement precisely:
+    strip comma grouping and map known local digit sets back to
+    ASCII, both fixed, context-free substitutions with no locale
+    guessing involved.
+
+    Forward mode (the default, no |R) inserts comma thousands
+    separators only -- the English-Wikipedia convention, and the most
+    common on Wikipedia overall -- and does NOT attempt national-
+    digit output, since that would require knowing the source wiki's
+    own language settings. Non-numeric input is returned unchanged in
+    forward mode, matching real MediaWiki's own graceful degradation
+    rather than raising.
+    """
+    if flag.strip() == 'R':
+        return num.replace(',', '').translate(_FORMATNUM_LOCAL_DIGITS).strip()
+    try:
+        value = float(num)
+    except ValueError:
+        return num
+    if value == int(value):
+        return f'{int(value):,}'
+    return f'{value:,}'
+
+
 # Extension Scribuntu
 # Only minimal support for Lua modules invoked via #invoke.
 # FIXME: import real Lua modules (would require a Lua interpreter,
@@ -2600,6 +2661,8 @@ parserFunctions = {
     'int': lambda string, *rest: str(int(string)),
 
     'padleft': lambda char, width, string: string.ljust(char, int(pad)), # CHECK_ME
+
+    'formatnum': sharp_formatnum,
 
 }
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -2636,6 +2636,145 @@ def sharp_padright(string, width, padding='0', *args):
     return _sharp_pad(string, width, padding, from_left=False)
 
 
+def sharp_len(string='', *args):
+    """{{#len: STRING }} -- character count. String functions
+    extension, hence the '#' prefix (unlike lc/uc/padleft/padright
+    above, which are core magic words without one)."""
+    return str(len(string))
+
+
+def sharp_pos(string='', target='', offset='0', *args):
+    """{{#pos: STRING | TARGET | OFFSET }} -- zero-based index of the
+    first occurrence of TARGET in STRING, searching from OFFSET
+    (default 0). Real MediaWiki semantics: returns an EMPTY STRING,
+    not -1, when TARGET isn't found -- Python's str.find() returns
+    -1, so that gets converted here rather than passed through
+    directly. Deliberately asymmetric with #rpos below, which returns
+    -1 on no match -- that's a real, documented quirk of the actual
+    String functions extension, not something to "fix" into
+    consistency here.
+    """
+    try:
+        offset = int(offset)
+    except (TypeError, ValueError):
+        offset = 0
+    result = string.find(target, offset)
+    return '' if result == -1 else str(result)
+
+
+def sharp_rpos(string='', target='', *args):
+    """{{#rpos: STRING | TARGET }} -- zero-based index of the LAST
+    occurrence of TARGET in STRING. Real MediaWiki semantics: returns
+    -1 (as a string) when TARGET isn't found -- unlike #pos above,
+    which returns empty string on no match. This asymmetry is real
+    and documented, not a bug to reconcile between the two."""
+    return str(string.rfind(target))
+
+
+def sharp_sub(string='', start='0', length=None, *args):
+    """{{#sub: STRING | START | LENGTH }} -- substring, matching
+    PHP's substr() semantics (what real MediaWiki's #sub is built on)
+    precisely rather than approximating with a plain Python slice:
+      - START >= 0: begins at that position (0-indexed).
+      - START < 0: begins that many characters from the end.
+      - LENGTH omitted: returns everything from START to the end.
+      - LENGTH >= 0: returns up to LENGTH characters.
+      - LENGTH < 0: stops that many characters before the end of the
+        *whole string* -- not relative to START. This is the part a
+        naive s[start:start+length]-style translation gets wrong:
+        substr("Hello world", 6, -2) is "wor" (stop 2 short of the
+        whole string's own end), not an empty/nonsensical result from
+        computing 6 + -2 = 4 (before start) and slicing s[6:4].
+    """
+    n = len(string)
+    try:
+        start = int(start)
+    except (TypeError, ValueError):
+        start = 0
+    if start < 0:
+        start = max(n + start, 0)
+    else:
+        start = min(start, n)
+    if length is None or length == '':
+        end = n
+    else:
+        try:
+            length = int(length)
+        except (TypeError, ValueError):
+            length = 0
+        if length >= 0:
+            end = min(start + length, n)
+        else:
+            end = max(n + length, start)
+    return string[start:end]
+
+
+def sharp_count(string='', substring='', *args):
+    """{{#count: STRING | SUBSTRING }} -- non-overlapping occurrence
+    count, matching PHP's substr_count(). An empty SUBSTRING has no
+    sensible count (Python's own str.count('') counts a match between
+    every character, e.g. "abc".count('') == 4, which isn't a
+    meaningful answer here), so that case returns '0' rather than
+    passing through Python's own quirky definition.
+    """
+    if not substring:
+        return '0'
+    return str(string.count(substring))
+
+
+def sharp_replace(string='', search='', replace='', limit=None, *args):
+    """{{#replace: STRING | SEARCH | REPLACE | LIMIT }} -- replaces
+    up to LIMIT occurrences of SEARCH with REPLACE (default: all of
+    them). An empty SEARCH is left as a no-op returning STRING
+    unchanged, rather than Python's own str.replace('', x) behavior
+    of inserting x between every character -- PHP's str_replace()
+    (what real MediaWiki's #replace is built on) treats an empty
+    search as not matching anything, not as matching every gap.
+    """
+    if not search:
+        return string
+    if limit is None or limit == '':
+        return string.replace(search, replace)
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        return string.replace(search, replace)
+    return string.replace(search, replace, limit)
+
+
+def sharp_explode(string='', delimiter='', position='0', limit=None, *args):
+    """{{#explode: STRING | DELIMITER | POSITION | LIMIT }} -- splits
+    STRING on DELIMITER and returns the segment at zero-based
+    POSITION (real MediaWiki supports a negative POSITION too,
+    counting from the end -- matches Python's own negative list
+    indexing directly, so no special-casing needed for that part).
+    LIMIT caps the number of segments produced, with the LAST segment
+    absorbing everything beyond that count -- exactly Python's own
+    str.split(delimiter, maxsplit) semantics, so LIMIT translates to
+    maxsplit = LIMIT - 1. An empty DELIMITER has no valid split
+    semantics (real PHP explode() rejects it outright), so that
+    returns '' rather than raising or guessing a behavior. POSITION
+    outside the resulting segment count also returns ''.
+    """
+    if not delimiter:
+        return ''
+    try:
+        position = int(position)
+    except (TypeError, ValueError):
+        position = 0
+    if limit is None or limit == '':
+        parts = string.split(delimiter)
+    else:
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = None
+        parts = string.split(delimiter, limit - 1) if limit and limit > 0 else string.split(delimiter)
+    if -len(parts) <= position < len(parts):
+        return parts[position]
+    return ''
+
+
 
 # Extension Scribuntu
 # Only minimal support for Lua modules invoked via #invoke.
@@ -2706,6 +2845,29 @@ parserFunctions = {
     '#timel': lambda *args: '',  # not supported
 
     '#titleparts': lambda *args: '',  # not supported
+
+    # String functions extension -- these are called as {{#len:...}},
+    # {{#pos:...}}, etc. in real wikitext, with a '#' prefix. The core
+    # case/url magic words further below (lc, uc, ucfirst, lcfirst,
+    # padleft, padright, urlencode, urldecode) are called without one
+    # -- {{lc:...}}, not {{#lc:...}} -- since they belong to a
+    # different, older part of MediaWiki's own syntax, not this
+    # extension. Both kinds are dispatched through this same dict
+    # either way; the '#' is just literally part of the string
+    # functions' own names as MediaWiki defines them.
+    '#len': sharp_len,
+
+    '#pos': sharp_pos,
+
+    '#rpos': sharp_rpos,
+
+    '#sub': sharp_sub,
+
+    '#count': sharp_count,
+
+    '#replace': sharp_replace,
+
+    '#explode': sharp_explode,
 
     # This function is used in some pages to construct links
     # http://meta.wikimedia.org/wiki/Help:URL

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -40,6 +40,21 @@ import time
 # be enabled without the other.
 logger = logging.getLogger('wikiextractor.extract')
 
+# A level between INFO (20) and DEBUG (10), for output that's too
+# granular for every run (per-article detail: which specific page had
+# which specific issue) but far too much to require full DEBUG
+# tracing to see at all (DEBUG here also includes low-level extraction
+# mechanics -- template invocation, parameter substitution -- entirely
+# unrelated to "which pages have errors" and vastly more voluminous).
+# Currently used for exactly one thing: the per-article error summary
+# in Extractor.extract() below. Registered globally via
+# addLevelName() so logger.log(DETAIL, ...) renders as "DETAIL: ..."
+# rather than a bare, unlabeled number; WikiExtractor.py's own CLI
+# (--verbose) sets a logger's threshold to this value the same way it
+# does for the standard levels.
+DETAIL = 15
+logging.addLevelName(DETAIL, 'DETAIL')
+
 # ----------------------------------------------------------------------
 
 # match tail after wikilink
@@ -1590,9 +1605,25 @@ class Extractor():
                 self.template_loop_errs,
                 self.malformed_expr_errs)
         if any(errs):
-            logger.warning("Template errors in article '%s' (%s): title(%d) recursion(%d, %d, %d) "
-                         "loop(%d) expr(%d)",
-                         self.title, self.id, *errs)
+            # DETAIL, not WARNING and not DEBUG: on a real, full-wiki
+            # run, a single common broken shared template can leave a
+            # large fraction of all articles with some nonzero count
+            # here, which turns "one WARNING line per article" into
+            # hundreds of thousands of lines -- individually genuine,
+            # but collectively drowning out everything else in the
+            # log. extract_process() in WikiExtractor.py now
+            # aggregates these same six counters across every article
+            # a worker processes and logs one WARNING-level summary
+            # per worker when it finishes; that's the line to look at
+            # first for gauging scope. This per-article line is for
+            # the next step down -- digging into which specific pages
+            # have issues -- without requiring full DEBUG tracing
+            # (which also includes low-level extraction mechanics
+            # entirely unrelated to this, and is vastly more
+            # voluminous). See DETAIL's own definition above.
+            logger.log(DETAIL, "Template errors in article '%s' (%s): title(%d) recursion(%d, %d, %d) "
+                       "loop(%d) expr(%d)",
+                       self.title, self.id, *errs)
 
     # ----------------------------------------------------------------------
     # Expand templates

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -1878,10 +1878,11 @@ class Extractor():
             loopKey = (self.id, title)
             if loopKey not in self.warned_loop_keys:
                 self.warned_loop_keys.add(loopKey)
-                logger.warning("Template loop detected: %s (article %s, id %s) -- "
-                                 "leaving unexpanded (further repeats in this "
-                                 "article are counted but not logged)",
-                                 title, self.title, self.id)
+                logger.debug("Template loop detected: %s (article %s, id %s) -- "
+                              "leaving unexpanded (further repeats in this article "
+                              "are counted, see the per-article WARNING-level "
+                              "summary, but not logged individually)",
+                              title, self.title, self.id)
             return '{{' + body + '}}'
 
         # Perform parameter substitution
@@ -2357,10 +2358,15 @@ def sharp_expr(expr, page_title=None, page_id=None, extractor=None):
         # The same malformed #expr call is frequently invoked many
         # times over within a single article (e.g. once per row of a
         # table built from a broken shared template) -- one genuine
-        # occurrence can otherwise produce hundreds of identical log
-        # lines. Same dedup shape as expandTemplate()'s own loop
-        # detection: count every occurrence, but only log the first
-        # one per (article, expression) pair.
+        # occurrence can otherwise produce hundreds of near-identical
+        # log lines. Same dedup shape as expandTemplate()'s own loop
+        # detection: count every occurrence (reflected in the single
+        # per-article WARNING-level summary logged at the end of
+        # extract(), which is what's actually useful for deciding
+        # which pages are worth targeting), but only log the first
+        # one per (article, expression) pair, and only at DEBUG --
+        # detail for digging into a specific already-identified page,
+        # not something that should show up at default verbosity.
         #
         # A second, distinct source of noise this same dedup can't
         # catch: nested #expr calls, e.g. {{#expr:{{#expr:X-1}}+1}},
@@ -2377,12 +2383,13 @@ def sharp_expr(expr, page_title=None, page_id=None, extractor=None):
                     return _SHARP_EXPR_ERROR_SPAN
                 extractor.warned_expr_keys.add(cascadeKey)
             if page_title is not None:
-                logger.warning("Malformed #expr: %r (article %s, id %s) -- this looks like "
-                               "a chain of nested #expr calls; further such chained failures "
-                               "in this article are counted but not logged",
-                               orig_expr, page_title, page_id)
+                logger.debug("Malformed #expr: %r (article %s, id %s) -- this looks like "
+                              "a chain of nested #expr calls; further such chained failures "
+                              "in this article are counted (see the per-article WARNING-level "
+                              "summary) but not logged individually",
+                              orig_expr, page_title, page_id)
             else:
-                logger.warning("Malformed #expr: %r", orig_expr)
+                logger.debug("Malformed #expr: %r", orig_expr)
             return _SHARP_EXPR_ERROR_SPAN
         if extractor is not None:
             extractor.malformed_expr_errs += 1
@@ -2391,11 +2398,12 @@ def sharp_expr(expr, page_title=None, page_id=None, extractor=None):
                 return _SHARP_EXPR_ERROR_SPAN
             extractor.warned_expr_keys.add(exprKey)
         if page_title is not None:
-            logger.warning("Malformed #expr: %r (article %s, id %s) -- further identical "
-                           "occurrences in this article are counted but not logged",
-                           orig_expr, page_title, page_id)
+            logger.debug("Malformed #expr: %r (article %s, id %s) -- further identical "
+                          "occurrences in this article are counted (see the per-article "
+                          "WARNING-level summary) but not logged individually",
+                          orig_expr, page_title, page_id)
         else:
-            logger.warning("Malformed #expr: %r", orig_expr)
+            logger.debug("Malformed #expr: %r", orig_expr)
         return _SHARP_EXPR_ERROR_SPAN
 
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -2576,6 +2576,66 @@ def sharp_formatnum(num, flag='', *args):
     return f'{value:,}'
 
 
+def _sharp_pad(string, width, padding='0', from_left=True):
+    """
+    Shared core for padleft/padright below -- the two real MediaWiki
+    functions differ only in which side gets padded. Matches PHP's
+    own str_pad() semantics, which real MediaWiki's implementation is
+    built on: the padding string is repeated as many times as needed
+    to cover the gap, then truncated to exactly that many characters
+    (not repeated a whole number of times and left over-long) before
+    being attached to the original string.
+
+    Real, worked example: padleft("1", 4, "xy") needs 3 characters of
+    padding (4 - len("1")). "xy" repeated is "xyxyxy...";  truncated
+    to 3 characters gives "xyx"; prepended to "1" gives "xyx1" -- not
+    "xyxy1" (which would be one whole extra repetition) and not "xy1"
+    (which would be short by one character).
+
+    :param width: target total length. Invalid or non-positive values
+        (can't sensibly pad to zero or a negative width) leave the
+        string unchanged rather than raising or truncating it --
+        matches real MediaWiki's own graceful degradation elsewhere
+        in this file (e.g. formatnum's forward mode on non-numeric
+        input) rather than an error a template author would never see
+        in their own rendered page.
+    :param padding: the string to repeat. An explicitly empty padding
+        string has nothing to repeat, so this also leaves the
+        original string unchanged rather than looping forever or
+        dividing by zero.
+    """
+    try:
+        width = int(width)
+    except (TypeError, ValueError):
+        return string
+    if not padding:
+        return string
+    needed = width - len(string)
+    if needed <= 0:
+        return string
+    pad_repeated = (padding * (needed // len(padding) + 1))[:needed]
+    if from_left:
+        return pad_repeated + string
+    else:
+        return string + pad_repeated
+
+
+def sharp_padleft(string, width, padding='0', *args):
+    """{{padleft: STRING | WIDTH | PADDING }} -- pads on the left
+    (prepends), matching real MediaWiki's own naming, which describes
+    which side gets the new padding characters -- not which side of
+    the original string they end up nearer to."""
+    return _sharp_pad(string, width, padding, from_left=True)
+
+
+def sharp_padright(string, width, padding='0', *args):
+    """{{padright: STRING | WIDTH | PADDING }} -- pads on the right
+    (appends). Same padding-string repeat-then-truncate semantics as
+    padleft -- see _sharp_pad()'s own docstring."""
+    return _sharp_pad(string, width, padding, from_left=False)
+
+
+
 # Extension Scribuntu
 # Only minimal support for Lua modules invoked via #invoke.
 # FIXME: import real Lua modules (would require a Lua interpreter,
@@ -2660,7 +2720,9 @@ parserFunctions = {
 
     'int': lambda string, *rest: str(int(string)),
 
-    'padleft': lambda char, width, string: string.ljust(char, int(pad)), # CHECK_ME
+    'padleft': sharp_padleft,
+
+    'padright': sharp_padright,
 
     'formatnum': sharp_formatnum,
 

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -2398,6 +2398,38 @@ def sharp_expr(expr, page_title=None, page_id=None, extractor=None):
         return _SHARP_EXPR_ERROR_SPAN
 
 
+def sharp_ifexpr(test, valueIfTrue='', valueIfFalse='', *args, page_title=None, page_id=None, extractor=None):
+    """
+    {{#ifexpr: EXPRESSION | VALUE_IF_TRUE | VALUE_IF_FALSE}}
+
+    Evaluates EXPRESSION via sharp_expr() itself -- not a separate
+    evaluator -- so this gets sharp_expr()'s own safe AST-only
+    evaluation, malformed-expression logging, and per-article dedup
+    (including cascade suppression) for free, rather than duplicating
+    any of it. Real MediaWiki semantics: a nonzero result selects
+    valueIfTrue, zero selects valueIfFalse; a malformed expression
+    (unlike #if/#ifeq, which never fail this way, since their own
+    condition is never itself evaluated as an expression) reports the
+    same as a bare, failing #expr would and returns that same error
+    indicator rather than silently guessing a branch.
+    """
+    result = sharp_expr(test, page_title=page_title, page_id=page_id, extractor=extractor)
+    if result == _SHARP_EXPR_ERROR_SPAN:
+        return result
+    try:
+        numeric_result = float(result)
+    except ValueError:
+        # Shouldn't happen -- sharp_expr() only ever returns the error
+        # span above or a str() of the int/float it computed -- but
+        # fail safe rather than raise, consistent with every other
+        # parser function here.
+        return _SHARP_EXPR_ERROR_SPAN
+    if numeric_result != 0:
+        return valueIfTrue.strip()
+    else:
+        return valueIfFalse.strip()
+
+
 def sharp_if(testValue, valueIfTrue, valueIfFalse=None, *args):
     # In theory, we should evaluate the first argument here,
     # but it was evaluated while evaluating part[0] in expandTemplate().
@@ -2526,18 +2558,18 @@ def sharp_invoke(module, function, frame):
 
 parserFunctions = {
 
-    # '#expr' is handled directly in callParserFunction(), same as
-    # '#invoke' below it, not dispatched through this dict -- it
-    # needs page_title/page_id threaded through for its own failure
-    # logging, which no other entry here needs.
+    # '#expr' and '#ifexpr' are handled directly in
+    # callParserFunction(), same as '#invoke' below them, not
+    # dispatched through this dict -- both need page_title/page_id/
+    # extractor threaded through for #expr's own failure logging
+    # (#ifexpr evaluates its condition via sharp_expr() itself, so it
+    # needs the same three), which no other entry here needs.
 
     '#if': sharp_if,
 
     '#ifeq': sharp_ifeq,
 
     '#iferror': sharp_iferror,
-
-    '#ifexpr': lambda *args: '',  # not supported
 
     '#ifexist': lambda *args: '',  # not supported
 
@@ -2583,14 +2615,14 @@ def callParserFunction(functionName, args, frame, page_title=None, page_id=None,
         reached here may live inside a transcluded template, but the
         article is what a real investigation would start from anyway,
         and it's what's actually available here). Threaded through to
-        #expr specifically, which logs them on failure to make a
-        malformed on-wiki call findable; no other parser function
-        currently needs them.
+        #expr and #ifexpr specifically, which log them on failure to
+        make a malformed on-wiki call findable; no other parser
+        function currently needs them.
     :param extractor: the calling Extractor, threaded through to
-        #expr specifically for its own per-article malformed-#expr
-        counting/dedup (see sharp_expr()'s own docstring) -- same
-        reasoning as page_title/page_id above, no other parser
-        function currently needs it.
+        #expr and #ifexpr specifically for their own per-article
+        malformed-#expr counting/dedup (see sharp_expr()'s own
+        docstring) -- same reasoning as page_title/page_id above, no
+        other parser function currently needs it.
     :return: the result of the invocation, None in case of failure.
 
     http://meta.wikimedia.org/wiki/Help:ParserFunctions
@@ -2604,6 +2636,8 @@ def callParserFunction(functionName, args, frame, page_title=None, page_id=None,
             return ret
         if functionName == '#expr':
             return sharp_expr(*args, page_title=page_title, page_id=page_id, extractor=extractor)
+        if functionName == '#ifexpr':
+            return sharp_ifexpr(*args, page_title=page_title, page_id=page_id, extractor=extractor)
         if functionName in parserFunctions:
             ret = parserFunctions[functionName](*args)
             # logger.debug('parserFunction> %s(%s) %s', functionName, args, ret)

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -2335,7 +2335,7 @@ def sharp_expr(expr, page_title=None, page_id=None, extractor=None):
     try:
         orig_expr = expr
         expr = re.sub('=', '==', expr)
-        expr = re.sub('mod', '%', expr)
+        expr = re.sub(r'\bmod\b', '%', expr)
         expr = re.sub(r'\bdiv\b', '/', expr)
         expr = re.sub(r'\bround\b', '|ROUND|', expr)
         # Malformed #expr input -- number directly adjacent to a

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -27,6 +27,7 @@ import warnings
 from functools import lru_cache
 from itertools import zip_longest
 from urllib.parse import quote as urlencode
+from urllib.parse import unquote as urldecode
 from html.entities import name2codepoint
 import logging
 import time
@@ -2709,6 +2710,8 @@ parserFunctions = {
     # This function is used in some pages to construct links
     # http://meta.wikimedia.org/wiki/Help:URL
     'urlencode': lambda string, *rest: urlencode(string),
+
+    'urldecode': lambda string, *rest: urldecode(string),
 
     'lc': lambda string, *rest: string.lower() if string else '',
 


### PR DESCRIPTION
Add a variety of unhandled # expressions to the template extractor.

Bury the random SyntaxWarning output in the ast parser.  Instead, if evaluating isn't working, output the article and id as best as possible so it can be debugged later.
