### PR TITLE
`<nowiki>` should protect the arguments inside it - 

### DIFF
--- a/tests/test_nowiki_brace_protection.py
+++ b/tests/test_nowiki_brace_protection.py
@@ -1,0 +1,193 @@
+"""
+Tests for _mask_nowiki()/_unmask_nowiki() and their use inside
+expandTemplates() -- protecting <nowiki>...</nowiki> regions from
+being misread as real template/link syntax during brace-matching.
+
+Root cause this fixes: findMatchingBraces() (used by expandTemplates()
+to find {{...}} template-call boundaries, and by splitParts() to split
+a call's own argument list on |) scans raw text for brace/bracket
+characters with no awareness of <nowiki> tags. A template using
+<nowiki>}}</nowiki> to *display* the literal characters "}}" -- a
+real, unremarkable pattern, not a contrived edge case -- can
+prematurely terminate an enclosing template call, silently truncating
+everything after that point into unprocessed, literal leftover text.
+
+Confirmed against real, live ur.wikipedia.org data:
+Template:Metadata population AT-1 (reached via Template:Infobox
+settlement, one of the most widely-used templates on the whole
+project) does exactly this in its own error-message branch, triggered
+by an easy-to-hit, unremarkable case -- calling it with an argument it
+doesn't recognize.
+
+The fix has to live inside expandTemplates() itself, not run once on
+the original article text, because a <nowiki> sequence can arrive
+*mid-expansion* -- introduced by template substitution, exactly what
+happens in the real Metadata population AT-1 case -- not just by
+being present in the wikitext being scanned at the top of the call
+stack.
+
+Run with:
+    python -m unittest tests.test_nowiki_brace_protection -v
+or, from the tests/ directory:
+    python -m unittest test_nowiki_brace_protection -v
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '..')  # allow running directly from tests/ without installing
+
+import wikiextractor.extract as ex
+
+
+class MaskUnmaskRoundTripTests(unittest.TestCase):
+    """_mask_nowiki()/_unmask_nowiki() directly, no template
+    expansion involved -- confirms the core primitive is correct
+    before relying on it inside expandTemplates().
+    """
+
+    def test_no_nowiki_present_is_a_cheap_no_op(self):
+        text = 'plain text, no nowiki here at all'
+        masked, placeholders = ex._mask_nowiki(text)
+        self.assertIs(masked, text)  # not just equal -- the exact same object, confirming the fast path
+        self.assertIsNone(placeholders)
+
+    def test_single_span_masked_and_restored_exactly(self):
+        text = 'before <nowiki>}}{{[[]]</nowiki> after'
+        masked, placeholders = ex._mask_nowiki(text)
+        self.assertNotIn('{', masked)
+        self.assertNotIn('}', masked)
+        self.assertNotIn('[', masked)
+        self.assertEqual(ex._unmask_nowiki(masked, placeholders), text)
+
+    def test_multiple_spans_each_masked_and_restored_exactly(self):
+        text = '<nowiki>}}</nowiki> middle <nowiki>{{</nowiki> end'
+        masked, placeholders = ex._mask_nowiki(text)
+        self.assertNotIn('{', masked)
+        self.assertNotIn('}', masked)
+        self.assertEqual(ex._unmask_nowiki(masked, placeholders), text)
+
+    def test_unmask_with_none_placeholders_is_a_no_op(self):
+        self.assertEqual(ex._unmask_nowiki('unchanged', None), 'unchanged')
+
+    def test_masked_placeholder_contains_no_pipe_either(self):
+        # Not just braces/brackets -- a literal "|" inside <nowiki>
+        # must not be readable as an argument separator by splitParts().
+        text = '<nowiki>a|b|c</nowiki>'
+        masked, placeholders = ex._mask_nowiki(text)
+        self.assertNotIn('|', masked)
+
+
+class ExpandTemplatesNowikiProtectionTests(unittest.TestCase):
+    """Through the real expandTemplates() -> findMatchingBraces() ->
+    expandTemplate() -> splitParts() chain -- confirming the
+    protection actually reaches every layer that needs it, not just
+    the masking primitive in isolation.
+    """
+
+    def make_extractor(self, templates):
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [])
+        extractor.templates = templates
+        extractor.templatePrefix = 'Template:'
+        return extractor
+
+    def test_nowiki_escaped_closing_braces_do_not_truncate_the_call(self):
+        # The exact shape of the original bug: a nowiki-escaped "}}"
+        # must not be read as the real closing brace of the enclosing
+        # template call.
+        extractor = self.make_extractor({})  # "Wrapper" undefined -> whole call resolves empty
+        result = extractor.expandTemplates(
+            '{{Wrapper|rowclass1=A|data1=<nowiki>}}</nowiki>|rowclass2=B|data2=C}}')
+        self.assertNotIn('rowclass2', result)
+        self.assertNotIn('data2', result)
+
+    def test_nowiki_escaped_pipe_is_not_read_as_an_argument_separator(self):
+        extractor = self.make_extractor({'Template:Foo': 'a=[[[{{{a}}}]]] b=[[[{{{b}}}]]]'})
+        result = extractor.expandTemplates('{{Foo|a=<nowiki>x|y</nowiki>|b=real}}')
+        # If the escaped "|" were wrongly treated as a real separator,
+        # parameter a would end up as just "x" and "y" would become a
+        # spurious third positional argument, leaving b unfilled.
+        self.assertIn('x|y', result)
+        self.assertIn('real', result)
+
+    def test_nowiki_containing_a_wikilink_does_not_confuse_brace_matching(self):
+        extractor = self.make_extractor({'Template:Foo': 'got: {{{a}}}'})
+        result = extractor.expandTemplates(
+            '{{Foo|a=<nowiki>[[not a real link]]</nowiki>}}')
+        self.assertIn('[[not a real link]]', result)
+
+    def test_multiple_nowiki_spans_in_one_call_all_protected(self):
+        extractor = self.make_extractor(
+            {'Template:Bar': 'A={{{a}}} B={{{b}}} C={{{c}}}'})
+        result = extractor.expandTemplates(
+            '{{Bar|a=<nowiki>}}</nowiki>|b=<nowiki>{{</nowiki>|c=3}}')
+        self.assertIn('A=<nowiki>}}</nowiki>', result)
+        self.assertIn('B=<nowiki>{{</nowiki>', result)
+        self.assertIn('C=3', result)
+
+    def test_unclosed_nowiki_tag_does_not_crash_or_regress(self):
+        # No closing tag at all -- _NOWIKI_RE simply won't match it
+        # (matches prior behavior for this malformed-wikitext case;
+        # this fix targets well-formed <nowiki>...</nowiki> pairs, not
+        # a general wikitext-repair mechanism).
+        extractor = self.make_extractor({'Template:Foo': 'x'})
+        result = extractor.expandTemplates('{{Foo}} <nowiki>unclosed forever')
+        self.assertIn('x', result)
+        self.assertIn('<nowiki>unclosed forever', result)
+
+    def test_real_world_shape_nowiki_arriving_mid_expansion_via_substitution(self):
+        # The specific mechanism that made the original bug hard to
+        # spot: the <nowiki> sequence isn't in the original article
+        # text at all -- it arrives only after a template's own body
+        # gets substituted in and re-scanned for further nested
+        # template calls. This is exactly why the fix has to run
+        # inside expandTemplates() on every call, not once at the top
+        # of the whole expansion.
+        templates = {
+            'Template:ErrorMessage': 'call it as {{Foo<nowiki>}}</nowiki> not like that',
+            'Template:Outer': ('before {{ErrorMessage}} '
+                                '| rowclass1 = should_survive | data1 = yes'),
+        }
+        extractor = self.make_extractor(templates)
+        result = extractor.expandTemplates('{{Outer}}')
+        self.assertIn('rowclass1', result)
+        self.assertIn('should_survive', result)
+
+
+class NowikiRealEndToEndTests(unittest.TestCase):
+    """Not expandTemplates() directly -- the real chain
+    (clean_text() -> expandTemplate() -> ...), confirming the fix
+    holds up through the full pipeline a real extraction run uses.
+    """
+
+    def test_real_pipeline_does_not_leak_raw_template_syntax(self):
+        templates = {
+            'Template:Metadata': (
+                '{{#switch: {{{2|}}}'
+                '| date = 2020-01-01'
+                '| #default = <nowiki>}}</nowiki> unrecognized keyword'
+                '}}'),
+            # Framework: a stand-in for real MediaWiki's own generic
+            # infobox-building templates -- takes rowclassN/dataN
+            # arguments and (in the real case) hands them to a Lua
+            # module; here it just echoes them back, which is enough
+            # to prove they survived as real, separate arguments
+            # rather than being swallowed by a premature "}}".
+            'Template:Framework': 'seen: {{{rowclass1}}} / {{{data1}}}',
+            'Template:Infobox': (
+                '{{Framework'
+                '| rowclass1 = {{Metadata|date}}'
+                '| data1 = 42'
+                '}}'),
+        }
+        extractor = ex.Extractor(1, "1", "https://x", "Test Article", [],
+                                  templates=templates, templatePrefix='Template:')
+        result = extractor.clean_text('{{Infobox}}', expand_templates=True)
+        joined = '\n'.join(result)
+        self.assertIn('42', joined)
+        self.assertNotIn('rowclass1', joined)
+        self.assertNotIn('{{Framework', joined)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -92,6 +92,13 @@ logging.addLevelName(DETAIL, 'DETAIL')
 # caller, at every level of recursion, without needing to change
 # expandTemplate(), splitParts(), or any of their own call sites.
 _NOWIKI_RE = re.compile(r'<nowiki\s*>(.*?)</nowiki\s*>', re.IGNORECASE | re.DOTALL)
+# A separate, cheaper pattern for the common-case presence check below
+# -- just the opening tag, no DOTALL/closing-tag search needed for
+# that. re.search() with IGNORECASE doesn't need to allocate a
+# lowercased copy of `text` the way `'<nowiki' not in text.lower()`
+# does, which matters here since this runs on every expandTemplates()
+# call, the vast majority of which have no <nowiki> at all.
+_NOWIKI_PRESENCE_RE = re.compile(r'<nowiki', re.IGNORECASE)
 
 
 def _mask_nowiki(text):
@@ -103,10 +110,11 @@ def _mask_nowiki(text):
     well-formed XML-sourced dump (XML itself forbids raw NUL bytes),
     so collision with real article text is not a practical concern.
 
-    Skips the regex scan entirely (a cheap, common-case fast path)
-    when `text` has no "<nowiki" substring at all -- true for the
-    overwhelming majority of expandTemplates() calls, so this keeps
-    the added cost close to zero except where it's actually needed.
+    Skips the substitution regex entirely (a cheap, common-case fast
+    path, via the separate _NOWIKI_PRESENCE_RE above) when `text` has
+    no "<nowiki" substring at all -- true for the overwhelming
+    majority of expandTemplates() calls, so this keeps the added cost
+    close to zero except where it's actually needed.
 
     :return: (masked_text, placeholders) where placeholders is a dict
         mapping each placeholder token back to the exact original
@@ -115,7 +123,7 @@ def _mask_nowiki(text):
         _unmask_nowiki() either way; it treats None as "nothing to
         restore".
     """
