### PR TITLE
Update wikiextractor version

### DIFF
--- a/wikiextractor/WikiExtractor.py
+++ b/wikiextractor/WikiExtractor.py
@@ -78,7 +78,7 @@ from . import template_blob
 # ===========================================================================
 
 # Program version
-__version__ = '3.0.8'
+__version__ = '3.1.0'
 
 # This module's own logger -- everything logged directly from
 # WikiExtractor.py (CLI progress, per-worker error summaries) goes


### PR DESCRIPTION
Main updates (including some previously released in 3.0.8):

- compatibility with recent versions of python, especially regex expression updates
- compatibility and identical results across linux/windows/mac using fork/spawn as needed
- better performance in high cpu low memory regimes, as we are passing SharedMemory blobs instead of entire template dicts
- exponential template expansions fixed
- #expr security hole fixed - can no longer execute arbitrary code on maliciously written wiki pages
- #expr comparisons fixed - `<=` was incorrectly processed as `<==` for example
- <nowiki> honored in template expansions, removing }} and infobox cruft from many pages
- missing pages restored: colons in titles no longer drop pages, final page not dropped
- a variety of other template improvements, missing operators added, some spacing fixed, future work needed
- optimizations that effectively cancel out the runtime added by the previous list of fixes