-    if '<nowiki' not in text.lower():
+    if not _NOWIKI_PRESENCE_RE.search(text):
         return text, None
     placeholders = {}
 
@@ -125,6 +133,7 @@ def _mask_nowiki(text):
         return token
 
     return _NOWIKI_RE.sub(replace, text), placeholders
+
 
 
 def _unmask_nowiki(text, placeholders):

--- a/wikiextractor/extract.py
+++ b/wikiextractor/extract.py
@@ -57,6 +57,88 @@ logging.addLevelName(DETAIL, 'DETAIL')
 
 # ----------------------------------------------------------------------
 
+# <nowiki>...</nowiki> marks its contents as literal text, exempt from
+# all wikitext parsing -- but findMatchingBraces() (used by
+# expandTemplates() to find {{...}} template-call boundaries, and by
+# splitParts() to split a call's own argument list on |) doesn't know
+# that: it just scans raw text for brace/bracket characters. A
+# template that uses <nowiki>}}</nowiki> to *display* the literal
+# characters "}}" -- a real, unremarkable pattern, e.g. inside an
+# error message explaining correct call syntax -- can prematurely
+# terminate an enclosing template call, silently truncating everything
+# after that point into unprocessed, literal leftover text. Confirmed
+# on real, live Wikipedia data: Template:Metadata population AT-1 (via
+# Template:Infobox settlement, one of the most widely-used templates
+# on the whole project) does exactly this in its own error-message
+# branch, which is reached by an easy-to-hit, unremarkable case
+# (calling it with an argument it doesn't recognize).
+#
+# Real MediaWiki avoids this by protecting <nowiki> regions during its
+# own preprocessing stage, before any brace-matching happens at all.
+# _mask_nowiki()/_unmask_nowiki() do the same here: replace each
+# <nowiki>...</nowiki> span (tags included) with an opaque placeholder
+# containing no brace, bracket, or pipe character at all, so it can't
+# be misread as real template/link syntax or a real argument
+# separator, then restore the original span verbatim afterward.
+#
+# This has to run inside expandTemplates() itself, not once on the
+# original article text -- a <nowiki> sequence can arrive *mid-
+# expansion*, introduced by template substitution (exactly what
+# happens in the real Metadata population AT-1 case above), not just
+# by being present in the wikitext being scanned at the top of the
+# call stack. expandTemplate() and splitParts() never see raw text
+# directly -- only slices of whatever expandTemplates() already
+# scanned -- so masking in that one place protects every downstream
+# caller, at every level of recursion, without needing to change
+# expandTemplate(), splitParts(), or any of their own call sites.
+_NOWIKI_RE = re.compile(r'<nowiki\s*>(.*?)</nowiki\s*>', re.IGNORECASE | re.DOTALL)
+
+
+def _mask_nowiki(text):
+    """Replaces each <nowiki>...</nowiki> span in `text` (tags
+    included) with an opaque placeholder token -- a NUL-delimited
+    string containing no brace, bracket, or pipe character, so it
+    can't be misread as template/link syntax or an argument separator
+    by anything downstream. NUL bytes are never valid content in a
+    well-formed XML-sourced dump (XML itself forbids raw NUL bytes),
+    so collision with real article text is not a practical concern.
+
+    Skips the regex scan entirely (a cheap, common-case fast path)
+    when `text` has no "<nowiki" substring at all -- true for the
+    overwhelming majority of expandTemplates() calls, so this keeps
+    the added cost close to zero except where it's actually needed.
+
+    :return: (masked_text, placeholders) where placeholders is a dict
+        mapping each placeholder token back to the exact original
+        <nowiki>...</nowiki> text it replaced, or None if nothing was
+        masked (the common case) -- pass this straight through to
+        _unmask_nowiki() either way; it treats None as "nothing to
+        restore".
+    """
+    if '<nowiki' not in text.lower():
+        return text, None
+    placeholders = {}
+
+    def replace(m):
+        token = '\x00NOWIKI%d\x00' % len(placeholders)
+        placeholders[token] = m.group(0)
+        return token
+
+    return _NOWIKI_RE.sub(replace, text), placeholders
+
+
+def _unmask_nowiki(text, placeholders):
+    """Restores every placeholder token _mask_nowiki() produced back
+    to its original, exact <nowiki>...</nowiki> text. `placeholders`
+    being None (nothing was masked) or empty is a correct, cheap no-op.
+    """
+    if not placeholders:
+        return text
+    for token, original in placeholders.items():
+        text = text.replace(token, original)
+    return text
+
+
 # match tail after wikilink
 tailRE = re.compile(r'\w+')
 syntaxhighlight = re.compile('&lt;syntaxhighlight .*?&gt;(.*?)&lt;/syntaxhighlight&gt;', re.DOTALL)
@@ -1663,6 +1745,11 @@ class Extractor():
 
         # logger.debug('<expandTemplates ' + str(len(self.frame)))
 
+        # See _mask_nowiki()'s own comment above for why this has to
+        # happen here, on every call, rather than once on the
+        # original article text.
+        wikitext, nowiki_placeholders = _mask_nowiki(wikitext)
+
         cur = 0
         # look for matching {{...}}
         for s, e in findMatchingBraces(wikitext, 2):
@@ -1670,6 +1757,7 @@ class Extractor():
             cur = e
         # leftover
         res += wikitext[cur:]
+        res = _unmask_nowiki(res, nowiki_placeholders)
         # logger.debug('   expandTemplates> %d %s', len(self.frame), res)
         return res
 


### PR DESCRIPTION
Recursive implementation from Claude.  Could probably be more efficient, honestly.  Currently it is going through the whole text looking for `<nowiki>` blocks that can be temporarily wrapped, whereas we could for example iteratively go through looking for template starts `{{` and `<nowiki>` blocks at the same time.

This adds a bit of runtime to the processing, but produces more correct output (templates don't get mangled if they were supposed to be protected by `<nowiki>`).  We can get back the runtime with other optimizations, or possibly optimize this further going forward.

https://github.com/WikiExtractor/wikiextractor/issues/425